### PR TITLE
Fix/testsuite windows tempdir

### DIFF
--- a/interpreter/Interpreter/Testsuite.lean
+++ b/interpreter/Interpreter/Testsuite.lean
@@ -258,16 +258,31 @@ def EXIT_OK   : UInt32 := 0
 def EXIT_FAIL : UInt32 := 1
 def EXIT_ERR  : UInt32 := 3
 
-/-- Make a process-scoped temp dir via `mktemp -d`. Returns `.error` if
-neither `mktemp` is on PATH nor a sensible fallback exists. -/
+/-- Make a process-scoped temp dir and return its path. On Unix this shells out to mktemp -d; on Windows, which has no mktemp, it creates a uniquely named directory under TEMP (or TMP) with IO.FS.createDirAll. Returns .error if the directory can't be created. -/
 def makeTempDir : IO (Except String String) := do
-  let res ← (IO.Process.output { cmd := "mktemp", args := #["-d", "-t", "wasm-testsuite.XXXXXXXX"] }).toBaseIO
-  match res with
-  | .ok out =>
-    if out.exitCode = 0 then return .ok out.stdout.trimAscii.toString
-    else return .error s!"mktemp failed: {out.stderr.trimAscii.toString}"
-  | .error _ =>
-    return .error "could not create a temporary directory (mktemp not found)"
+  if System.Platform.isWindows then
+    let base ← do
+      match ← IO.getEnv "TEMP" with
+      | some d => pure d
+      | none   =>
+        match ← IO.getEnv "TMP" with
+        | some d => pure d
+        | none   => return .error "could not determine temp directory (TEMP and TMP are unset)"
+    let ns ← IO.monoMsNow
+    let path := System.FilePath.mk base / s!"wasm-testsuite-{ns}"
+    try
+      IO.FS.createDirAll path
+      return .ok path.toString
+    catch e =>
+      return .error s!"could not create temp directory {path}: {e.toString}"
+  else
+    let res ← (IO.Process.output { cmd := "mktemp", args := #["-d", "-t", "wasm-testsuite.XXXXXXXX"] }).toBaseIO
+    match res with
+    | .ok out =>
+      if out.exitCode = 0 then return .ok out.stdout.trimAscii.toString
+      else return .error s!"mktemp failed: {out.stderr.trimAscii.toString}"
+    | .error _ =>
+      return .error "could not create a temporary directory (mktemp not found)"
 
 def runAll (a : Args) : IO UInt32 := do
   let files ← try discoverFiles a.pattern

--- a/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
@@ -106,7 +106,7 @@ def multiValueModule : Module :=
     a `Store` field and `Store` doesn't. Returns `[]` on any non-success
     outcome so the helper is total. Same idiom as `MemGrow.runValues`. -/
 private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store) (args : List Value) : List Value :=
+    (st : Store Unit) (args : List Value) : List Value :=
   match run fuel m idx st args with
   | .Success vs _ => vs
   | _ => []
@@ -125,7 +125,7 @@ theorem swap_runs :
     interesting bit is the `Post`'s value-list has length 2 — every earlier
     example's `Post` carried a length-≤ 1 list. -/
 theorem swapSpec (a b : UInt32) :
-    FuncSpec multiValueModule 0 (· = [.i32 b, .i32 a])
+    FuncSpec ({} : HostEnv Unit) multiValueModule 0 (· = [.i32 b, .i32 a])
       (fun _ vs => vs = [.i32 a, .i32 b]) := by
   apply FuncSpec.of_wp_body
     (f := { params := [.i32, .i32], body := Swap, results := [.i32, .i32] })
@@ -139,7 +139,7 @@ theorem swapSpec (a b : UInt32) :
 /-! ### Check 3 — `FuncSpec` whose body is a single multi-value block -/
 
 theorem pairBlockSpec (x : UInt32) :
-    FuncSpec multiValueModule 1 (· = [.i32 x])
+    FuncSpec ({} : HostEnv Unit) multiValueModule 1 (· = [.i32 x])
       (fun _ vs => vs = [.i32 (x - 1), .i32 (1 + x)]) := by
   apply FuncSpec.of_wp_body
     (f := { params := [.i32], body := PairBlock, results := [.i32, .i32] })
@@ -157,7 +157,7 @@ theorem pairBlockSpec (x : UInt32) :
     every earlier example `vs` had length 1, so this is the first test that
     the rule composes when `f.results.length > 1`. -/
 theorem callsSwapSpec :
-    FuncSpec multiValueModule 2 (· = [])
+    FuncSpec ({} : HostEnv Unit) multiValueModule 2 (· = [])
       (fun _ vs => vs = [.i32 8]) := by
   apply FuncSpec.of_wp_body
     (f := { params := [], body := CallsSwap, results := [.i32] })


### PR DESCRIPTION
test runner couldn't run on Windows (used Unix-only mktemp), added a Windows path