### PR TITLE
Fix Memchr proof: swap arg order so entry reversal gives correct locals

### DIFF
--- a/programs/lean/Project/Memchr/Spec.lean
+++ b/programs/lean/Project/Memchr/Spec.lean
@@ -44,7 +44,7 @@ Memory remains unchanged. Carries the side condition that every offset
 def MemchrSpec : Prop :=
   ∀ (env : HostEnv Unit) (initial : Store Unit) (ptr len needle : UInt32)
     (hmem : ∀ k < len.toNat, (k + ptr.toNat) % 4294967296 < initial.mem.pages * 65536),
-    TerminatesWith env «module» 0 initial [.i32 ptr, .i32 len, .i32 needle]
+    TerminatesWith env «module» 0 initial [.i32 needle, .i32 len, .i32 ptr]
       (fun st' rs => rs = [.i32 (memchrAux st'.mem ptr needle len.toNat 0)])
 
 @[proves Project.Memchr.Spec.MemchrSpec]


### PR DESCRIPTION
The Memchr proof was broken (excluded from build), because TerminatesWith passed args as [ptr, len, needle], but entry reverses them, so the runtime had [needle, len, ptr], mismatching the invariant and making the initial step unprovable (needle = ptr).