### PR TITLE
Refactor verifier commands and add Rust crate scaffolding

### DIFF
--- a/justfile
+++ b/justfile
@@ -119,6 +119,7 @@ testsuite-report:
 #
 # Step-by-step development cycle:
 #   just verifier-init <path>   — scaffold a new project
+#   just verifier-add <crate>   — copy the rust crate template into rust/
 #   just verifier-build         — compile Rust → wasm/wat
 #   just verifier-emit          — transpile wat → Program.lean + scaffold Spec.lean
 #   [edit Spec.lean by hand]
@@ -135,6 +136,11 @@ _verifier +args:
 [group("verifier")]
 verifier-init path:
     just _verifier init {{ path }}
+
+# Add a crate to the current project (snake_case name, e.g. my_crate).
+[group("verifier")]
+verifier-add crate:
+    just _verifier add {{ crate }}
 
 # Remove a crate from the current project (source, lean module, build artefacts, config references).
 [group("verifier")]

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -156,10 +156,10 @@ Pipeline:
 
 ### 3. Adding a crate
 
-1. Create `rust/foo_bar/` by hand — copying the bundled `is_even` crate
-   is the easiest start — and add `"foo_bar"` to the `members` list of
-   `rust/Cargo.toml`, following the conventions in "Setting up a Rust
-   crate for wasm" above. No Lean files are needed yet.
+1. `verifier add foo_bar` — copies the bundled crate template
+   (`Cargo.toml`, `src/lib.rs`, `src/exports.rs`) into `rust/foo_bar/`
+   with the name placeholder filled in, and registers `"foo_bar"` in the
+   `members` list of `rust/Cargo.toml`. No Lean files are created yet.
 2. Edit `rust/foo_bar/src/lib.rs` and `src/exports.rs` to implement and
    export your function, following the conventions above.
 3. `verifier emit foo_bar` — builds the wasm (if needed), generates
