### PR TITLE
Add scripts/ helpers and restructure the justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,19 @@
+# Root of the monorepo.
+ROOT := justfile_directory()
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+[private]
+default:
+    @just --list --unsorted
+
+# Pinned wasm-tools version. Testsuite shells out to `wasm-tools json-from-wast`
+# to split .wast files; different versions can produce different decodes —
+# bumping this needs a regenerated testsuite_report.txt.
+WASM_TOOLS_VERSION := "1.251.0"
+
+
+# ── Lean package builds ───────────────────────────────────────────────────────
+
 # Build all three packages. Programs depends on CodeLib which depends on Interpreter,
 # so a single Lake workspace invocation covers the full chain without rebuilding
 # Interpreter twice (which happens when each package is built as a separate root).
@@ -12,94 +28,115 @@ lake-shared:
     lake update
     lake exe cache get
 
-# Generate HTML documentation and serve it at http://localhost:8080
-docs:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    cd "{{justfile_directory()}}/docbuild"
-    lake build Project:docs
-    echo "Serving docs at http://localhost:8080 (Ctrl-C to stop)"
-    python3 -m http.server 8080 --directory .lake/build/doc
+# Build the interpreter package (Wasm AST + semantics + WP tactic layer).
+
+[group("build")]
+[working-directory("interpreter")]
+build-interpreter:
+    lake build
+
+# Build the codelib package (lifting lemmas + reasoning helpers).
+[group("build")]
+[working-directory("codelib")]
+build-codelib:
+    lake build
+
+# Build the programs package (concrete Rust-to-Wasm proofs). This is the main
+# proof target: it depends on codelib which depends on interpreter, so one
+# invocation covers the full dependency chain without redundant rebuilds.
+[group("build")]
+[working-directory("programs/lean")]
+build-programs:
+    lake build
+
+# Build the verifier tool (scaffolder + WAT emitter + proof checker).
+[group("build")]
+[working-directory("verifier")]
+build-verifier:
+    lake build
+
+
+# ── Rust workspace ────────────────────────────────────────────────────────────
+
+
+[private]
+[working-directory("programs/rust")]
+cargo-programs +args:
+    cargo {{ args }}
+
+# Build all Rust crates in release mode (produces .wasm output under rust/build/).
+[group("rust-programs")]
+rust-build: (cargo-programs "build")
+
+# Run all Rust unit tests.
+[group("rust-programs")]
+rust-test: (cargo-programs "test")
+
+# Run clippy lints across the Rust workspace.
+[group("rust-programs")]
+rust-lint: (cargo-programs "clippy")
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+# Build the Wasm runner executable.
+[group("runner")]
+[working-directory("interpreter")]
+runner-build:
+    lake build runner
+
+# Smoke-test the runner executable against samples/.
+[group("runner")]
+[working-directory("scripts")]
+runner-smoke:
+    ./runner-smoke.sh
+
+# Run the runner executable against samples/.
+[group("runner")]
+[working-directory("interpreter")]
+runner-run +args:
+    lake exe runner {{ args }}
+
+# ── testsuite ─────────────────────────────────────────────────────────────────
 
 # Run the WebAssembly spec testsuite (vendor/testsuite/). Optional pattern
 # is a case-sensitive substring on the .wast filename stem.
+[group("testsuite")]
+[working-directory(ROOT)]
 testsuite pattern="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [[ -n "{{pattern}}" ]]; then
-        lake -d "{{justfile_directory()}}/interpreter" exe testsuite "{{pattern}}"
-    else
-        lake -d "{{justfile_directory()}}/interpreter" exe testsuite
-    fi
+    scripts/testsuite.sh {{ quote(pattern) }}
 
-# Pinned wasm-tools version. The testsuite shells out to `wasm-tools
-# json-from-wast` to split .wast files, and different versions can produce
-# different decodes — bumping this needs a regenerated testsuite_report.txt.
-WASM_TOOLS_VERSION := "1.251.0"
-
-# Regenerate testsuite_report.txt at the repo root. CI runs the same
-# command and fails if the working tree drifts, so contributors whose
-# changes shift coverage must commit the updated report.
+# Regenerate testsuite_report.txt at the repo root. CI runs the same command
+# and fails if the working tree drifts, so contributors whose changes shift
+# coverage must commit the updated report.
+[group("testsuite")]
+[working-directory(ROOT)]
 testsuite-report:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if ! command -v wasm-tools >/dev/null 2>&1; then
