### PR TITLE
Multivalue

### DIFF
--- a/interpreter/Interpreter/Wasm.lean
+++ b/interpreter/Interpreter/Wasm.lean
@@ -32,6 +32,7 @@ import Interpreter.Wasm.Examples.MemGrow
 import Interpreter.Wasm.Examples.MemFill
 import Interpreter.Wasm.Examples.MemCopy
 import Interpreter.Wasm.Examples.GlobalCounter
+import Interpreter.Wasm.Examples.MultiValue
 
 /-! # Wasm
 

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -212,53 +212,90 @@ private def atomToValueType? : String → Option Wasm.ValueType
   | "nullexternref" => some .i32
   | _     => none
 
+/-- Resolve a `(type N)` reference on a block/loop/if to the signature
+declared in the module's type table. Returns `none` if the index/id is
+unknown or the entry's signature is outside our supported integer
+subset; callers fall back to whatever inline `(param ...)` /
+`(result ...)` annotations follow. Constructed by `parseFunc` and
+threaded through `Ctx` so block/loop/if parsing can see the type table. -/
+abbrev BlockTypeResolver :=
+  String → Option (List Wasm.ValueType × List Wasm.ValueType)
+
 /-- Skip block/loop/if type annotations and collect explicit param/result
-types. The block-type info is discarded by callers (Wasm's block
-constructors carry no signature) but we still parse it to advance the
-token stream. -/
-private partial def skipBlockType :
+types. The block constructors `Wasm.Instruction.block` / `loop` / `iff`
+carry only arities (`paramArity`, `resultArity`), so we throw away the
+element types after counting them — but we *do* honour `(type N)`
+references by consulting the module's type table via `resolveType`, so
+a `block (type $sig)` whose entry declares non-zero arities is parsed
+with the correct arities instead of silently degenerating to `0 0`. -/
+private partial def skipBlockType (resolveType : BlockTypeResolver) :
     List Wasm.ValueType → List Wasm.ValueType → List Sexpr →
     List Wasm.ValueType × List Wasm.ValueType × List Sexpr
   | ps, rs, .list (.atom "result" :: ts) :: r =>
     let extra := ts.filterMap fun
       | .atom a => atomToValueType? a
       | _       => none
-    skipBlockType ps (rs ++ extra) r
+    skipBlockType resolveType ps (rs ++ extra) r
   | ps, rs, .list (.atom "param" :: ts) :: r =>
     let extra := ts.filterMap fun
       | .atom a => atomToValueType? a
       | _       => none
-    skipBlockType (ps ++ extra) rs r
-  | ps, rs, .list (.atom "type" :: _) :: r => skipBlockType ps rs r
+    skipBlockType resolveType (ps ++ extra) rs r
+  | ps, rs, .list (.atom "type" :: .atom ref :: _) :: r =>
+    -- A `(type N)` annotation adopts the type-table entry's signature as
+    -- the block's arity. wasm-tools commonly emits a redundant
+    -- `(type N) (param …) (result …)` triple where the inline forms
+    -- restate the resolved signature, so we also consume any trailing
+    -- `(param …)` / `(result …)` siblings to avoid double-counting.
+    -- If resolution fails, fall through to the inline accumulators.
+    match resolveType ref with
+    | some (resolvedPs, resolvedRs) =>
+      let r' := r.dropWhile fun
+        | .list (.atom "param" :: _)  => true
+        | .list (.atom "result" :: _) => true
+        | _ => false
+      (resolvedPs, resolvedRs, r')
+    | none => skipBlockType resolveType ps rs r
+  | ps, rs, .list (.atom "type" :: _) :: r =>
+    -- Malformed `(type …)` form (no atom reference) — preserve the old
+    -- behaviour of silently advancing the token stream.
+    skipBlockType resolveType ps rs r
   | ps, rs, .atom a :: r =>
     match atomToValueType? a with
     | some t => (ps, rs ++ [t], r)
     | none   => (ps, rs, .atom a :: r)
   | ps, rs, xs => (ps, rs, xs)
 
-/-- Pull an optional `$label` and any `(param T*)`/`(result T*)`
-annotations off the front of a block/loop/if's tokens. Returns the
-label (if any), parameter arity, result arity, and the remaining
-tokens. -/
-private def parseBlockHeader (xs : List Sexpr)
+/-- Pull an optional `$label` and any `(type N)` / `(param T*)` /
+`(result T*)` annotations off the front of a block/loop/if's tokens.
+Returns the label (if any), parameter arity, result arity, and the
+remaining tokens. `resolveType` looks up `(type N)` references against
+the module's type table; pass `fun _ => none` (or `Ctx.empty`'s default)
+when no type table is available. -/
+private def parseBlockHeader (resolveType : BlockTypeResolver) (xs : List Sexpr)
     : Option String × Nat × Nat × List Sexpr :=
   match xs with
   | .atom a :: r =>
     if a.startsWith "$" then