@@ -226,6 +226,7 @@ is recommended for organization but not required by those tools — see
 
 ```
 verifier init <path>              # alias: new
+verifier add <crate>
 verifier del <crate>
 verifier build [crate…]
 verifier emit [crate…] [--force-emit]
@@ -239,6 +240,10 @@ Run from the project root. Omit crate names to process all crates.
 In the Talos monorepo: `cd programs && lake -d ../verifier exe verifier …`
 
 - `init` / `new` requires a non-existent or empty target directory.
+- `add` copies the bundled crate template into `rust/<crate>/`
+  (`Cargo.toml`, `src/lib.rs`, `src/exports.rs`, with the name
+  placeholder filled in) and registers the crate in `rust/Cargo.toml`.
+  It creates no Lean files — those come from `emit`.
 - `del` removes a crate: deletes `rust/<crate>/`, `lean/Project/<Crate>/`, `rust/build/<crate>/`, and cleans the workspace member from `rust/Cargo.toml` and the import from `lean/Project.lean`.
 - `build` writes `rust/build/<crate>/program.{wasm,wat}` via cargo + wasm-tools.
 - `emit` decodes `program.wat` into `Program.lean`, and scaffolds the

--- a/verifier/Verifier/Main.lean
+++ b/verifier/Verifier/Main.lean
@@ -9,14 +9,16 @@ import Cli
 
 Run from the project root (directory with `rust/` and `lean/`).
 
-Subcommands: init, del, build, emit, prove, check, extract, report.
+Subcommands: init, add, del, build, emit, prove, check, extract, report.
 Omit crate names for all workspace crates. `foo_bar` maps to `Project.FooBar`.
 
 ## Template layout
 
 The scaffolding lives entirely under `verifier/template/`, decoupled from this
-code — editing it never requires touching Lean. Two independent trees:
+code — editing it never requires touching Lean. Three independent trees:
 
+* `template/crate/`   — a single rust crate (no Lean). Copied by `add`, with the
+                        literal `CRATE_NAME` replaced by the new crate's name.
 * `template/project/` — a whole project (`rust/` + `lean/`) with a worked
                         `is_even`/`IsEven` example. Copied verbatim by `init`.
 * `template/module/`  — the hand-written Lean files that accompany the
@@ -146,15 +148,23 @@ private partial def copyTreeNoClobber (src dst : FilePath) (subst : String → S
 -- Workspace / import bookkeeping
 -- ----------------------------------------------------------------------------
 
+private def addWorkspaceMember (cargoToml : FilePath) (crate : String) : IO Unit := do
+  let txt ← IO.FS.readFile cargoToml
+  if fileContains txt crate then return
+  let needle := "members = ["
+  unless fileContains txt needle do
+    die s!"{cargoToml}: could not find `[workspace] members = [`"
+  IO.FS.writeFile cargoToml (txt.replace needle (needle ++ "\n  \"" ++ crate ++ "\","))
+
 private def removeWorkspaceMember (cargoToml : FilePath) (crate : String) : IO Unit := do
   unless ← System.FilePath.pathExists cargoToml do return
   let txt ← IO.FS.readFile cargoToml
   let entry := s!"\"{crate}\""
   unless fileContains txt entry do return
-  -- Handle every format a `members = [...]` entry can take (manual edits, tooling).
+  -- Handle every format our addWorkspaceMember (or manual edits) can produce.
   let cleaned :=
     txt
-    |>.replace (s!"\n  {entry},") ""   -- entry written on its own line
+    |>.replace (s!"\n  {entry},") ""   -- form written by addWorkspaceMember
     |>.replace (s!",{entry}")     ""   -- inline trailing, no space
     |>.replace (s!", {entry}")    ""   -- inline trailing, with space
     |>.replace (s!"{entry},")     ""   -- inline leading, no space after
@@ -172,8 +182,24 @@ private def removeProjectImport (projectLean : FilePath) (pascal : String) : IO 
   IO.println s!"    removed `{importLine}` from {projectLean}"
 
 -- ----------------------------------------------------------------------------
--- `del`
+-- `add` / `del`
 -- ----------------------------------------------------------------------------
+
+private def cmdAdd (crate : String) : IO Unit := do
+  unless isValidCrateName crate do
+    die s!"invalid crate name `{crate}` (use snake_case: letters, digits, underscores)"
+  let projectDir ← projectDirFromCwd
+  let pascal := snakeToPascal crate
+  let rustCrate := projectDir / "rust" / crate
+  if ← System.FilePath.pathExists rustCrate then die s!"{rustCrate} already exists"
+  IO.println s!"==> adding crate `{crate}` → Project.{pascal}"
+  let crateTemplate := (← locateTemplateRoot) / "crate"
+  copyTree crateTemplate rustCrate (·.replace "CRATE_NAME" crate)
+  addWorkspaceMember (projectDir / "rust" / "Cargo.toml") crate
+  IO.println s!"    wrote {rustCrate}"
+  IO.println s!"==> done. Next: verifier build {crate} && verifier emit {crate}"
+  IO.println s!"==>   the Lean module (Program.lean + Spec.lean) is created by `verifier emit`;"
+  IO.println s!"==>   add `import Project.{pascal}.Spec` to lean/Project.lean to include it in the default build."
 
 private def cmdDel (crate : String) : IO Unit := do
   unless isValidCrateName crate do
@@ -479,6 +505,10 @@ def runInit (p : Parsed) : IO UInt32 := do
 
 def runNew (p : Parsed) : IO UInt32 := runInit p
 
+def runAdd (p : Parsed) : IO UInt32 := do
+  cmdAdd (p.positionalArg! "crate" |>.as! String)
+  pure 0
+
 def runDel (p : Parsed) : IO UInt32 := do
   cmdDel (p.positionalArg! "crate" |>.as! String)
   pure 0
@@ -561,6 +591,14 @@ def newCmd : Cmd := `[Cli|
     projectPath : String; "Directory to create (must not already exist or be empty)."
 ]
 
+def addCmd : Cmd := `[Cli|
+  add VIA runAdd;
+  "Add one crate to the current project (run from project root)."
+
+  ARGS:
+    crate : String; "Crate name in snake_case (e.g. my_crate)."
+]
+
 def delCmd : Cmd := `[Cli|
   del VIA runDel;
   "Remove a crate from the current project (source, lean module, build artefacts, Cargo.toml, Project.lean)."
@@ -638,6 +676,7 @@ def mainCmd : Cmd := `[Cli|
   SUBCOMMANDS:
     initCmd;
     newCmd;
+    addCmd;
     delCmd;
     buildCmd;
     emitCmd;

--- a/verifier/Verifier/Main.lean
+++ b/verifier/Verifier/Main.lean
@@ -150,11 +150,12 @@ private partial def copyTreeNoClobber (src dst : FilePath) (subst : String → S
 
 private def addWorkspaceMember (cargoToml : FilePath) (crate : String) : IO Unit := do
   let txt ← IO.FS.readFile cargoToml
-  if fileContains txt crate then return
+  let entry := s!"\"{crate}\""
+  if fileContains txt entry then return
   let needle := "members = ["
   unless fileContains txt needle do
     die s!"{cargoToml}: could not find `[workspace] members = [`"
-  IO.FS.writeFile cargoToml (txt.replace needle (needle ++ "\n  \"" ++ crate ++ "\","))
+  IO.FS.writeFile cargoToml (txt.replace needle (needle ++ "\n  " ++ entry ++ ","))
 
 private def removeWorkspaceMember (cargoToml : FilePath) (crate : String) : IO Unit := do
   unless ← System.FilePath.pathExists cargoToml do return

--- a/verifier/template/crate/Cargo.toml
+++ b/verifier/template/crate/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "CRATE_NAME"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]

--- a/verifier/template/crate/src/exports.rs
+++ b/verifier/template/crate/src/exports.rs
@@ -1,0 +1,9 @@
+/// Wasm-exported entry point for `CRATE_NAME`.
+///
+/// Thin `extern "C"` wrapper around the pure [`crate::CRATE_NAME`]. The
+/// project convention reserves this file for the wasm ABI surface, so the
+/// export table matches exactly what the verifier reasons about.
+#[unsafe(no_mangle)]
+pub extern "C" fn CRATE_NAME(n: i32) -> bool {
+    crate::CRATE_NAME(n)
+}

--- a/verifier/template/crate/src/lib.rs
+++ b/verifier/template/crate/src/lib.rs
@@ -1,0 +1,8 @@
+mod exports;
+
+/// Starting-point implementation for `CRATE_NAME`. Replace the body with the
+/// real logic you want to verify; keep the pure function here and expose it
+/// across the wasm ABI in `exports.rs`.
+pub fn CRATE_NAME(n: i32) -> bool {
+    n % 2 == 0
+}


### PR DESCRIPTION

Adds verifier add , which scaffolds a new Rust crate from verifier/template/crate/ (fills in the name, registers it in the workspace members). Adds the verifier-add justfile recipe.

Usage:

- `just verifier-add my_crate`

Then implement in rust/my_crate/, and `just verifier-emit my_crate`