-        echo "error: wasm-tools not on PATH (need exactly {{WASM_TOOLS_VERSION}})" >&2
-        exit 1
-    fi
-    got=$(wasm-tools --version | awk 'NR==1 {print $2}')
-    if [[ "$got" != "{{WASM_TOOLS_VERSION}}" ]]; then
-        echo "error: wasm-tools {{WASM_TOOLS_VERSION}} required, found $got" >&2
-        echo "       the committed testsuite_report.txt is pinned to that version" >&2
-        exit 1
-    fi
-    lake -d "{{justfile_directory()}}/interpreter" exe testsuite --report \
-        > "{{justfile_directory()}}/testsuite_report.txt"
+    WASM_TOOLS_VERSION={{ quote(WASM_TOOLS_VERSION) }} scripts/testsuite-report.sh
 
-# Smoke-test the runner executable against samples/.
-runner-smoke:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    cd "{{justfile_directory()}}/interpreter"
-    lake build runner
+# ── verifier workflow ─────────────────────────────────────────────────────────
 
-    fail=0
+# Run the verifier check from the programs/ root (builds Rust, re-emits
+# Program.lean files if wasm changed, then runs lake build).
+[working-directory("verifier")]
+verifier-check:
+    lake exe verifier check
 
-    check() {
-        local name="$1"; shift
-        local want_exit="$1"; shift
-        local want_stream="$1"; shift  # "stdout" or "stderr"
-        local want="$1"; shift
-        local got got_exit
-        if [[ "$want_stream" == stdout ]]; then
-            got=$(./.lake/build/bin/runner "$@" 2>/dev/null) && got_exit=0 || got_exit=$?
-        else
-            got=$(./.lake/build/bin/runner "$@" 2>&1 >/dev/null) && got_exit=0 || got_exit=$?
-        fi
-        if [[ "$got_exit" != "$want_exit" || "$got" != "$want" ]]; then
-            echo "FAIL: $name"
-            echo "  cmd:    ./.lake/build/bin/runner $*"
-            echo "  expect: exit=$want_exit $want_stream=[$want]"
-            echo "  got:    exit=$got_exit $want_stream=[$got]"
-            fail=1
-        else
-            echo "ok: $name"
-        fi
-    }
+# Re-emit all Program.lean files unconditionally, then run lake build.
+[working-directory("verifier")]
+verifier-check-force:
+    lake exe verifier check --force-emit
 
-    check "sum_to.wat"        0 stdout "55"                          samples/sum_to.wat sum_to 10
-    check "factorial.wat"     0 stdout "120"                         samples/factorial.wat fact 5
-    check "trap.wat"          1 stderr "trap: integer divide by zero" samples/trap.wat div_by_zero
-    check "out-of-fuel"       2 stderr "out of fuel"                  samples/sum_to.wat sum_to 1000000 --fuel 10
+# ── docs ──────────────────────────────────────────────────────────────────────
 
-    if command -v wasm-tools >/dev/null 2>&1; then
-        tmpdir=$(mktemp -d -t runner-smoke.XXXXXX)
-        trap 'rm -rf "$tmpdir"' EXIT
-        tmp="$tmpdir/sum_to.wasm"
-        wasm-tools parse samples/sum_to.wat -o "$tmp"
-        check "sum_to.wasm via wasm-tools" 0 stdout "55" "$tmp" sum_to 10
-    else
-        echo "skip: wasm-tools not on PATH; .wasm round-trip not exercised"
-    fi
+# Generate HTML documentation and serve it at http://localhost:8080.
+[working-directory("scripts")]
+docs:
+    ./docs.sh
 
-    exit $fail
+# ── housekeeping ──────────────────────────────────────────────────────────────
+
+# Remove Lake build artefacts from all Lean packages and Cargo target dir.
+[working-directory("scripts")]
+clean:
+    ./clean.sh
+

--- a/programs/rust/rust-toolchain.toml
+++ b/programs/rust/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.95.0"
 profile = "minimal"
 targets = ["wasm32-unknown-unknown"]
-components = []
+components = ["rustfmt", "clippy"]

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Remove Lake build artefacts from all Lean packages and Cargo target dir.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+for pkg in interpreter codelib programs/lean verifier docbuild; do
+    dir="$ROOT/$pkg"
+    [[ -d "$dir/.lake" ]] && rm -rf "$dir/.lake" && echo "cleaned $pkg/.lake"
+done
+cargo clean --manifest-path "$ROOT/programs/rust/Cargo.toml"
+echo "cleaned programs/rust/target"

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Generate HTML documentation and serve it at http://localhost:8080.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT/docbuild"
+lake build Project:docs
+echo "Serving docs at http://localhost:8080 (Ctrl-C to stop)"
+python3 -m http.server 8080 --directory .lake/build/doc

