### PR TITLE
runner: drop mathlib from link graph

### DIFF
--- a/interpreter/Interpreter/Runner.lean
+++ b/interpreter/Interpreter/Runner.lean
@@ -1,4 +1,4 @@
-import Interpreter.Wasm
+import Interpreter.Wasm.Semantics
 import Interpreter.Wasm.Decoder.Wat
 
 /-!


### PR DESCRIPTION
## Summary
- The `runner` exe was importing the `Interpreter.Wasm` umbrella, which re-exports the Wp tactic layer (`import Mathlib.Tactic` in `Wp/Defs.lean`) and the Examples. Linking the binary therefore dragged in every mathlib `.c.o`.
- Narrowed the import to `Interpreter.Wasm.Semantics` + `Interpreter.Wasm.Decoder.Wat` — what the runner actually uses. Mathlib is now fully off the runner's transitive deps.

## Why
The CI `Smoke test` job (which builds `runner`) was taking ~13 min because `lake exe cache get` only ships mathlib `.olean` files; the `.c.o` native objects must be compiled per-runner whenever an executable links them. The `Build & verify proofs` job is library-only, so it didn't hit this. With this change `lake build runner` goes from ~5946 jobs to 16 locally.

## Test plan
- [x] `lake build runner` succeeds (16 jobs, no mathlib)
- [x] `runner samples/factorial.wat fact 5` → `120`
- [ ] CI smoke job wall-clock drops to roughly the proof job's runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)