-      let (ps, rs, r') := skipBlockType [] [] r
+      let (ps, rs, r') := skipBlockType resolveType [] [] r
       (some (a.drop 1).toString, ps.length, rs.length, r')
     else
-      let (ps, rs, r') := skipBlockType [] [] xs
+      let (ps, rs, r') := skipBlockType resolveType [] [] xs
       (none, ps.length, rs.length, r')
   | _ =>
-    let (ps, rs, r') := skipBlockType [] [] xs
+    let (ps, rs, r') := skipBlockType resolveType [] [] xs
     (none, ps.length, rs.length, r')
 
 structure Ctx where
-  funcIds    : Std.HashMap String Nat
-  localIds   : Std.HashMap String Nat
-  globalIds  : Std.HashMap String Nat := {}
-  labelNames : List (Option String) := []
+  funcIds          : Std.HashMap String Nat
+  localIds         : Std.HashMap String Nat
+  globalIds        : Std.HashMap String Nat := {}
+  labelNames       : List (Option String) := []
+  /-- Resolves `(type N)` / `(type $sig)` references on `block`/`loop`/`if`
+  to the parsed signature, so multi-value block-types declared via the
+  type table are decoded with their correct arity. Defaults to "always
+  none" — callers without a type table behave exactly as before. -/
+  resolveBlockType : BlockTypeResolver := fun _ => none
 
 def Ctx.empty : Ctx := { funcIds := {}, localIds := {} }
 
@@ -681,13 +718,13 @@ private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
 private partial def foldedStructured (ctx : Ctx)
     (mk : Nat → Nat → List Wasm.Instruction → Wasm.Instruction)
     (xs : List Sexpr) : Except Err (List Wasm.Instruction) := do
-  let (label, ps, rs, xs') := parseBlockHeader xs
+  let (label, ps, rs, xs') := parseBlockHeader ctx.resolveBlockType xs
   let body ← parseInstrSeq (ctx.pushLabel label) xs'
   .ok [mk ps rs body]
 
 private partial def foldedIf (ctx : Ctx) (xs : List Sexpr)
     : Except Err (List Wasm.Instruction) := do
-  let (label, ps, rs, xs') := parseBlockHeader xs
+  let (label, ps, rs, xs') := parseBlockHeader ctx.resolveBlockType xs
   let bodyCtx := ctx.pushLabel label
   let mut condInstrs : List Wasm.Instruction := []
   let mut cur := xs'
@@ -824,7 +861,7 @@ private partial def parseStructured (ctx : Ctx)
     (mk : Nat → Nat → List Wasm.Instruction → Wasm.Instruction)
     (stops : Array String) (toks : List Sexpr)
     : Except Err (List Wasm.Instruction × List Sexpr) := do
-  let (label, ps, rs, toks') := parseBlockHeader toks
+  let (label, ps, rs, toks') := parseBlockHeader ctx.resolveBlockType toks
   let (body, after) ← parseInstrsUntil (ctx.pushLabel label) toks' stops
   match after with
   | _ :: aft => .ok ([mk ps rs body], dropTrailingLabel aft)
@@ -832,7 +869,7 @@ private partial def parseStructured (ctx : Ctx)
 
 private partial def parseIf (ctx : Ctx) (toks : List Sexpr)
     : Except Err (List Wasm.Instruction × List Sexpr) := do
-  let (label, ps, rs, toks') := parseBlockHeader toks
+  let (label, ps, rs, toks') := parseBlockHeader ctx.resolveBlockType toks
   let bodyCtx := ctx.pushLabel label
   let (thn, after) ← parseInstrsUntil bodyCtx toks' #["else", "end"]
   match after with
@@ -1055,7 +1092,11 @@ private def parseFunc (funcIds : Std.HashMap String Nat)
       | _ =>
         headerDone := true
     | _ => headerDone := true
-  let ctx : Ctx := { funcIds, localIds, globalIds }
+  let resolveBlockType : BlockTypeResolver := fun ref =>
+    match resolveTypeRef types ref with
+    | .ok sig  => some sig
+    | .error _ => none
+  let ctx : Ctx := { funcIds, localIds, globalIds, resolveBlockType }
   let instrs ← parseInstrSeq ctx rest
   return { symId, inlineExports,
            func := {

--- a/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
@@ -1,0 +1,217 @@
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Block
+import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Spec.Termination
+import Interpreter.Wasm.Decoder.Wat
+
+/-! ## Example: multi-value
+
+    End-to-end coverage for Wasm's multi-value extension. The interpreter,
+    decoder, and WP layer are already arity-generic
+    (`Function.results : List ValueType`,
+    `Instruction.block paramArity resultArity`, `wp_block_cons` over an
+    arbitrary `rs : Nat`, `wp_call_cons` passing `vs : List Value` of any
+    length, `FuncSpec.of_wp_body` taking `s'.values.take f.results.length`);
+    this file is the first place those code paths are exercised with
+    `results.length > 1` at the *spec* level.
+
+    All three Wasm functions live in one shared `multiValueModule` so that
+    `callsSwap`'s `call 0` resolves against the same module its caller's
+    `FuncSpec` is stated on — `wp_call_cons` needs the callee's spec and the
+    surrounding goal to mention the same module.
+
+    Five progressively stronger checks:
+
+    * `swap_runs`                   — concrete `run` of a 2-result function,
+                                       compared against an expected `List
+                                       Value` via `native_decide`. (We can't
+                                       use `TerminatesWith` directly here
+                                       because `Result` carries a `Store`
+                                       and `Store` has no `DecidableEq`
+                                       instance.)
+    * `swapSpec`                    — abstract `FuncSpec` for the 2-result
+                                       `swap`, via `FuncSpec.of_wp_body`.
+                                       Exercises
+                                       `Post (s'.values.take 2 ++ ...)`
+                                       end-to-end.
+    * `pairBlockSpec`               — `FuncSpec` whose body is a single
+                                       `block 0 2 [...]`. Exercises
+                                       `wp_block_cons` with
+                                       `resultArity = 2`.
+    * `callsSwapSpec`               — `FuncSpec` for a function that calls
+                                       `swap` and reduces both returned
+                                       values. Exercises `wp_call_cons`
+                                       against a multi-value `vs`.
+    * `multiValueBlockTypeDecodes`  — decodes a `(block (type $sig))`
+                                       WAT snippet and asserts the parsed
+                                       block has the correct arity. Locks
+                                       in the decoder fix that resolves
+                                       `(type N)` block annotations
+                                       against the module's type table.
+
+    Convention reminder: `FuncSpec`'s `args` parameter is the *caller's
+    operand stack at the call site*, head = top. For a function with two
+    `i32` parameters called as `(i32.const a) (i32.const b) (call $f)`,
+    `args = [.i32 b, .i32 a]` (b on top); `run` then reverses the prefix to
+    set `local 0 = a`, `local 1 = b`. -/
+
+namespace Wasm
+
+/-! ### Function bodies -/
+
+/-- `swap a b` pops two i32s and pushes them in the opposite order. With
+    `local 0 = a` (first pushed, deepest) and `local 1 = b` (second pushed,
+    top), the body leaves `[a, b]` on the stack (`a` on top), so the call
+    flips the top two i32s. -/
+def Swap : Program := [.localGet 1, .localGet 0]
+
+/-- One i32 in, *two* i32s out via a `block` annotated `(result i32 i32)`.
+    The block computes `[x - 1, 1 + x]` (top = `x - 1`) and the function
+    returns those two values verbatim. The order in the spec — `1 + x`,
+    not `x + 1` — matches what `wp_add_cons` literally produces:
+    `i32.add` is defined as `top + second`, and the body pushes `x` then
+    `1` before `.add`, so `top = 1`, `second = x`, result = `1 + x`. -/
+def PairBlock : Program := [
+  .block 0 2 [
+    .localGet 0, .const 1, .add,
+    .localGet 0, .const 1, .sub
+  ]
+]
+
+/-- Pushes `3` then `5`, calls function 0 (= `Swap`), then `.add`s the two
+    returned values. Concrete result: `[.i32 8]`. -/
+def CallsSwap : Program := [
+  .const 3,
+  .const 5,
+  .call 0,
+  .add
+]
+
+/-! ### Shared module
+
+    One module holds all three functions so that `callsSwap`'s `.call 0`
+    dispatches to the same `Swap` that `swapSpec` was proved on — which is
+    what lets `wp_call_cons (swapSpec 3 5)` compose inside `callsSwapSpec`. -/
+
+def multiValueModule : Module :=
+  { funcs :=
+      [ { params  := [.i32, .i32], body := Swap,      results := [.i32, .i32] },
+        { params  := [.i32],       body := PairBlock, results := [.i32, .i32] },
+        { params  := [],           body := CallsSwap, results := [.i32] } ] }
+
+/-! ### Check 1 — concrete `run` of a multi-value function -/
+
+/-- Helper: extract just the values list from a `Result`. `List Value` has
+    `DecidableEq` (so `native_decide` works on it), whereas `Result` carries
+    a `Store` field and `Store` doesn't. Returns `[]` on any non-success
+    outcome so the helper is total. Same idiom as `MemGrow.runValues`. -/
+private def runValues (fuel : Nat) (m : Module) (idx : Nat)
+    (st : Store) (args : List Value) : List Value :=
+  match run fuel m idx st args with
+  | .Success vs _ => vs
+  | _ => []
+
+/-- Pushing `1` then `2` (so `2` is on top) and calling `swap` leaves
+    `[1, 2]` (now `1` on top). Closed by `native_decide`, which compiles
+    `run` to native code and evaluates it. -/
+theorem swap_runs :
+    runValues 10 multiValueModule 0 multiValueModule.initialStore
+      [.i32 2, .i32 1] = [.i32 1, .i32 2] := by
+  native_decide
+
+/-! ### Check 2 — abstract `FuncSpec` for `Swap` -/
+
+/-- For *any* two i32 inputs, `swap` returns them in flipped order. The
+    interesting bit is the `Post`'s value-list has length 2 — every earlier
+    example's `Post` carried a length-≤ 1 list. -/
+theorem swapSpec (a b : UInt32) :
+    FuncSpec multiValueModule 0 (· = [.i32 b, .i32 a])
+      (fun _ vs => vs = [.i32 a, .i32 b]) := by
+  apply FuncSpec.of_wp_body
+    (f := { params := [.i32, .i32], body := Swap, results := [.i32, .i32] })
+  · rfl
+  · rintro args rfl initial
+    simp [Function.toLocals, Function.numParams]
+    unfold Swap
+    wp_run
+    simp
+
+/-! ### Check 3 — `FuncSpec` whose body is a single multi-value block -/
+
+theorem pairBlockSpec (x : UInt32) :
+    FuncSpec multiValueModule 1 (· = [.i32 x])
+      (fun _ vs => vs = [.i32 (x - 1), .i32 (1 + x)]) := by
+  apply FuncSpec.of_wp_body
+    (f := { params := [.i32], body := PairBlock, results := [.i32, .i32] })
+  · rfl
+  · rintro args rfl initial
+    simp [Function.toLocals, Function.numParams]
+    unfold PairBlock
+    apply wp_block_cons
+    wp_run
+    simp
+
+/-! ### Check 4 — caller that consumes both results of a multi-value call -/
+
+/-- `callsSwap` exercises `wp_call_cons` against a multi-value `vs`: in
+    every earlier example `vs` had length 1, so this is the first test that
+    the rule composes when `f.results.length > 1`. -/
+theorem callsSwapSpec :
+    FuncSpec multiValueModule 2 (· = [])
+      (fun _ vs => vs = [.i32 8]) := by
+  apply FuncSpec.of_wp_body
+    (f := { params := [], body := CallsSwap, results := [.i32] })
+  · rfl
+  · rintro args rfl initial
+    simp [Function.toLocals, Function.numParams]
+    unfold CallsSwap
+    wp_run
+    apply wp_call_cons
+      (Pre  := (· = [.i32 5, .i32 3]))
+      (Post := fun _ vs => vs = [.i32 3, .i32 5])
+      (swapSpec 3 5)
+    · rfl
+    · rintro st' vs rfl
+      wp_run
+      decide
+
+/-! ### Check 5 — decoder: `block (type $sig)` resolves to the right arity
+
+    `wasm-tools` commonly emits multi-value block-types via the type
+    table (`block (type $sig)`) rather than inline `(result i32 i32)`.
+    Before the decoder fix, the `(type N)` reference on a block was
+    silently dropped and the block degenerated to `paramArity = 0,
+    resultArity = 0`. The check below decodes a small module that uses
+    the type-table form and asserts the parsed block has the correct
+    `(0, 2)` arity. -/
+
+/-- Tiny WAT module: declares a type `$pair = () → (i32, i32)`, then a
+    function that returns two i32s by entering a `block (type $pair)`
+    holding two `i32.const`s. -/
+private def multiValueWat : String :=
+  "(module
+     (type $pair (func (result i32 i32)))
+     (func (result i32 i32)
+       (block (type $pair)
+         (i32.const 1)
+         (i32.const 2))))"
+
+/-- Pull the `(paramArity, resultArity)` of the first instruction of the
+    first function, if it's a `block`. -/
+private def firstBlockArity (m : Wasm.Module) : Option (Nat × Nat) :=
+  match m.funcs.head? with
+  | some f =>
+    match f.body.head? with
+    | some (.block ps rs _) => some (ps, rs)
+    | _ => none
+  | none => none
+
+/-- The decoded module has a block with `(paramArity = 0, resultArity = 2)`
+    — i.e., the `(type $pair)` reference was honoured. Closed by
+    `native_decide` on the literal decoder output. -/
+theorem multiValueBlockTypeDecodes :
+    (Wasm.Decoder.Wat.decode multiValueWat).toOption.bind firstBlockArity
+      = some (0, 2) := by
+  native_decide
+
+end Wasm


### PR DESCRIPTION
I picked this from the roadmap, and I added Examples/MultiValue.lean as a minimal end to end check, specifically swap_runs is a concrete run via native_decide, swapSpec and pairBlockSpec are FuncSpecs for a two result function and a block with resultArity = 2, callsSwapSpec is chechiking when caller consumes both results through wp_call_cons, and multiValueBlockTypeDecodes is a decoder regression for (block (type $pair)). 

In Decoder/Wat.lean, block/loop/if parsing now resolves (type N) / (type $sig) against the module’s type table, the same lookup as function headers, threaded through Ctx.resolveBlockType and skipBlockType.

Changes:
interpreter/Interpreter/Wasm/Examples/MultiValue.lean — new examples and proofs above.
interpreter/Interpreter/Wasm.lean — import MultiValue so they build with the package.
interpreter/Interpreter/Wasm/Decoder/Wat.lean — honour (type N) on structured control-flow headers.
Tested with lake build from interpreter/. I used AI to help plan the work and navigate the codebase (especially Lean proof syntax in the example file) but reviewed the diffs; the example proofs follow the same FuncSpec.of_wp_body / wp_run pattern as the existing examples.