### PR TITLE
Add Lean toolchain badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Talos
 
+[![Lean](https://img.shields.io/badge/Lean-v4.30.0-blue?logo=lean)](lean-toolchain)
+
 **Talos** is a WebAssembly interpreter written in Lean 4, named after the bronze giant of Greek mythology who guarded Crete — a mechanical guardian, built to enforce rules.
 
 The same definitions that _execute_ a Wasm program are the ones you _reason about_. There is no separate spec interpreter to keep in sync: evaluation and proof share a single codebase.


### PR DESCRIPTION
## Summary
- Adds a shields.io badge under the title showing the current Lean toolchain version (`v4.30.0`), linking to `lean-toolchain`.

## Notes
- Static badge — version string must be bumped manually when the toolchain changes. Happy to swap for a dynamic `endpoint` badge that reads `lean-toolchain` directly if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)