### PR TITLE
Add support for Codex

### DIFF
--- a/.agents/skills/lean-lsp-mcp/SKILL.md
+++ b/.agents/skills/lean-lsp-mcp/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: lean-lsp-mcp
+description: Lean LSP MCP tools for interactive Lean proof development — tool reference, workflows, and examples
+---
+
+# Lean LSP MCP — Skill File for AI Agents
+
+/- Adapted from the lean-lsp-mcp README (MIT License, (c) Oliver Dressler).
+   Source: https://github.com/oOo0oOo/lean-lsp-mcp
+   MIT License is compatible with this project's AGPL-3.0 license. -/
+
+## IMPORTANT: Always Use Lean MCP Tools for Lean Proofs
+
+When working on Lean proofs in a Lean project, **always** use the lean-lsp-mcp
+tools. These tools are available directly in your tool palette — you do NOT need to
+start a subprocess, launch a REPL, or run any setup commands.
+
+**If the tools are not in your palette** (i.e., you cannot find `lean_goal`,
+`lean_diagnostic_messages`, etc. among your available tools), **STOP IMMEDIATELY
+and signal the user BEFORE doing anything else** — do not attempt proof work, do
+not fall back to `lake build` loops, do not dispatch proof agents. Tell the user:
+> "The lean-lsp-mcp tools are not available in my tool palette. These tools are
+> essential for efficient Lean proof development: they provide interactive feedback
+> (proof goals, diagnostics, type information) without rebuilding the project.
+> Without them, the only option is `lake build`, which can easily take minutes on
+> a big file and does not provide intermediate goal states — making iterative proof
+> development impractical. Please connect the MCP server or install it
+> (`pip install lean-lsp-mcp` or `uvx lean-lsp-mcp`) and configure it in your MCP
+> client settings. See https://github.com/oOo0oOo/lean-lsp-mcp for setup
+> instructions."
+**If you get "Error: Not connected"** when calling a lean-lsp-mcp tool, the MCP
+server has likely crashed and is restarting. Wait a couple of minutes and retry.
+This is a transient error — the server will typically recover on its own. Do NOT
+fall back to `lake build` loops or stop working entirely; just wait briefly and
+retry the tool call.
+
+**Do NOT proceed with proof work without these tools** — wait for the user to
+connect the MCP server. Falling back to `lake build` loops wastes minutes per
+iteration where the MCP tools give sub-second feedback.
+
+The tools give you:
+- Proof goal context at any position (`lean_goal`)
+- Diagnostics (errors, warnings) without rebuilding (`lean_diagnostic_messages`)
+- Type information via hover (`lean_hover_info`)
+- Try multiple tactics without modifying the file (`lean_multi_attempt`)
+- Code actions for `step*?` suggestions (`lean_code_actions`)
+- External search tools (LeanSearch, Loogle, Lean Finder, Hammer, State Search)
+- Verification of axiom usage (`lean_verify`)
+
+Without these tools, you are flying blind — you cannot see proof goals, you cannot
+tell if a tactic worked, and you must recompile the whole file after every change.
+
+**Do NOT use `lake build` to iterate on proofs.** The MCP tools give incremental
+feedback in seconds. `lake build` rebuilds from scratch and can easily take minutes
+on a big file. Only use `lake build` once at the very end to confirm the final result.
+
+**NEVER run `lake clean` or delete `.lake/`.** This forces a full rebuild (30+ min).
+Fix root causes instead.
+
+## ⚠️ Initial Setup: Run `lake build` Before First MCP Use
+
+The lean-lsp-mcp LSP server has a **cold-start timeout issue**: if the project's
+`.olean` files are missing or stale (e.g., after a `git merge`, branch switch, or
+fresh clone), the first MCP tool call will time out because the LSP tries to elaborate
+the file from scratch — which requires compiling all dependencies, easily exceeding
+the MCP request timeout.
+
+**Before the VERY FIRST use of any lean-lsp-mcp tool** (typically at the start of a
+new verification task), run:
+
+```bash
+cd <lean_project_path> && lake build
+```
+
+This pre-compiles all `.olean` files so the LSP can load them instantly. After this
+initial build, the MCP tools will respond in seconds for incremental edits.
+
+**When to run the initial build:**
+- At the start of a new agent session (first task assignment)
+- After `git merge` / `git pull` that changed `.lean` files in dependencies
+- After switching branches
+- After any operation that invalidates `.olean` caches
+
+**You do NOT need to re-run `lake build` during normal proof iteration.** Once the
+initial build is done, the LSP picks up file edits incrementally. Only re-run
+`lake build` for the specific cases listed in "When to use `lean_build`" below.
+
+## Tool Reference
+
+### File and Goal Inspection (read-only — use freely)
+
+| Tool | Purpose | Key Parameters |
+|---|---|---|
+| `lean_goal` | **THE MOST IMPORTANT TOOL** — get proof goals at a position | `file_path`, `line`, optional `column` |
+| `lean_diagnostic_messages` | Get errors/warnings/infos for a file | `file_path`, optional `severity`, `start_line`, `end_line` |
+| `lean_file_outline` | Get imports and declarations with type signatures | `file_path` |
+| `lean_hover_info` | Get type and docs for a symbol | `file_path`, `line`, `column` |
+| `lean_term_goal` | Get expected type at a position | `file_path`, `line`, optional `column` |
+| `lean_completions` | Get autocompletions (use on incomplete code) | `file_path`, `line`, `column` |
+| `lean_declaration_file` | Find where a symbol is declared | `file_path`, `symbol` |
+| `lean_references` | Find all references to a symbol | `file_path`, `line`, `column` |
+| `lean_code_actions` | Get quick fixes and "Try This" suggestions | `file_path`, `line` |
+| `lean_run_code` | Run a self-contained Lean code snippet (must include imports) | `code` |
+| `lean_verify` | Check axioms used by a theorem | `file_path`, `theorem_name` |
+
+### Tactic Exploration (does NOT modify the file)
+
+| Tool | Purpose | Key Parameters |
+|---|---|---|
+| `lean_multi_attempt` | **Try multiple tactics and see results** — does not modify the file | `file_path`, `line`, `snippets` (array of tactics) |
+
+`lean_multi_attempt` is extremely valuable: pass 3+ candidate tactics and see which
+ones close the goal (or make progress) — all without touching the file. Use this
+before committing to a tactic with `edit`.
+
+### File Modification
+
+| Tool | Purpose | Key Parameters |
+|---|---|---|
+| `lean_build` | Rebuild project and restart LSP | optional `clean`, `lean_project_path` |
+
+**Important:** The MCP server manages a single LSP session per project. When you
+edit a `.lean` file on disk (using `edit`/`create` tools), the LSP server picks up
+the change automatically (typically within a few seconds). You do NOT need to call
+`lean_build` after every edit.
+
+### When to use `lean_build` (and when NOT to)
+
+`lean_build` runs `lake build` and restarts the LSP server. It takes **10–30+
+minutes** on large projects. Use it ONLY when:
+
+- **Initial setup** — before the very first MCP tool call in a new session (see
+  "Initial Setup" section above). You can also run `lake build` directly in bash.
+- **You modified a dependency file** and need to refresh the imports in the file
+  you are currently working on (e.g., you changed a lemma in `A.lean` and
+  need `B.lean` to pick up the new version).
+- **You added new `import` statements** that require recompilation of upstream modules.
+- As a **final build check** after completing all proof work, to confirm the project
+  compiles cleanly end-to-end.
+
+Before calling `lean_build`, think twice — you will easily be waiting 10+ minutes. If
+you only edited the file you are currently working on, you do NOT need `lean_build`
+— the LSP picks up changes automatically.
+
+### ⛔ NEVER call `lean_build` to recover from LSP timeouts or crashes
+
+When an MCP tool call times out or returns an error (e.g., `McpError: MCP error
+-32001: Request timed out`), the LSP server has likely crashed and is auto-restarting.
+**Do NOT call `lean_build`** — it triggers a full `lake build` and restarts the LSP,
+which is massive overkill. The LSP auto-restarts on its own within 1–2 minutes.
+
+**The correct recovery procedure:**
+1. **Wait 2 minutes.** Do other work (update plan, write comments, think about the
+   next proof step) — do not poll the LSP repeatedly during this time.
+2. **Retry the MCP tool call.** If it still times out, wait another 2 minutes and
+   retry once more.
+3. **Only if the LSP is still unresponsive after 3 retries**, call `lean_build`.
+
+This applies to ALL MCP tool failures — `lean_goal`, `lean_diagnostic_messages`,
+`lean_multi_attempt`, etc. The pattern is always: **wait, then retry**.
+
+### External Search Tools (rate-limited)
+
+| Tool | Purpose | Rate Limit |
+|---|---|---|
+| `lean_leansearch` | Search Mathlib via natural language (leansearch.net) | 3 req/30s |
+| `lean_loogle` | Search Mathlib by type signature (loogle.lean-lang.org) | 3 req/30s |
+| `lean_leanfinder` | Semantic search by mathematical meaning (Lean Finder) | 10 req/30s |
+| `lean_state_search` | Find lemmas to close the current goal (premise-search.com) | 6 req/30s |
+| `lean_hammer_premise` | Get premise suggestions for automation tactics | 6 req/30s |
+| `lean_local_search` | Search local project + stdlib for declarations | No limit |
+
+**Use `lean_local_search` first** — it is fast, free, and confirms declarations exist
+before you try to use them. Use the external tools when you need Mathlib results or
+cannot find what you need locally.
+
+### Profiling
+
+| Tool | Purpose | Key Parameters |
+|---|---|---|
+| `lean_profile_proof` | Run `lean --profile` on a theorem — returns per-line timing | `file_path`, `line` |
+
+**Use sparingly** — profiling is slow. Only profile when a proof is taking too long
+and you need to identify the bottleneck.
+
+## Core Workflow
+
+### 1. Edit the file on disk, then inspect goals
+
+The MCP tools operate on the file as it exists on disk. Your workflow is:
+
+1. **Edit the `.lean` file** using the standard `edit`/`create` tools
+2. **Use `lean_goal`** to inspect the proof state (the LSP picks up the change)
+3. **Use `lean_diagnostic_messages`** to check for errors
+
+### 2. The sorry-driven workflow
+
+1. **Start with sorry:** Write the theorem statement with `sorry` as the proof body
+2. **Use `lean_goal`** on the sorry line to see what needs to be proved
+3. **Use `lean_multi_attempt`** to try several tactics at once
+4. **Replace sorry** with the successful tactic (via `edit` tool)
+5. **Add sorry below** the tactic to pause and inspect the new goal
+6. **Repeat:** `lean_goal` -> `lean_multi_attempt` -> `edit` -> `lean_goal`
+7. **Remove the final sorry** when the proof is complete
+
+### 3. Check proof state — use lean_goal liberally
+
+`lean_goal` is your most important tool. Call it:
+- On sorry lines to see what needs to be proved
+- On tactic lines to see the state before/after the tactic
+- After every edit to verify the tactic did what you expected
+
+**Omit `column`** to see both `goals_before` (line start) and `goals_after` (line end)
+— this shows how the tactic transforms the proof state. "no goals" means the proof
+is complete at that point.
+
+### 4. Try multiple tactics before committing
+
+Use `lean_multi_attempt` to test tactics without modifying the file:
+
+```
+lean_multi_attempt(
+  file_path="MyProject/Properties/Foo.lean",
+  line=42,
+  snippets=["agrind", "scalar_tac", "grind", "bv_tac 16", "simp [*]; agrind"]
+)
+```
+
+This returns the resulting goal state for each tactic. Pick the one that works best,
+then apply it with `edit`.
+
+### 5. Verify a completed proof
+
+After finishing a proof:
+
+1. **`lean_diagnostic_messages`** with `severity="error"` — must return empty
+2. **`lean_verify`** with the theorem name — checks axiom usage, flags suspicious
+   patterns (sorry, native_decide in non-test code, etc.)
+3. **`lean_build`** — one final build to confirm everything compiles cleanly
+
+## Diagnosing Slow Incremental Replay — KEEPING LEAN REACTIVE IS CRITICAL
+
+> **Terminology:** "Interactivity" and "incrementality" mean the same thing in this
+> context — the ability to edit one tactic and get near-instant feedback because Lean
+> only re-elaborates the changed part. We use both terms interchangeably.
+
+Keeping Lean reactive during interactive proof development is **the single most important
+factor for productivity**. Fast feedback (< 0.5s per tactic) enables rapid iteration —
+try a tactic, see the result, adjust, repeat. Slow feedback destroys this loop.
+
+**Target: < 0.5s response when appending a tactic at the end of the proof.** When you
+add a new tactic line at the bottom of a proof, Lean should react almost immediately
+(under half a second) because only the new tactic needs elaboration — everything above
+is already cached. If instead you see multi-second delays, big chunks of the proof are
+being re-elaborated. **Step back and restructure the proof** rather than tolerating the
+slowness — it compounds over many edit cycles.
+
+**Common causes:**
+
+1. **`by ...` blocks inside `apply`/`exact`/`refine` arguments.** For example:
+   ```lean
+   apply lemma arg1 (by scalar_tac) (by agrind) (by grind)
+   exact foo (by bv_tac 16) (by simp_all)
+   ```
+   The entire `apply`/`exact`/`refine` expression (including all `by` blocks) is
+   elaborated as a single unit. Editing *any* `by` block forces re-elaboration of
+   *all* of them. If those `by` blocks contain expensive tactics, every edit pays
+   the full cost.
+
+   **Fix:** Extract inline `by` blocks into `have` statements:
+   ```lean
+   -- SLOW: all by-blocks re-elaborate together
+   apply lemma arg1 (by scalar_tac) (by agrind) (by grind)
+
+   -- FAST: each have is independently checkpointed
+   have h1 : precond1 := by scalar_tac
+   have h2 : precond2 := by agrind
+   have h3 : precond3 := by grind
+   apply lemma arg1 h1 h2 h3
+   ```
+
+2. **Large proof blocks without `have` boundaries.** Each tactic step is an elaboration
+   checkpoint, but `have` is especially effective: it creates a self-contained sub-proof
+   whose result is cached. If the sub-proof's input hasn't changed, the elaborator can
+   skip it entirely during incremental replay. Without `have` boundaries, changes can
+   force re-elaboration of large contiguous sections.
+
+   **Fix:** Use `have` to break large proofs into independently checkpointed sections,
+   especially around expensive tactic calls.
+
+## The step*? Workflow for Complex Function Bodies
+
+When developing a proof for a function body with many monadic calls:
+
+1. Write `step*?` as the tactic (via `edit` tool on disk)
+2. Call `lean_code_actions` on that line — it returns the expanded proof script
+   as a "Try This" resolved edit
+3. Alternatively, call `lean_diagnostic_messages` on that line — the expansion
+   appears as an INFO diagnostic
+4. Copy the expanded script into your proof and work through it
+5. Once the full proof works, try collapsing back into a single `step*`
+6. If `step*` works, use it (shorter is better). If not, keep the expanded form.
+
+**How it works:** `step*?` generates a suggestion via `addTryThisTacticSeqSuggestion`.
+`lean_code_actions` retrieves it as a resolved edit with the full tactic sequence.
+
+## Key Tips
+
+1. **Use `lean_goal` after every edit** — it is the primary feedback mechanism
+2. **Use `lean_multi_attempt` to explore** — try 3-5 tactics at once without touching the file
+3. **Use `lean_local_search` before guessing** — verify lemma names exist before using them
+4. **Use `lean_hover_info` to check types** — essential when building complex proof terms
+5. **Use `lean_code_actions` for step*?** — retrieves the expanded proof script
+6. **Use `lean_diagnostic_messages` after edits** — check for errors (empty = tactic worked)
+7. **Use `lean_verify` on completed proofs** — confirms no `sorry`, checks axiom usage
+8. **Use `lean_state_search` when stuck** — finds lemmas that could close the current goal
+9. **Use `lean_hammer_premise` for automation hints** — suggests lemmas for `simp only [...]`
+10. **File edits are via the standard `edit`/`create` tools** — MCP tools are read-only
+    (except `lean_build`). Edit the file on disk, then use MCP tools to inspect the result.
+11. **`lean_multi_attempt` does not modify the file** — it only shows what *would* happen.
+    After choosing a tactic, you must apply it yourself with the `edit` tool.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/worktree-init.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project
+
+A project for **verifying WebAssembly code using Lean 4**. The vehicle is a built-in Wasm interpreter written in Lean: the same definitions that _execute_ a program are the ones you _reason about_, so there is no separate "spec" interpreter to keep in sync with the runner.
+
+The interpreter is deliberately optimized for **simplicity of reasoning, not execution speed**. When making changes, prefer the formulation that is easiest to unfold and `simp` through in proofs over the one that runs faster — performance work belongs behind a separate, proven-equivalent implementation, not in the reference interpreter.
+
+Lean toolchain is pinned in `lean-toolchain`.
+
+## Repository layout
+
+Three Lake packages in a monorepo, forming a strict dependency chain:
+
+```
+interpreter/   ← Wasm AST, semantics, WP tactic layer  (Lake package: Interpreter)
+codelib/       ← lifting lemmas and reasoning helpers   (Lake package: CodeLib)
+programs/      ← concrete Rust-to-Wasm verification     (Lake package: Programs)
+```
+
+`programs/rust/` holds the Rust source crates; `programs/Programs/` holds the
+generated `Program.lean` files and hand-written `Spec.lean` / `Proofs.lean`.
+
+Dependency direction: `interpreter` → `codelib` → `programs`. Downstream code
+imports `CodeLib`, never the interpreter directly.
+
+## Build / run / verify
+
+```bash
+just lake-shared        # once: populate repo-root .lake/packages (Mathlib owner: interpreter/)
+# then, for each package:
+cd <package> && lake build
+```
+
+Third-party Lake dependencies (Mathlib and its transitive packages) live in **one** tree at the repo root: `.lake/packages`. Every `lakefile.toml` sets `packagesDir` to that path; per-package `.lake/` holds only `build/` and `config/`.
+
+There is no separate test runner. Example correctness is encoded as Lean theorems and `native_decide` checks inside the examples; a successful `lake build` means every proof and decidable example check passed. To check a single source file in isolation: `lake env lean <path>`.
+
+## Architecture
+
+Three layers, kept deliberately small:
+
+- **Syntax (AST).** Instructions, functions, and modules. Keep the surface area minimal — only add constructs once they are needed by a concrete proof, and prefer the formulation that matches the Wasm spec's terminology so semantics and reasoning lemmas stay legible. Read the current state of `interpreter/Interpreter/Wasm/Syntax.lean` before assuming what is or isn't supported.
+- **Semantics (interpreter).** A fuel-bounded big-step interpreter. Traps (insufficient operands, out-of-bounds access, division by zero, etc.) are observable as a `none` result from `run`. When changing the semantics, the structure of the state and the shape of `step`/`run` are load-bearing for every existing proof — extend in place rather than rewriting, and keep new cases consistent with the existing ones. Read the file before editing.
+- **Reasoning (examples and lemmas).** The standard proof style: unfold the interpreter and `simp` to reduce both sides to the same concrete computation; use `native_decide` for concrete-input sanity checks; compose previously proven theorems as black boxes rather than re-unfolding the interpreter for larger results. New examples should follow this pattern.
+
+## Public spec API: don't expose fuel
+
+`run` takes an explicit `fuel : Nat` so that it terminates syntactically, but fuel is a proof obligation, not part of what a wasm function "does". User-facing specs should never mention fuel — no `∃ fuel, run … fuel = some rs` and no fixed numeric fuel in the statement. Use the fuel-free predicates from `Interpreter/Wasm/Spec/Termination.lean` instead:
+
+- `Wasm.TerminatesWith m entry args P` — total correctness (some fuel succeeds, result satisfies `P`). Discharge via `TerminatesWith.of_run` / `of_run_eq` by exhibiting a concrete fuel internally.
+- `Wasm.PartiallyMeets m entry args P` — partial correctness (every terminating fuel-bounded run satisfies `P`).
+
+When writing or updating a `@[wasm_spec]` theorem, reach for these — the fuel value belongs inside the proof, not the statement.
+
+## Examples
+
+Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built Wasm module and proves theorems about it using the WP tactic layer. The standard pattern: state the property, apply `wp_run` to reduce to a concrete computation, then close with `simp` / `omega` / domain lemmas. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 Cajal Technologies
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+GNU Affero General Public License v3.0 — see [LICENSE](LICENSE).

--- a/verifier/report/package-lock.json
+++ b/verifier/report/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "talos-report",
       "version": "0.2.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "astro": "^4.16.0",
         "katex": "^0.16.11",

--- a/verifier/report/package.json
+++ b/verifier/report/package.json
@@ -2,6 +2,7 @@
   "name": "talos-report",
   "version": "0.2.0",
   "private": true,
+  "license": "AGPL-3.0-only",
   "type": "module",
   "description": "Static-site generator (Astro) that turns `verifier extract` JSON artifacts into a browsable progress report.",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add repository-level `AGENTS.md` instructions for Codex agents working in this Lean/Wasm verification project.
- Add a `lean-lsp-mcp` Codex skill with Lean proof workflow guidance and MCP tool usage notes.
- Add a Codex session-start hook configuration for worktree initialization.
- Set the project license to GNU Affero General Public License v3.0 and align report package metadata with `AGPL-3.0-only`.

## Validation

- Parsed `.codex/hooks.json`, `verifier/report/package.json`, and `verifier/report/package-lock.json` with `python3 -m json.tool`.
- Ran `git diff --cached --check` before each commit.
