### PR TITLE
Remove #eval lines to silence lake build output

### DIFF
--- a/interpreter/Interpreter/Wasm/Examples/EarlyReturn.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EarlyReturn.lean
@@ -19,10 +19,6 @@ def EarlyReturn : Program := [
   .const 888
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := EarlyReturn }] }
-  run 10 m 0 m.initialStore [.i32 42]
-
 theorem earlyReturnSpec (m : Module) (st : Store) (x : UInt32) :
     wp m EarlyReturn
         (fun c => c = .Return st [.i32 x])

--- a/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
@@ -20,12 +20,6 @@ def IsOddRec : Program := [
   .localGet 0
 ]
 
-#eval
-  let m : Module :=
-    { funcs := [{ params := [.i32], body := IsEvenRec },
-                { params := [.i32], body := IsOddRec }] }
-  run 1000 m 1 m.initialStore [.i32 5]
-
 def evenOddModule : Module :=
   { funcs := [{ params := [.i32], body := IsEvenRec },
               { params := [.i32], body := IsOddRec }] }

--- a/interpreter/Interpreter/Wasm/Examples/Factorial.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Factorial.lean
@@ -22,10 +22,6 @@ def Factorial : Program := [
   .localGet 1
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], locals := [.i32], body := Factorial }] }
-  run 1000 m 0 m.initialStore [.i32 4]
-
 theorem factorialSpec (m : Module) (st : Store) (n : UInt32) :
     wp m Factorial
         (fun c => ∃ st' s', c = .Fallthrough st' s' ∧

--- a/interpreter/Interpreter/Wasm/Examples/GlobalCounter.lean
+++ b/interpreter/Interpreter/Wasm/Examples/GlobalCounter.lean
@@ -22,20 +22,6 @@ def tickModule : Module :=
   { funcs   := [{ params := [], locals := [], body := tickBody }]
     globals := [{ type := .i32, init := .i32 0 }] }
 
--- Sanity: three successive calls increment the global.
-#eval
-  let m := tickModule
-  let st0 := m.initialStore
-  match run 10 m 0 st0 [] with
-  | .Success vs st1 =>
-    match run 10 m 0 st1 [] with
-    | .Success vs2 st2 =>
-      match run 10 m 0 st2 [] with
-      | .Success vs3 _ => (vs, vs2, vs3)
-      | _ => ([], [], [.i32 99])
-    | _ => ([], [], [.i32 99])
-  | _ => ([], [], [.i32 99])
-
 theorem tickModule_initial_global :
     tickModule.initialStore.globals.globals = [.i32 0] := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/IfAbs.lean
+++ b/interpreter/Interpreter/Wasm/Examples/IfAbs.lean
@@ -15,13 +15,6 @@ def IfAbs : Program := [
     [.localGet 0]
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := IfAbs }] }
-  run 10 m 0 m.initialStore [.i32 0xFFFFFFFE]
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := IfAbs }] }
-  run 10 m 0 m.initialStore [.i32 7]
-
 theorem ifAbsSpec (m : Module) (st : Store) (x : UInt32) :
     wp m IfAbs
         (fun c => c = .Fallthrough st

--- a/interpreter/Interpreter/Wasm/Examples/IsEven.lean
+++ b/interpreter/Interpreter/Wasm/Examples/IsEven.lean
@@ -9,10 +9,6 @@ namespace Wasm
 
 def IsEven : Program := [.localGet 0, .const 1, .and, .eqz]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := IsEven }] }
-  run 10 m 0 m.initialStore [.i32 3]
-
 theorem isEvenSpec (m : Module) (st : Store) (v : UInt32) :
     wp m IsEven
         (fun c => c = .Fallthrough st

--- a/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
@@ -60,10 +60,6 @@ private def runTrapMsg (fuel : Nat) (m : Module) (idx : Nat)
   | .Trap _ msg => some msg
   | _ => none
 
-#eval runValues 10 copyModule 0 copyModule.initialStore []
-#eval runValues 10 copyModule 1 copyModule.initialStore []
-#eval runTrapMsg 10 copyModule 2 copyModule.initialStore []
-
 theorem copy_disjoint_moves_bytes :
     runValues 10 copyModule 0 copyModule.initialStore [] = [.i32 0x44332211] := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/MemDataSection.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemDataSection.lean
@@ -24,10 +24,6 @@ def memModule : Module :=
       { pagesMin := 1
         data := [{ offset := some 0, bytes := [0x42, 0x43, 0x44, 0x45] }] } }
 
