### PR TITLE
verifier new: point scaffolded CodeLib require at GitHub

### DIFF
--- a/verifier/Verifier/Main.lean
+++ b/verifier/Verifier/Main.lean
@@ -135,6 +135,24 @@ private def templateFiles : List (String × String) := [
     include_str "../template/lean/Project/IsOdd/Run.lean")
 ]
 
+/-- The bundled `lean/lakefile.toml` points `CodeLib` at the in-repo path
+`../../../codelib` so the template itself builds inside the Talos monorepo.
+Scaffolded projects live outside the monorepo, so we rewrite the require
+to point at the published `cajal-technologies/talos` GitHub repo. -/
+private def scaffoldedLakefile : String :=
+  "name = \"Project\"\n\
+   version = \"0.1.0\"\n\
+   defaultTargets = [\"Project\"]\n\
+   \n\
+   [[require]]\n\
+   name = \"CodeLib\"\n\
+   git = \"https://github.com/cajal-technologies/talos.git\"\n\
+   subDir = \"codelib\"\n\
+   rev = \"main\"\n\
+   \n\
+   [[lean_lib]]\n\
+   name = \"Project\"\n"
+
 -- ----------------------------------------------------------------------------
 -- `check`
 -- ----------------------------------------------------------------------------
@@ -334,6 +352,7 @@ private def cmdNew (projectPathIn : String) : IO Unit := do
   IO.FS.createDirAll projectDir
   IO.println s!"==> scaffolding template into {projectDir}"
   for (rel, content) in templateFiles do
+    let content := if rel = "lean/lakefile.toml" then scaffoldedLakefile else content
     writeFile (projectDir / rel) content
   IO.println "==> cargo check"
   runOrDie "cargo" #["check"] (cwd := some (projectDir / "rust"))


### PR DESCRIPTION
## Summary
- The bundled `verifier/template/lean/lakefile.toml` requires `CodeLib` via the in-repo path `../../../codelib` so the template builds inside the Talos monorepo. Scaffolded projects live outside the monorepo, where that path does not resolve.
- Added a `scaffoldedLakefile` constant in `verifier/Verifier/Main.lean` that requires `CodeLib` from `https://github.com/cajal-technologies/talos.git` with `subDir = "codelib"` and `rev = "main"`.
- In `cmdNew`, the write loop now substitutes that content for the bundled `lean/lakefile.toml` while leaving the template file itself untouched.

## Test plan
- [x] `lake build` in `verifier/` succeeds.
- [ ] `verifier new <path>` outside the monorepo produces a project whose `lake update` + `lake build` succeed against the published GitHub repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)