### PR TITLE
Add verifier report preview workflow (Vercel)

### DIFF
--- a/.github/workflows/verifier-report-preview.yml
+++ b/.github/workflows/verifier-report-preview.yml
@@ -59,10 +59,12 @@ jobs:
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
         run: |
           set -euo pipefail
           url=$(vercel deploy programs/out \
             --token="$VERCEL_TOKEN" \
+            --scope="$VERCEL_SCOPE" \
             --yes \
             --archive=tgz)
           echo "deploy-url=$url" >> "$GITHUB_OUTPUT"
@@ -72,6 +74,7 @@ jobs:
         id: alias
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
         run: |
           set -euo pipefail
@@ -80,7 +83,9 @@ jobs:
           else
             alias="talos-verifier-report-latest.vercel.app"
           fi
-          vercel alias set "$DEPLOY_URL" "$alias" --token="$VERCEL_TOKEN"
+          vercel alias set "$DEPLOY_URL" "$alias" \
+            --token="$VERCEL_TOKEN" \
+            --scope="$VERCEL_SCOPE"
           echo "alias-url=https://$alias" >> "$GITHUB_OUTPUT"
           echo "Stable URL: https://$alias"
 

--- a/.github/workflows/verifier-report-preview.yml
+++ b/.github/workflows/verifier-report-preview.yml
@@ -1,0 +1,78 @@
+name: Verifier Report Preview
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Don't pile up deploys for the same PR / branch.
+concurrency:
+  group: verifier-report-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy report preview
+    runs-on: ubuntu-latest
+    # Secrets aren't exposed to PRs from forks, so skip the job there
+    # instead of failing. Pushes and same-repo PRs run normally.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `verifier extract` records the repo commit; full history isn't
+          # needed but a real .git is.
+          fetch-depth: 1
+
+      # Verifier executable doesn't need Mathlib (matches verifier-freshness.yml).
+      - uses: leanprover/lean-action@v1
+        with:
+          lake-package-directory: verifier
+          build-args: verifier
+          use-mathlib-cache: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build report
+        working-directory: programs
+        run: lake -d ../verifier exe verifier report --out ./out
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      # `vercel deploy <dir>` uploads the directory as a static site and
+      # prints the unique preview URL on stdout. The URL is stable for
+      # this commit but differs across runs — re-deploys produce new URLs.
+      - name: Deploy to Vercel (preview)
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          url=$(vercel deploy programs/out \
+            --token="$VERCEL_TOKEN" \
+            --yes \
+            --archive=tgz)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview URL: $url"
+
+      - name: Sticky-comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: verifier-report-preview
+          message: |
+            **Verifier report preview**: ${{ steps.deploy.outputs.url }}
+
+            Built from ${{ github.event.pull_request.head.sha }}. Updated on each push.

--- a/.github/workflows/verifier-report-preview.yml
+++ b/.github/workflows/verifier-report-preview.yml
@@ -52,9 +52,10 @@ jobs:
         run: npm install --global vercel@latest
 
       # `vercel deploy <dir>` uploads the directory as a static site and
-      # prints the unique preview URL on stdout. The URL is stable for
-      # this commit but differs across runs — re-deploys produce new URLs.
-      - name: Deploy to Vercel (preview)
+      # prints the unique per-deploy URL on stdout. We then alias it to a
+      # stable URL (per-PR for PRs, "latest" for main) so reviewers can
+      # bookmark/reload one address across re-deploys.
+      - name: Deploy to Vercel
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -64,8 +65,24 @@ jobs:
             --token="$VERCEL_TOKEN" \
             --yes \
             --archive=tgz)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "Preview URL: $url"
+          echo "deploy-url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deploy URL: $url"
+
+      - name: Alias deploy to a stable URL
+        id: alias
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy-url }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            alias="talos-verifier-report-pr-${{ github.event.pull_request.number }}.vercel.app"
+          else
+            alias="talos-verifier-report-latest.vercel.app"
+          fi
+          vercel alias set "$DEPLOY_URL" "$alias" --token="$VERCEL_TOKEN"
+          echo "alias-url=https://$alias" >> "$GITHUB_OUTPUT"
+          echo "Stable URL: https://$alias"
 
       - name: Sticky-comment preview URL on PR
         if: github.event_name == 'pull_request'
@@ -73,6 +90,6 @@ jobs:
         with:
           header: verifier-report-preview
           message: |
-            **Verifier report preview**: ${{ steps.deploy.outputs.url }}
+            **Verifier report preview**: ${{ steps.alias.outputs.alias-url }}
 
-            Built from ${{ github.event.pull_request.head.sha }}. Updated on each push.
+            (This URL is stable for this PR — it always points to the latest build of ${{ github.event.pull_request.head.sha }}.)


### PR DESCRIPTION
## Summary

- New non-blocking GitHub Actions workflow that builds the `verifier report` static site from `programs/` and deploys it to Vercel as a per-PR preview.
- Sticky-comments the preview URL on the PR (one comment, edited in place on each push).
- Skips silently on fork PRs (no access to secrets).

## Setup required before this works

Three repo secrets need to be added: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`. Steps:

1. Locally: `npm i -g vercel && cd programs && mkdir -p out && touch out/index.html && vercel link` — create a new Hobby-tier project (e.g. `talos-verifier-report`), then `rm -rf programs/out`.
2. `cat programs/.vercel/project.json` → grab `orgId` and `projectId`.
3. Create a token at https://vercel.com/account/tokens.
4. Add all three under Settings → Secrets and variables → Actions.

Make sure `.vercel/` is gitignored.

## Test plan

- [ ] Add the three secrets to the repo.
- [ ] Push a follow-up commit (or re-run via `workflow_dispatch`) and confirm the workflow builds and deploys.
- [ ] Check that the sticky PR comment appears with a live Vercel URL.
- [ ] Open the URL and verify the report renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)