### PR TITLE
CLAUDE.md: use mathlib cache instead of rebuilding from source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,12 @@ imports `CodeLib`, never the interpreter directly.
 
 ```bash
 # from each package directory:
-lake build       # builds the libraries and executables
+lake update
+lake exe cache get
+lake build
 ```
+
+**Never run a bare `lake build` in a fresh checkout, CI job, GitHub Action, README snippet, or shell command** — it will recompile Mathlib from source (tens of minutes to hours). Always precede it with `lake update && lake exe cache get` so Mathlib is pulled from the prebuilt cache. This applies everywhere `lake build` is mentioned: docs, READMEs, CI workflows, scripts, and ad-hoc terminal commands.
 
 There is no separate test runner. Example correctness is encoded as Lean theorems and `native_decide` checks inside the examples; a successful `lake build` means every proof and decidable example check passed. To check a single source file in isolation: `lake env lean <path>`.
 


### PR DESCRIPTION
## Summary
- Replace the bare `lake build` snippet in CLAUDE.md with the cache-aware sequence: `lake update && lake exe cache get && lake build`.
- Add an explicit warning that a bare `lake build` (in CLI, CI, GitHub Actions, READMEs, scripts) will recompile Mathlib from source and should be avoided everywhere.

## Why
Rebuilding Mathlib from source takes tens of minutes to hours. The prebuilt cache is the intended path; making this obvious in CLAUDE.md ensures it propagates to any future docs, workflows, and ad-hoc commands.

## Test plan
- [ ] Skim the updated Build / run / verify section in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)