### PR TITLE
Share Lake packages at a single repo-root .lake/packages

### DIFF
--- a/.claude/worktree-init.sh
+++ b/.claude/worktree-init.sh
@@ -45,6 +45,12 @@ PY
 }
 
 seeded=0
+# Shared Mathlib + transitive Lake deps (~multi-GB); one tree at repo root.
+if [[ -d "$src/.lake/packages" && ! -e "$cwd/.lake/packages" ]]; then
+    mkdir -p "$cwd/.lake"
+    clone_dir "$src/.lake/packages" "$cwd/.lake/packages"
+    seeded=$((seeded + 1))
+fi
 for pkg in "${pkgs[@]}"; do
     src_lake="$src/$pkg/.lake"
     dst_lake="$cwd/$pkg/.lake"
@@ -53,12 +59,6 @@ for pkg in "${pkgs[@]}"; do
     [[ -e "$dst_lake" ]] && continue
 
     mkdir -p "$dst_lake"
-    # packages/ is the bulk (~7-9 GB, hundreds of thousands of files) and is
-    # treated as immutable from the worktree's perspective — clone the whole
-    # subtree in one syscall.
-    if [[ -d "$src_lake/packages" ]]; then
-        clone_dir "$src_lake/packages" "$dst_lake/packages"
-    fi
     # build/ and config/ are small and may be touched by builds — per-file
     # COW clone via cp -c is fine here.
     for sub in build config; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,12 @@ imports `CodeLib`, never the interpreter directly.
 ## Build / run / verify
 
 ```bash
-# from each package directory:
-lake update
-lake exe cache get
-lake build
+just lake-shared        # once: populate repo-root .lake/packages (Mathlib owner: interpreter/)
+# then, for each package:
+cd <package> && lake build
 ```
 
-**Never run a bare `lake build` in a fresh checkout, CI job, GitHub Action, README snippet, or shell command** — it will recompile Mathlib from source (tens of minutes to hours). Always precede it with `lake update && lake exe cache get` so Mathlib is pulled from the prebuilt cache. This applies everywhere `lake build` is mentioned: docs, READMEs, CI workflows, scripts, and ad-hoc terminal commands.
+Third-party Lake dependencies (Mathlib and its transitive packages) live in **one** tree at the repo root: `.lake/packages`. Every `lakefile.toml` sets `packagesDir` to that path; per-package `.lake/` holds only `build/` and `config/`.
 
 There is no separate test runner. Example correctness is encoded as Lean theorems and `native_decide` checks inside the examples; a successful `lake build` means every proof and decidable example check passed. To check a single source file in isolation: `lake env lean <path>`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The codebase has five main parts — described at a level that shouldn't go stal
 ## Building
 
 ```bash
-lake build
+just build
 ```
 
 Dependencies:

--- a/codelib/lake-manifest.json
+++ b/codelib/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.2.0",
- "packagesDir": ".lake/packages",
+ "packagesDir": "../.lake/packages",
  "packages":
  [{"type": "path",
    "scope": "",

--- a/codelib/lakefile.toml
+++ b/codelib/lakefile.toml
@@ -1,6 +1,7 @@
 name = "CodeLib"
 version = "0.1.0"
 defaultTargets = ["CodeLib"]
+packagesDir = "../.lake/packages"
 
 [[require]]
 name = "WasmInterpreterLean"

--- a/interpreter/lake-manifest.json
+++ b/interpreter/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.2.0",
- "packagesDir": ".lake/packages",
+ "packagesDir": "../.lake/packages",
  "packages":
  [{"url": "https://github.com/leanprover-community/mathlib4",
    "type": "git",

--- a/interpreter/lakefile.toml
+++ b/interpreter/lakefile.toml
@@ -1,6 +1,7 @@
 name = "Interpreter"
 version = "0.1.0"
 defaultTargets = ["Interpreter"]
+packagesDir = "../.lake/packages"
 
 [[require]]
 name = "mathlib"

--- a/justfile
+++ b/justfile
@@ -2,8 +2,14 @@
 # so a single Lake workspace invocation covers the full chain without rebuilding
 # Interpreter twice (which happens when each package is built as a separate root).
 # Interpreter executables (runner, testsuite) are built by their own recipes below.
-build:
+build: lake-shared
     lake -d {{justfile_directory()}}/programs    build
+
+[private]
+[working-directory("interpreter")]
+lake-shared:
+    lake update
+    lake exe cache get
 
 # Generate HTML documentation and serve it at http://localhost:8080
 docs:

--- a/justfile
+++ b/justfile
@@ -2,8 +2,9 @@
 # so a single Lake workspace invocation covers the full chain without rebuilding
 # Interpreter twice (which happens when each package is built as a separate root).
 # Interpreter executables (runner, testsuite) are built by their own recipes below.
+[working-directory("programs/lean")]
 build: lake-shared
-    lake -d {{justfile_directory()}}/programs    build
+    lake build
 
 [private]
 [working-directory("interpreter")]

--- a/programs/lean/lake-manifest.json
+++ b/programs/lean/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.2.0",
- "packagesDir": ".lake/packages",
+ "packagesDir": "../../.lake/packages",
  "packages":
  [{"type": "path",
    "scope": "",

--- a/programs/lean/lakefile.toml
+++ b/programs/lean/lakefile.toml
@@ -1,6 +1,7 @@
 name = "Project"
 version = "0.1.0"
 defaultTargets = ["Project"]
+packagesDir = "../../.lake/packages"
 
 [[require]]
 name = "CodeLib"

--- a/verifier/lake-manifest.json
+++ b/verifier/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.2.0",
- "packagesDir": ".lake/packages",
+ "packagesDir": "../.lake/packages",
  "packages":
  [{"type": "path",
    "scope": "",

--- a/verifier/lakefile.toml
+++ b/verifier/lakefile.toml
@@ -1,6 +1,7 @@
 name = "Verifier"
 version = "0.1.0"
 defaultTargets = ["verifier"]
+packagesDir = "../.lake/packages"
 
 [[require]]
 name = "WasmInterpreterLean"

--- a/verifier/template/lean/lake-manifest.json
+++ b/verifier/template/lean/lake-manifest.json
@@ -1,5 +1,5 @@
 {"version": "1.2.0",
- "packagesDir": ".lake/packages",
+ "packagesDir": "../../../.lake/packages",
  "packages":
  [{"type": "path",
    "scope": "",

--- a/verifier/template/lean/lakefile.toml
+++ b/verifier/template/lean/lakefile.toml
@@ -1,6 +1,7 @@
 name = "Project"
 version = "0.1.0"
 defaultTargets = ["Project"]
+packagesDir = "../../../.lake/packages"
 
 [[require]]
 name = "CodeLib"


### PR DESCRIPTION
# Share Lake packages at a single repo-root `.lake/packages`

## Problem

Each Lean package (`interpreter`, `codelib`, `programs/lean`, `verifier`,
`verifier/template/lean`) was its own Lake root with the default
`packagesDir = ".lake/packages"`, so Mathlib and its transitive git deps were
fetched and cached **once per package**. On my machine that was ~**15 GB** of
duplicated dependency trees:

```
4.9G  interpreter/.lake
4.6G  codelib/.lake
4.6G  programs/lean/.lake
725M  verifier/.lake
```

## Change

Point every package's `packagesDir` at one shared tree at the repo root, so the
git deps (Mathlib + transitive) are checked out once and every package's
`.lake/build/` reuses them. `interpreter` owns the direct Mathlib pin
(`rev = "v4.30.0"`); the others inherit it through their path dependencies.
`lake-manifest.json` files were regenerated accordingly.

Supporting changes:

- **`justfile`** — `just build` runs `lake-shared`, then
  `lake build` (from `programs/lean/`).
- **`.claude/worktree-init.sh`** — seeds the single shared `.lake/packages` once
  (APFS clone) instead of one tree per worktree.
- **`CLAUDE.md`** / **`CONTRIBUTING.md`** — docs updated; build is now `just build`.

After the change there is a single `.lake/packages/mathlib` at the repo root and
no per-package `*/.lake/packages`; each package keeps only its own `.lake/build/`.

## Notes

- Multiple Lake roots are intentionally kept; only the shared-dependency
  location changes, not the package layout.
- `docbuild` already used `../.lake/packages` and has its own git deps
  (`doc-gen4`), out of scope here.

## Test plan

- [ ] Fresh clone + `just build` → single `.lake/packages/mathlib`, no `*/.lake/packages`.
- [ ] `du -hs .lake/packages */.lake` shows one shared tree, not per-package copies.
- [ ] CI build / testsuite passes unchanged.