-#eval run 10 memModule 0 memModule.initialStore []
-
-#eval memModule.initialStore.mem.read32 0
-
 theorem memDataSection_read32_zero :
     memModule.initialStore.mem.read32 0 = 0x45444342 := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/MemFill.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemFill.lean
@@ -42,9 +42,6 @@ private def runTrapMsg (fuel : Nat) (m : Module) (idx : Nat)
   | .Trap _ msg => some msg
   | _ => none
 
-#eval runValues 10 fillModule 0 fillModule.initialStore []
-#eval runTrapMsg 10 fillModule 1 fillModule.initialStore []
-
 theorem fill_then_load_returns_repeated_byte :
     runValues 10 fillModule 0 fillModule.initialStore []
       = [.i64 0xABABABABABABABAB] := by

--- a/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
@@ -44,10 +44,6 @@ private def runValues (fuel : Nat) (m : Module) (idx : Nat)
   | .Success vs _ => vs
   | _ => []
 
-#eval runValues 10 growModule 0 growModule.initialStore []  -- [1]
-#eval runValues 10 growModule 1 growModule.initialStore []  -- [3]
-#eval runValues 10 growModule 2 growModule.initialStore []  -- [1, -1]
-
 theorem memorySize_reads_pagesMin :
     runValues 10 growModule 0 growModule.initialStore [] = [.i32 1] := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/MemI64.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemI64.lean
@@ -71,18 +71,6 @@ private def runValues (fuel : Nat) (m : Module) (idx : Nat)
   | .Success vs _ => vs
   | _ => []
 
-#eval runValues 10 i64MemModule 0 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 1 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 2 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 3 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 4 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 5 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 6 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 7 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 8 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 9 i64MemModule.initialStore []
-#eval runValues 10 i64MemModule 10 i64MemModule.initialStore []
-
 theorem load64_returns_word :
     runValues 10 i64MemModule 0 i64MemModule.initialStore [] = [.i64 0xFF2233445566FF88] := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
@@ -44,13 +44,6 @@ def narrowI32Module : Module :=
       , { body := store16RoundtripBody } ]
     memory := some { pagesMin := 1, data := [{ offset := some 0, bytes := initBytes }] } }
 
-#eval run 10 narrowI32Module 0 narrowI32Module.initialStore []  -- load8U  → 0x42
-#eval run 10 narrowI32Module 1 narrowI32Module.initialStore []  -- load8S  → 0xFFFFFFFF
-#eval run 10 narrowI32Module 2 narrowI32Module.initialStore []  -- load16U → 0xABCD
-#eval run 10 narrowI32Module 3 narrowI32Module.initialStore []  -- load16S → 0xFFFFFFCD
-#eval run 10 narrowI32Module 4 narrowI32Module.initialStore []  -- store8  → 0xAB
-#eval run 10 narrowI32Module 5 narrowI32Module.initialStore []  -- store16 → 0xABCD
-
 /-- Project the value stack out of a `Result`. `Store` carries a function-
     valued `Mem`, so it has no decidable equality; comparing the values
     alone keeps the `native_decide` checks below well-typed. -/

--- a/interpreter/Interpreter/Wasm/Examples/MemReplace.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemReplace.lean
@@ -29,8 +29,6 @@ def replaceModule : Module :=
   { funcs := [{ params := [.i32], locals := [.i32], body := replaceBody }]
     memory := some { pagesMin := 1, data := [{ offset := some 0, bytes := [42, 0, 0, 0] }] } }
 
-#eval run 20 replaceModule 0 replaceModule.initialStore [.i32 99]
-
 theorem replaceModule_init_mem :
     replaceModule.initialStore.mem.read32 0 = 42 := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/SelectMin.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SelectMin.lean
