### PR TITLE
CI: cache shared .lake/packages tree for Mathlib reuse

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: .lake/packages
+          key: lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('interpreter/lake-manifest.json') }}
+          restore-keys: |
+            lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-
       - uses: leanprover/lean-action@v1
         with:
           lake-package-directory: programs/lean
@@ -35,6 +41,12 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: .lake/packages
+          key: lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('interpreter/lake-manifest.json') }}
+          restore-keys: |
+            lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-
       - uses: leanprover/lean-action@v1
         with:
           lake-package-directory: interpreter

--- a/.github/workflows/testsuite-report.yml
+++ b/.github/workflows/testsuite-report.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           submodules: true
 
+      - uses: actions/cache@v4
+        with:
+          path: .lake/packages
+          key: lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('interpreter/lake-manifest.json') }}
+          restore-keys: |
+            lake-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-
+
       - uses: leanprover/lean-action@v1
         with:
           lake-package-directory: interpreter


### PR DESCRIPTION
## Summary

- Moving all Lake packages to a shared `<repo>/.lake/packages/` tree (#39) put Mathlib's oleans outside the path that `leanprover/lean-action@v1` caches (only `<lake-package-directory>/.lake`). Every CI run was falling back to `lake exe cache get` or recompiling Mathlib — observed on [run 27023854766](https://github.com/cajal-technologies/talos/actions/runs/27023854766/job/79760835862?pr=39).
- Add an explicit `actions/cache@v4` step before each `lean-action` invocation that uses `use-mathlib-cache: true`, caching the shared `.lake/packages` tree.
- Cache key hashes `lean-toolchain` and `interpreter/lake-manifest.json` (interpreter owns the Mathlib pin; other packages inherit via path requires). `restore-keys` lets unrelated PRs reuse the cache when only the manifest hasn't changed.

Affected jobs: `lean_action_ci.yml` (`build`, `test`) and `testsuite-report.yml` (`check`). Verifier jobs use `use-mathlib-cache: false` and don't need this.

## Test plan

- [ ] Re-run CI and confirm the `Mathlib Cache` group in lean-action's log shows oleans being decompressed/reused rather than rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)