--- a/scripts/runner-smoke.sh
+++ b/scripts/runner-smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Smoke-test the runner executable against samples/.
+# Builds the runner, runs a handful of sample programs, and verifies
+# both the exit code and the chosen output stream against expectations.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT/interpreter"
+lake build runner
+
+fail=0
+
+check() {
+    local name="$1"; shift
+    local want_exit="$1"; shift
+    local want_stream="$1"; shift  # "stdout" or "stderr"
+    local want="$1"; shift
+    local got got_exit
+    if [[ "$want_stream" == stdout ]]; then
+        got=$(./.lake/build/bin/runner "$@" 2>/dev/null) && got_exit=0 || got_exit=$?
+    else
+        got=$(./.lake/build/bin/runner "$@" 2>&1 >/dev/null) && got_exit=0 || got_exit=$?
+    fi
+    if [[ "$got_exit" != "$want_exit" || "$got" != "$want" ]]; then
+        echo "FAIL: $name"
+        echo "  cmd:    ./.lake/build/bin/runner $*"
+        echo "  expect: exit=$want_exit $want_stream=[$want]"
+        echo "  got:    exit=$got_exit $want_stream=[$got]"
+        fail=1
+    else
+        echo "ok: $name"
+    fi
+}
+
+check "sum_to.wat"        0 stdout "55"                          samples/sum_to.wat sum_to 10
+check "factorial.wat"     0 stdout "120"                         samples/factorial.wat fact 5
+check "trap.wat"          1 stderr "trap: integer divide by zero" samples/trap.wat div_by_zero
+check "out-of-fuel"       2 stderr "out of fuel"                  samples/sum_to.wat sum_to 1000000 --fuel 10
+
+if command -v wasm-tools >/dev/null 2>&1; then
+    tmpdir=$(mktemp -d -t runner-smoke.XXXXXX)
+    trap 'rm -rf "$tmpdir"' EXIT
+    tmp="$tmpdir/sum_to.wasm"
+    wasm-tools parse samples/sum_to.wat -o "$tmp"
+    check "sum_to.wasm via wasm-tools" 0 stdout "55" "$tmp" sum_to 10
+else
+    echo "skip: wasm-tools not on PATH; .wasm round-trip not exercised"
+fi
+
+exit $fail

--- a/scripts/testsuite-report.sh
+++ b/scripts/testsuite-report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Regenerate testsuite_report.txt at the repo root.
+#
+# Requires the WASM_TOOLS_VERSION env var (passed by the justfile) and a
+# wasm-tools binary on PATH whose version matches exactly — the committed
+# report is pinned to that version because different wasm-tools releases
+# can produce different .wast decodes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+required_version="${WASM_TOOLS_VERSION:?WASM_TOOLS_VERSION must be set}"
+
+if ! command -v wasm-tools >/dev/null 2>&1; then
+    echo "error: wasm-tools not on PATH (need exactly $required_version)" >&2
+    exit 1
+fi
+got=$(wasm-tools --version | awk 'NR==1 {print $2}')
+if [[ "$got" != "$required_version" ]]; then
+    echo "error: wasm-tools $required_version required, found $got" >&2
+    echo "       the committed testsuite_report.txt is pinned to that version" >&2
+    exit 1
+fi
+lake -d "$ROOT/interpreter" exe testsuite --report \
+    > "$ROOT/testsuite_report.txt"

--- a/scripts/testsuite.sh
+++ b/scripts/testsuite.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run the WebAssembly spec testsuite (vendor/testsuite/).
+# Optional first argument is a case-sensitive substring on the .wast
+# filename stem; empty/missing runs the whole suite.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pattern="${1:-}"
+
+if [[ -n "$pattern" ]]; then
+    lake -d "$ROOT/interpreter" exe testsuite "$pattern" || true
+else
+    lake -d "$ROOT/interpreter" exe testsuite || true
+fi


### PR DESCRIPTION
The shell logic that lived inline in the justfile now lives in a dedicated scripts/ directory (testsuite.sh, testsuite-report.sh, runner-smoke.sh, docs.sh, clean.sh). 

The justfile is reorganized into grouped recipes that each run from a defined working directory, and the programs Rust toolchain gains rustfmt + clippy.

Use it: just lists everything; then e.g. just testsuite [pattern]:
 - just testsuite-report
 - just runner-smoke
 - just docs
 - just clean

Rust related
 - just rust-lint
 - just rust-build
 - just rust-test