@@ -16,13 +16,6 @@ def SelectMin : Program := [
   .const 42, .drop                   -- pad with const 42; drop it again
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32, .i32], body := SelectMin }] }
-  run 10 m 0 m.initialStore [.i32 3, .i32 7]
-#eval
-  let m : Module := { funcs := [{ params := [.i32, .i32], body := SelectMin }] }
-  run 10 m 0 m.initialStore [.i32 9, .i32 4]
-
 theorem selectMinSpec (m : Module) (st : Store) (x y : UInt32) :
     wp m SelectMin
         (fun c => c = .Fallthrough st

--- a/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
@@ -22,10 +22,6 @@ def SimpleLoop : Program := [
     .localGet 1
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], locals := [.i32], body := SimpleLoop }] }
-  run 100 m 0 m.initialStore [.i32 10]
-
 theorem simpleLoopSpec (m : Module) (st : Store) (n : UInt32) :
     wp m SimpleLoop
         (fun c => ∃ st' s', c = .Fallthrough st' s' ∧ s'.values = [.i32 n])

--- a/interpreter/Interpreter/Wasm/Examples/SumI64.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SumI64.lean
@@ -15,10 +15,6 @@ def SumI64 : Program := [
   .wrapI64
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := SumI64 }] }
-  run 10 m 0 m.initialStore [.i32 5]
-
 theorem sumI64Spec (m : Module) (st : Store) (x : UInt32) :
     wp m SumI64
         (fun c => c = .Fallthrough st

--- a/interpreter/Interpreter/Wasm/Examples/Switch.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Switch.lean
@@ -22,16 +22,6 @@ def Switch : Program := [
   .const 30, .ret
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := Switch }] }
-  run 10 m 0 m.initialStore [.i32 0]
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := Switch }] }
-  run 10 m 0 m.initialStore [.i32 1]
-#eval
-  let m : Module := { funcs := [{ params := [.i32], body := Switch }] }
-  run 10 m 0 m.initialStore [.i32 7]
-
 theorem switchSpec (m : Module) (st : Store) (i : UInt32) :
     wp m Switch
         (fun c => c = .Return st

--- a/interpreter/Interpreter/Wasm/Examples/TrapDivZero.lean
+++ b/interpreter/Interpreter/Wasm/Examples/TrapDivZero.lean
@@ -12,13 +12,6 @@ def TrapDivZero : Program := [
   .localGet 0, .localGet 1, .divU
 ]
 
-#eval
-  let m : Module := { funcs := [{ params := [.i32, .i32], body := TrapDivZero }] }
-  run 10 m 0 m.initialStore [.i32 10, .i32 3]
-#eval
-  let m : Module := { funcs := [{ params := [.i32, .i32], body := TrapDivZero }] }
-  run 10 m 0 m.initialStore [.i32 10, .i32 0]
-
 theorem trapDivZeroSpec (m : Module) (st : Store) (a b : UInt32) :
     wp m TrapDivZero
         (fun c =>

--- a/programs/Programs/Crates/Itoa/Program.lean
+++ b/programs/Programs/Crates/Itoa/Program.lean
@@ -7453,6 +7453,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 15128866331338589247
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/Crates/Itoa/module.wat"
   unless ← path.pathExists do return

--- a/programs/Programs/Crates/NumInteger/Program.lean
+++ b/programs/Programs/Crates/NumInteger/Program.lean
@@ -113,6 +113,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 15244946472501003244
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/Crates/NumInteger/module.wat"
   unless ← path.pathExists do return

--- a/programs/Programs/RustStd/Option/Program.lean
+++ b/programs/Programs/RustStd/Option/Program.lean
@@ -105,6 +105,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 6850677042129948027
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/RustStd/Option/module.wat"
   unless ← path.pathExists do return

--- a/programs/Programs/Simple/Memchr/Program.lean
+++ b/programs/Programs/Simple/Memchr/Program.lean
@@ -66,6 +66,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 4315268944418168635
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/Simple/Memchr/module.wat"
   unless ← path.pathExists do return

--- a/programs/Programs/Simple/ReverseInplace/Program.lean
+++ b/programs/Programs/Simple/ReverseInplace/Program.lean
@@ -93,6 +93,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 7464388080641027426
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/Simple/ReverseInplace/module.wat"
   unless ← path.pathExists do return

--- a/programs/Programs/Simple/XorSum/Program.lean
+++ b/programs/Programs/Simple/XorSum/Program.lean
@@ -64,6 +64,7 @@ def «module» : Wasm.Module :=
 private def expectedWatHash : UInt64 := 13997200556762420734
 
 -- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.
+#guard_msgs (drop info) in
 #eval show IO Unit from do
   let path : System.FilePath := "Programs/Simple/XorSum/module.wat"
   unless ← path.pathExists do return

--- a/verifier/Verifier/Emit.lean
+++ b/verifier/Verifier/Emit.lean
@@ -287,13 +287,17 @@ def «module» (m : Wasm.Module) : String :=
 /-- Emit the drift-check block: a `UInt64` hash constant pinned to the
 `module.wat` content at emit time, plus a `#eval` that re-reads the sibling
 file at elaboration time and `throw`s if the hash disagrees. The path is
-resolved relative to the lake-project root (lake's elaboration cwd). -/
+resolved relative to the lake-project root (lake's elaboration cwd). The
+`#guard_msgs (drop info) in` wrapper silences the success-case `()` info
+message; if the hash disagrees, `#eval` emits an `error` which still
+surfaces. -/
 def driftCheck (relWatPath : String) (watHash : UInt64) : String :=
   String.intercalate "\n" [
     "/-- Hash of the source `module.wat` captured when `verifier check` last ran. -/",
     s!"private def expectedWatHash : UInt64 := {watHash.toNat}",
     "",
     "-- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.",
+    "#guard_msgs (drop info) in",
     "#eval show IO Unit from do",
     s!"  let path : System.FilePath := {repr relWatPath}",
     "  unless ← path.pathExists do return",

--- a/verifier/Verifier/EmitMini.lean
+++ b/verifier/Verifier/EmitMini.lean
@@ -283,13 +283,17 @@ def «module» (m : Wasm.Module) : String :=
 /-- Emit the drift-check block: a `UInt64` hash constant pinned to the
 `module.wat` content at emit time, plus a `#eval` that re-reads the sibling
 file at elaboration time and `throw`s if the hash disagrees. The path is
-resolved relative to the lake-project root (lake's elaboration cwd). -/
+resolved relative to the lake-project root (lake's elaboration cwd). The
+`#guard_msgs (drop info) in` wrapper silences the success-case `()` info
+message; if the hash disagrees, `#eval` emits an `error` which still
+surfaces. -/
 def driftCheck (relWatPath : String) (watHash : UInt64) : String :=
   String.intercalate "\n" [
     "/-- Hash of the source `module.wat` captured when `verifier check` last ran. -/",
     s!"private def expectedWatHash : UInt64 := {watHash.toNat}",
     "",
     "-- Compile-time drift check: errors if `module.wat` has changed without a corresponding re-emit.",
+    "#guard_msgs (drop info) in",
     "#eval show IO Unit from do",
     s!"  let path : System.FilePath := {repr relWatPath}",
     "  unless ← path.pathExists do return",

--- a/verifier/template/lean/Project/IsEven/Run.lean
+++ b/verifier/template/lean/Project/IsEven/Run.lean
@@ -17,10 +17,6 @@ def isEven (n : UInt32) : List Value :=
   | .Success rs _ => rs
   | _             => []
 
-#eval isEven 0   -- [.i32 1]
-#eval isEven 1   -- [.i32 0]
-#eval isEven 42  -- [.i32 1]
-
 example : isEven 0 = [.i32 1] := by native_decide
 example : isEven 1 = [.i32 0] := by native_decide
 example : isEven 4 = [.i32 1] := by native_decide

--- a/verifier/template/lean/Project/IsOdd/Run.lean
+++ b/verifier/template/lean/Project/IsOdd/Run.lean
@@ -16,10 +16,6 @@ def isEven (n : UInt32) : List Value :=
   | .Success rs _ => rs
   | _             => []
 
-#eval isOdd 0    -- [.i32 0]
-#eval isOdd 1    -- [.i32 1]
-#eval isEven 42  -- [.i32 1]
-
 example : isOdd 0 = [.i32 0] := by native_decide
 example : isOdd 1 = [.i32 1] := by native_decide
 example : isOdd 4 = [.i32 0] := by native_decide


### PR DESCRIPTION
## Summary

- Delete pure-value `#eval` lines from the interpreter `Examples/` files and the verifier `Run.lean` templates — each one was already covered by a `native_decide` example/theorem alongside it, so they only added build-time info noise.
- Wrap the IO drift-check `#eval show IO Unit from do …` blocks in the six generated `programs/Programs/.../Program.lean` files with `#guard_msgs (drop info) in`. The hash-mismatch error path still surfaces; only the success-case `() : Unit` info is dropped.
- Update `verifier/Verifier/Emit.lean` and `verifier/Verifier/EmitMini.lean` so future re-emits produce the wrapped form.

## Reviewer notes

- `lake build` in `interpreter/` and `verifier/` both complete cleanly.
- `programs/` has 4 pre-existing `Spec.lean` failures (`TerminatesWith.of_wp_entry rfl` mismatches in `IsEven/XorSum/NumInteger/Option`) that reproduce on the pristine branch and are unrelated to this change.
- The two emitters now diverge from the existing generated files only by the added `#guard_msgs (drop info) in` line — re-running `lake exe verifier check` would produce byte-identical drift-check blocks to what's committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)