### PR TITLE
xor_sum: take &[u32], confine unsafe to the export wrapper

### DIFF
--- a/programs/rust/xor_sum/src/exports.rs
+++ b/programs/rust/xor_sum/src/exports.rs
@@ -4,7 +4,13 @@
 /// `len == 0`.
 ///
 /// Thin `extern "C"` wrapper around [`crate::xor_sum`].
+///
+/// # Safety
+///
+/// `ptr` must be valid for reads of `len` `u32` words and properly
+/// aligned.
 #[unsafe(no_mangle)]
-pub extern "C" fn xor_sum(ptr: *const u32, len: usize) -> u32 {
-    unsafe { crate::xor_sum(ptr, len) }
+pub unsafe extern "C" fn xor_sum(ptr: *const u32, len: usize) -> u32 {
+    let xs = unsafe { core::slice::from_raw_parts(ptr, len) };
+    crate::xor_sum(xs)
 }

--- a/programs/rust/xor_sum/src/lib.rs
+++ b/programs/rust/xor_sum/src/lib.rs
@@ -1,19 +1,13 @@
 mod exports;
 
-/// XOR-fold a slice of `u32`s laid out contiguously in linear memory.
+/// XOR-fold a slice of `u32`s.
 ///
-/// Reads `len` little-endian `u32` words starting at `ptr`. Returns `0`
-/// when `len == 0`.
-///
-/// # Safety
-///
-/// `ptr` must be valid for reads of `len` `u32` words and properly
-/// aligned.
-pub unsafe fn xor_sum(ptr: *const u32, len: usize) -> u32 {
+/// Returns `0` when `xs` is empty.
+pub fn xor_sum(xs: &[u32]) -> u32 {
     let mut acc: u32 = 0;
     let mut i: usize = 0;
-    while i < len {
-        acc ^= unsafe { *ptr.add(i) };
+    while i < xs.len() {
+        acc ^= xs[i];
         i += 1;
     }
     acc


### PR DESCRIPTION
## Summary
- `programs/rust/xor_sum/src/lib.rs` now exposes a safe `pub fn xor_sum(xs: &[u32]) -> u32` with no `unsafe`.
- The raw-pointer / C-ABI boundary (`from_raw_parts`) lives entirely in `exports.rs`, matching the verifier convention used by the other crates (lib.rs = safe Rust API, exports.rs = unsafe extern "C" wrapper).
- `lake exe verifier check` rebuilds `Project.XorSum.Program` from the new wasm and the existing spec/proof still go through (7 crates, lake build OK, 0 sorrys).

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown --release` in `programs/rust/xor_sum`
- [x] `lake exe verifier check` from `programs/` — all crates build, 0 sorrys

🤖 Generated with [Claude Code](https://claude.com/claude-code)