### PR TITLE
Add interpreter ROADMAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Not sure where to begin? Here are some directions that tend to produce useful co
 
 **Find an interpreter bug via an example.** Write a small Wasm program that exercises today's supported features and prove something about it. If the proof fails because the interpreter behaves unexpectedly, that's a real bug. Reporting it with a minimal reproducer is a valuable contribution on its own; fixing it is even better.
 
-**Extend the spec testsuite coverage.** Run `just testsuite`, find a failing test, trace why it fails, implement the missing piece, and verify the test passes. This is the fastest feedback loop for interpreter work.
+**Extend the spec testsuite coverage.** Run `just testsuite`, find a failing test, trace why it fails, implement the missing piece, and verify the test passes. This is the fastest feedback loop for interpreter work. For a higher-level view of which Wasm features are missing and roughly how they're prioritized, see [`interpreter/ROADMAP.md`](interpreter/ROADMAP.md).
 
 **Add a Rust crate to `programs/`.** The `programs/` package contains Rust crates compiled to Wasm with Lean proofs of their behavior. Adding a new crate with a spec and at least one proof is welcome. **Open a GitHub issue describing the crate and the property you intend to prove before starting** — this avoids duplicated effort and lets us flag any concerns early.
 

--- a/interpreter/ROADMAP.md
+++ b/interpreter/ROADMAP.md
@@ -1,0 +1,54 @@
+# Interpreter roadmap
+
+A running, opinionated list of Wasm features the interpreter does not yet support, roughly ranked by how often they show up when verifying real Rust-compiled Wasm. This is a guide for contributors looking for impactful work, not a commitment. Items near the top unlock the most real-world programs; items near the bottom are specialized and can wait.
+
+If you want to pick something up, open an issue first so we can compare notes on the design — especially for tier 1 items, where the data-model choices ripple through the rest of the interpreter and the WP layer.
+
+## Tier 1 — common, blocking real programs
+
+### Host functions / imports
+
+Today `Module` has no `imports` field and `call` only dispatches to in-module functions. Without imports, no program that does I/O, allocates via a host allocator, or interacts with a runtime is verifiable — which rules out most "real" Wasm.
+
+Sketch of what's needed:
+
+- An import descriptor in `Module` (name, signature).
+- A host-function environment threaded through `Config`.
+- A `call_host` step rule that consults the environment.
+- A spec-level story for "the host does X" — probably an uninterpreted relation the user supplies per program, so that proofs can reason about host effects abstractly.
+
+### Tables and `call_indirect`
+
+Rust emits `call_indirect` for trait objects, function pointers, and some closure shapes. Without it, anything using `dyn Trait` is off-limits. Implementation involves `funcref`, element segments for table initialization, and the runtime type-check (with trap on mismatch or out-of-bounds).
+
+### Small but pervasive ops: `memory.grow`, `memory.size`, `unreachable`, `select`
+
+All trivially small additions to `Instruction` and the step function, but constantly emitted by rustc. `unreachable` in particular is what panics lower to — without it you can't even state "this path panics", let alone prove a function is panic-free.
+
+## Tier 2 — common in real codegen
+
+### Bulk memory: `memory.copy`, `memory.fill`, `memory.init`, `data.drop`
+
+LLVM emits these for `memcpy`/`memset`, struct moves, and `Vec` operations. Without them, rustc-compiled code only works with bulk-memory disabled, which is a persistent footgun.
+
+### Multi-value results
+
+`paramArity` / `resultArity` already exist on the block-like instructions, so the interpreter is mostly ready. The gap is in `Function` and the public `run` API, which are i32-shaped. Multi-value lets functions return tuples and is required for some Rust ABIs.
+
+### Floats (f32 / f64)
+
+Large surface area: NaN propagation, rounding modes, canonicalization. Rarely worth the implementation cost for verification work unless a target program needs them. Punt until forced.
+
+## Tier 3 — nice to have, low priority
+
+- Mutable global imports (rounds out the host-functions design).
+- Start function.
+- Multiple memories.
+- Reference types beyond `funcref` (`externref`).
+- SIMD (`v128`).
+- Exception handling.
+- GC proposal.
+
+## Meta-gap: module linking
+
+There is currently no story for one verified module calling another. If the project heads toward verifying a *system* rather than a single program, the linking model shapes the host-function design above and is worth settling before tier 1 (1) gets built out. Worth a design discussion before code.


### PR DESCRIPTION
## Summary

- Adds [`interpreter/ROADMAP.md`](interpreter/ROADMAP.md): a tiered list of Wasm features the interpreter does not yet support, ranked by how often they show up when verifying real Rust-compiled Wasm.
- Links to it from the "Extend the spec testsuite coverage" bullet in `CONTRIBUTING.md`, so contributors looking for impactful work have a higher-level view alongside the testsuite-driven feedback loop.

## Why

The testsuite tells you *which spec tests fail*, but not which gaps unlock real programs. The roadmap makes that prioritization explicit (host functions and `call_indirect` over floats, etc.) and flags one meta-gap — module linking — worth a design discussion before tier-1 work starts.

## Notes for reviewers

- The list is opinionated, not a commitment. Push back on the ranking if you disagree — easiest to argue about in a doc.
- No code changes; only docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)