### PR TITLE
add table write instructions (table.set/grow/fill/copy/init, elem.drop)

### DIFF
--- a/.github/workflows/testsuite-report.yml
+++ b/.github/workflows/testsuite-report.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     name: Check testsuite_report.txt is up to date
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/testsuite-report.yml
+++ b/.github/workflows/testsuite-report.yml
@@ -12,6 +12,7 @@ jobs:
   check:
     name: Check testsuite_report.txt is up to date
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -702,11 +702,8 @@ private def stubImmediateCount (op : String) : Option Nat :=
 if op == "ref.test" || op == "ref.cast"
      || op == "br_on_null" || op == "br_on_non_null"
      || op == "return_call" || op == "return_call_ref" || op == "call_ref"
-     || op == "elem.drop" || op == "throw" || op == "tag"
-     -- `table.get`/`table.size` are modelled (see `parseInstr`/`parseFolded`);
-     -- the rest of the table ops are still stubbed.
-     || op == "table.set"
-     || op == "table.grow" || op == "table.fill"
+     || op == "throw" || op == "tag"
+     -- all table ops are now modelled; see `parseInstr`/`parseFolded`.
      || op == "struct.new" || op == "struct.new_default"
      || op == "array.new" || op == "array.new_default" || op == "array.new_fixed"
      -- array element accessors take 1 atom (the array type ref) only;
@@ -730,10 +727,8 @@ if op == "ref.test" || op == "ref.cast"
      || op == "array.copy"
      || op == "array.init_data" || op == "array.init_elem"
   then some 2
-  -- `table.init` and `table.copy` are handled separately by
-  -- `consumeTableBulkAtoms` (0..2 label-looking atoms — wasm-tools'
-  -- canonical print emits 0/1 when default tables are used and 2
-  -- when both tables are named).
+  -- `table.init` and `elem.drop` are now modelled instructions;
+  -- `table.copy` likewise. All have explicit cases in `parseInstr`/`parseFolded`.
   else none
 
 /-- Drop the first `n` atom tokens from `toks`. Errors if a non-atom is
@@ -832,6 +827,17 @@ private def parseOptTableIdx (ctx : Ctx) (mk : Nat → Wasm.Instruction)
     else .ok ([mk 0], .atom a :: rest')
   | rest' => .ok ([mk 0], rest')
 
+/-- Consume one optional table-index atom, returning the resolved index and
+the remaining token stream.  Used by `table.copy` which takes two such
+indices (dst then src), each optional and defaulting to 0. -/
+private def parseOneOptTableIdx (ctx : Ctx)
+    : List Sexpr → Except Err (Nat × List Sexpr)
+  | .atom a :: rest =>
+    if looksLikeLabel a then do
+      .ok ((← resolveNamed ctx.tableNames "table" a), rest)
+    else .ok (0, .atom a :: rest)
+  | rest => .ok (0, rest)
+
 mutual
 
 private partial def parseInstr (ctx : Ctx) (toks : List Sexpr)
@@ -866,10 +872,25 @@ private partial def parseInstr (ctx : Ctx) (toks : List Sexpr)
     | "ref.null"    => match rest with
       | .atom ht :: rest' => .ok ([if isNullFuncrefHeapType ht then .refNull else .unreachable], rest')
       | _ => .error "ref.null expects a heap-type immediate"
-    -- `table.get`/`table.size` carry an *optional* table-index immediate
-    -- (default 0); see `parseOptTableIdx`.
+    -- `table.get`/`table.size`/`table.set` carry an *optional* table-index
+    -- immediate (default 0); see `parseOptTableIdx`.
     | "table.get"   => parseOptTableIdx ctx .tableGet rest
     | "table.size"  => parseOptTableIdx ctx .tableSize rest
+    | "table.set"   => parseOptTableIdx ctx .tableSet rest
+    | "table.grow"  => parseOptTableIdx ctx .tableGrow rest
+    | "table.fill"  => parseOptTableIdx ctx .tableFill rest
+    | "table.copy"  => do
+      let (dst, r1) ← parseOneOptTableIdx ctx rest
+      let (src, r2) ← parseOneOptTableIdx ctx r1
+      .ok ([.tableCopy dst src], r2)
+    | "table.init" => do
+      match rest with
+      | .atom seg :: r1 =>
+        let segIdx ← parseNat seg
+        let (tableIdx, r2) ← parseOneOptTableIdx ctx r1
+        .ok ([.tableInit tableIdx segIdx], r2)
+      | _ => .error "table.init: expected segment index immediate"
+    | "elem.drop"  => parseImmediateNat parseNat .elemDrop op rest
     | "select"    =>
       let rec dropResults : List Sexpr → List Sexpr
         | .list (.atom "result" :: _) :: r => dropResults r
@@ -899,8 +920,6 @@ private partial def parseInstr (ctx : Ctx) (toks : List Sexpr)
           -- immediates so the token stream stays aligned.
           let rest' ← if op == "v128.const" then
             consumeV128ConstImmediates rest
-          else if op == "table.copy" || op == "table.init" then
-            .ok (consumeTableBulkAtoms 2 rest)
           else if op == "br_on_cast" || op == "br_on_cast_fail" then
             consumeBrOnCastImmediates op rest
           else match stubImmediateCount op with
@@ -961,6 +980,12 @@ private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
       | _ => .error "folded ref.null expects exactly one heap-type immediate"
     | "table.get"   => foldedOptTableIdx ctx .tableGet rest
     | "table.size"  => foldedOptTableIdx ctx .tableSize rest
+    | "table.set"   => foldedOptTableIdx ctx .tableSet rest
+    | "table.grow"  => foldedOptTableIdx ctx .tableGrow rest
+    | "table.fill"  => foldedOptTableIdx ctx .tableFill rest
+    | "table.copy"  => foldedTableCopy ctx rest
+    | "table.init"  => foldedTableInit ctx rest
+    | "elem.drop"   => foldedWithImmediate ctx parseNat (fun i => [.elemDrop i]) rest
     | "call_indirect" | "return_call_indirect" => do
       let (instr, leftover) ← parseCallIndirect ctx rest
       unless leftover.isEmpty do
@@ -1069,6 +1094,38 @@ private partial def foldedOptTableIdx (ctx : Ctx) (mk : Nat → Wasm.Instruction
         acc := acc ++ sub
       | .atom a => .error s!"folded table op: unexpected atom operand '{a}'"
     .ok (acc ++ [mk tableIdx])
+
+/-- Folded form of `table.copy`. Consumes two optional table-index atoms
+(dst then src, both defaulting to 0) then processes the three operand
+sub-expressions. -/
+private partial def foldedTableCopy (ctx : Ctx)
+    : List Sexpr → Except Err (List Wasm.Instruction) := fun xs => do
+  let (dst, r1) ← parseOneOptTableIdx ctx xs
+  let (src, r2) ← parseOneOptTableIdx ctx r1
+  let mut acc : List Wasm.Instruction := []
+  for s in r2 do
+    match s with
+    | .list ys =>
+      let sub ← parseFolded ctx ys
+      acc := acc ++ sub
+    | .atom a => .error s!"folded table.copy: unexpected atom operand '{a}'"
+  .ok (acc ++ [.tableCopy dst src])
+
+private partial def foldedTableInit (ctx : Ctx)
+    : List Sexpr → Except Err (List Wasm.Instruction) := fun xs => do
+  match xs with
+  | .atom seg :: rest =>
+    let segIdx ← parseNat seg
+    let (tableIdx, r2) ← parseOneOptTableIdx ctx rest
+    let mut acc : List Wasm.Instruction := []
+    for s in r2 do
+      match s with
+      | .list ys =>
+        let sub ← parseFolded ctx ys
+        acc := acc ++ sub
+      | .atom a => .error s!"folded table.init: unexpected atom operand '{a}'"
+    .ok (acc ++ [.tableInit tableIdx segIdx])
+  | _ => .error "folded table.init: expected segment index immediate"
 
 private partial def parseBrTable (ctx : Ctx) (toks : List Sexpr)
     : Except Err (List Wasm.Instruction × List Sexpr) := do

--- a/interpreter/Interpreter/Wasm/Examples/TableSet.lean
+++ b/interpreter/Interpreter/Wasm/Examples/TableSet.lean
@@ -1,0 +1,83 @@
+import Interpreter.Wasm.Decoder.Wat
+import Interpreter.Wasm.Wp.Tactic
+
+/-! ## Example: `table.set`
+
+    `table.set t` pops a `funcref` from the top of the stack and an i32 index
+    from just below it, then writes the funcref into `tables[t][i]`.  The i32
+    must be pushed *before* the funcref so that the funcref ends up on top.
+
+    Two halves:
+    * `tableSetRoundTripSpec` proves the AST program directly via `wp_run`:
+      write `funcref 0` into slot 1, then read it back with `table.get`.
+    * the `Decoded` section feeds `.wat` text through the decoder and checks
+      the write-then-read round-trip and the null-slot case (`native_decide`). -/
+
+namespace Wasm
+
+/-- `TableSetRoundTrip` writes `funcref 0` into slot 1 of table 0 and then
+reads it back.  The i32 index is pushed first so the funcref sits on top when
+`table.set` executes.  Against a starting table `[some 0, none]` the final
+stack holds `[.funcref (some 0)]` and table 0 is `[some 0, some 0]`. -/
+def TableSetRoundTrip : Program := [
+  .const 1,     -- push index 1 (i32; goes below on stack)
+  .refFunc 0,   -- push funcref 0 (lands on top)
+  .tableSet 0,  -- tables[0][1] := funcref 0
+  .const 1,     -- push index 1
+  .tableGet 0   -- push tables[0][1] = funcref (some 0)
+]
+
+theorem tableSetRoundTripSpec (m : Module) (st : Store Unit)
+    (htbl : st.tables = [[some 0, none]]) :
+    wp m TableSetRoundTrip
+        (fun c => c = .Fallthrough { st with tables := [[some 0, some 0]] }
+                    { params := [], locals := [], values := [.funcref (some 0)] })
+        st { params := [], locals := [], values := [] } := by
+  unfold TableSetRoundTrip
+  wp_run
+  simp [htbl]
+
+namespace Decoded
+
+/-- A `.wat` module with a 2-slot funcref table and two exported functions:
+`set_and_check` writes `funcref $f0` into the given slot then reads it back,
+returning 0 (not null); `check_null` reads a never-written slot, returning 1
+(null). -/
+def tableSetWat : String := "
+(module
+  (func $f0 (result i32) i32.const 7)
+  (table 2 funcref)
+  (func $set_and_check (export \"set_and_check\") (param i32) (result i32)
+    local.get 0
+    ref.func $f0
+    table.set
+    local.get 0
+    table.get
+    ref.is_null)
+  (func $check_null (export \"check_null\") (param i32) (result i32)
+    local.get 0
+    table.get
+    ref.is_null))
+"
+
+private def decoded : Wasm.Module :=
+  match Wasm.Decoder.Wat.decode tableSetWat with
+  | .ok m    => m
+  | .error _ => default
+
+theorem decodes_three_funcs : decoded.funcs.length = 3 := by native_decide
+
+private def runVals (idx : Nat) (args : List Value) : List Value :=
+  match run 20 decoded idx (decoded.initialStore (α := Unit)) args with
+  | .Success vs _ => vs
+  | _ => []
+
+/-- `set_and_check 1` writes funcref $f0 into slot 1, reads it back, and
+returns 0 (not null). -/
+theorem set_and_check_slot1 : runVals 1 [.i32 1] = [.i32 0] := by native_decide
+
+/-- Slot 0 is never written; `check_null 0` reads it and returns 1 (null). -/
+theorem check_null_slot0 : runVals 2 [.i32 0] = [.i32 1] := by native_decide
+
+end Decoded
+end Wasm

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -1009,10 +1009,9 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
         .Fallthrough st { s with values := .i32 (if r.isNone then 1 else 0) :: vs }
       | _ => .Invalid "refIsNull: ill-shaped operand stack"
 
-    -- Table read instructions. Both look the runtime table up on the
-    -- store; neither mutates it. An out-of-range *table* index is a
-    -- validation error (`.Invalid`); an out-of-bounds *element* index is a
-    -- genuine runtime trap, with the wasm spec's canonical wording so the
+    -- Table instructions. An out-of-range *table* index is a validation
+    -- error (`.Invalid`); an out-of-bounds *element* index is a genuine
+    -- runtime trap, with the wasm spec's canonical wording so the
     -- testsuite's `assert_trap` text matcher accepts it.
     | _, .tableGet tableIdx => match s.values with
       | .i32 i :: vs =>
@@ -1028,6 +1027,95 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
       | none     => .Invalid s!"tableSize: table index {tableIdx} out of range"
       | some tbl =>
         .Fallthrough st { s with values := .i32 (UInt32.ofNat tbl.length) :: s.values }
+    | _, .tableSet tableIdx => match s.values with
+      | .funcref r :: .i32 i :: vs =>
+        match st.tables[tableIdx]? with
+        | none     => .Invalid s!"tableSet: table index {tableIdx} out of range"
+        | some tbl =>
+          match tbl[i.toNat]? with
+          | none   => .Trap st "out of bounds table access"
+          | some _ =>
+            let tbl' := tbl.set i.toNat r
+            .Fallthrough { st with tables := st.tables.set tableIdx tbl' }
+                         { s with values := vs }
+      | _ => .Invalid "tableSet: ill-shaped operand stack"
+    | _, .tableGrow tableIdx => match s.values with
+      | .i32 delta :: .funcref r :: vs =>
+        match st.tables[tableIdx]? with
+        | none => .Invalid s!"tableGrow: table index {tableIdx} out of range"
+        | some tbl =>
+          match m.tables[tableIdx]? >>= (·.max) with
+          | none =>
+            .Fallthrough { st with tables := st.tables.set tableIdx (tbl ++ List.replicate delta.toNat r) }
+                         { s with values := .i32 (UInt32.ofNat tbl.length) :: vs }
+          | some n =>
+            if tbl.length + delta.toNat ≤ n then
+              .Fallthrough { st with tables := st.tables.set tableIdx (tbl ++ List.replicate delta.toNat r) }
+                           { s with values := .i32 (UInt32.ofNat tbl.length) :: vs }
+            else
+              .Fallthrough st { s with values := .i32 (0xFFFFFFFF : UInt32) :: vs }
+      | _ => .Invalid "tableGrow: ill-shaped operand stack"
+    | _, .tableFill tableIdx => match s.values with
+      | .i32 len :: .funcref val :: .i32 idx :: vs =>
+        match st.tables[tableIdx]? with
+        | none => .Invalid s!"tableFill: table index {tableIdx} out of range"
+        | some tbl =>
+          if idx.toNat + len.toNat > tbl.length then
+            .Trap st "out of bounds table access"
+          else
+            let tbl' := tbl.take idx.toNat ++ List.replicate len.toNat val ++ tbl.drop (idx.toNat + len.toNat)
+            .Fallthrough { st with tables := st.tables.set tableIdx tbl' }
+                         { s with values := vs }
+      | _ => .Invalid "tableFill: ill-shaped operand stack"
+    -- table.copy dst src: pops i32 len (top), i32 src_offset, i32 dst_offset.
+    -- Reads from srcTable[src..src+len) and writes to dstTable[dst..dst+len).
+    -- Trap is checked atomically before any write.  Same-table overlap is
+    -- handled correctly because srcSlice is extracted from the original table.
+    | _, .tableCopy dstTableIdx srcTableIdx => match s.values with
+      | .i32 len :: .i32 src :: .i32 dst :: vs =>
+        match st.tables[dstTableIdx]? with
+        | none => .Invalid s!"tableCopy: dst table index {dstTableIdx} out of range"
+        | some dstTbl =>
+          match st.tables[srcTableIdx]? with
+          | none => .Invalid s!"tableCopy: src table index {srcTableIdx} out of range"
+          | some srcTbl =>
+            if dst.toNat + len.toNat > dstTbl.length ∨ src.toNat + len.toNat > srcTbl.length then
+              .Trap st "out of bounds table access"
+            else
+              let srcSlice := (srcTbl.drop src.toNat).take len.toNat
+              let dstTbl' := dstTbl.take dst.toNat ++ srcSlice ++ dstTbl.drop (dst.toNat + len.toNat)
+              .Fallthrough { st with tables := st.tables.set dstTableIdx dstTbl' }
+                           { s with values := vs }
+      | _ => .Invalid "tableCopy: ill-shaped operand stack"
+
+    | _, .tableInit tableIdx segIdx => match s.values with
+      | .i32 len :: .i32 src :: .i32 dst :: vs =>
+        match st.tables[tableIdx]? with
+        | none => .Invalid s!"tableInit: table index {tableIdx} out of range"
+        | some dstTbl =>
+          match st.elementSegments[segIdx]? with
+          | none => .Invalid s!"tableInit: segment index {segIdx} out of range"
+          | some none =>
+            if 0 < len.toNat ∨ dst.toNat + len.toNat > dstTbl.length then
+              .Trap st "out of bounds table access"
+            else
+              .Fallthrough st { s with values := vs }
+          | some (some funcs) =>
+            if src.toNat + len.toNat > funcs.length
+               ∨ dst.toNat + len.toNat > dstTbl.length then
+              .Trap st "out of bounds table access"
+            else
+              let srcSlice := (funcs.drop src.toNat).take len.toNat
+              let dstTbl' := dstTbl.take dst.toNat ++ srcSlice ++ dstTbl.drop (dst.toNat + len.toNat)
+              .Fallthrough { st with tables := st.tables.set tableIdx dstTbl' }
+                           { s with values := vs }
+      | _ => .Invalid "tableInit: ill-shaped operand stack"
+    | _, .elemDrop i =>
+      match st.elementSegments[i]? with
+      | none => .Invalid s!"elemDrop: segment index {i} out of range"
+      | some _ =>
+        let elementSegments' := st.elementSegments.set i none
+        .Fallthrough { st with elementSegments := elementSegments' } s
 
 def exec (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (p : Program)
     (env : HostEnv α := {}) : Continuation α :=

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -170,14 +170,21 @@ inductive Instruction where
   | refIsNull : Instruction        -- ref.is_null:   pop a ref, push i32 1 if null else 0
 
   -- Table instructions. The runtime tables live on the `Store` (one
-  -- `TableInst = List (Option Nat)` per declared table). These read them
-  -- without mutating: `table.get t` pops an i32 index `i` and pushes
-  -- `tables[t][i]` as a `funcref` (trapping if `i` is past the table's
-  -- current length); `table.size t` pushes the table's current length as
-  -- an i32. A `tableIdx` that is itself out of range is a validation
-  -- error, not a runtime trap.
+  -- `TableInst = List (Option Nat)` per declared table). `table.get t`
+  -- pops an i32 index `i` and pushes `tables[t][i]` as a `funcref`
+  -- (trapping if `i` is past the table's current length); `table.size t`
+  -- pushes the table's current length as an i32; `table.set t` pops a
+  -- `funcref` and then an i32 index `i` and writes the funcref into
+  -- `tables[t][i]` (trapping if `i` is out of bounds). A `tableIdx` that
+  -- is itself out of range is a validation error, not a runtime trap.
   | tableGet  : Nat → Instruction  -- table.get t
   | tableSize : Nat → Instruction  -- table.size t
+  | tableSet  : Nat → Instruction  -- table.set t
+  | tableGrow : Nat → Instruction  -- table.grow t
+  | tableFill : Nat → Instruction  -- table.fill t
+  | tableCopy : (dstTableIdx srcTableIdx : Nat) → Instruction  -- table.copy dst src
+  | tableInit : (tableIdx segIdx : Nat) → Instruction          -- table.init t e
+  | elemDrop  : Nat → Instruction                               -- elem.drop e
 
   -- i32 memory loads (static byte offset; address popped from stack as i32)
   | load8U  : UInt32 → Instruction  -- i32.load8_u:  zero-extend 1 byte  → i32
@@ -357,7 +364,7 @@ deriving Repr, Inhabited
 
 /-- Runtime representation of a single table: a list of `funcref` slots
 (`none` = null, `some i` = function index `i`). The length is the
-table's current size; we don't model `table.grow`. -/
+table's current size. -/
 abbrev TableInst : Type := List (Option Nat)
 
 /-- The mutable runtime state threaded through execution: module-level

--- a/interpreter/Interpreter/Wasm/Wp/Atomic.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Atomic.lean
@@ -672,6 +672,78 @@ macro "wp_atomic" : tactic => `(tactic|
        wp m rest Q st { s with values := .i32 (UInt32.ofNat tbl.length) :: s.values } env) := by
   wp_atomic
 
+@[simp, wp_simp] theorem wp_tableSet_cons :
+    wp m (.tableSet tableIdx :: rest) Q st s env ↔
+    (match s.values with
+     | .funcref r :: .i32 i :: vs =>
+       (match st.tables[tableIdx]? with
+        | none     => Q (.Invalid s!"tableSet: table index {tableIdx} out of range")
+        | some tbl =>
+          (match tbl[i.toNat]? with
+           | none   => Q (.Trap st "out of bounds table access")
+           | some _ =>
+             wp m rest Q { st with tables := st.tables.set tableIdx (tbl.set i.toNat r) }
+                         { s with values := vs } env))
+     | _ => Q (.Invalid "tableSet: ill-shaped operand stack")) := by
+  wp_atomic
+
+@[simp, wp_simp] theorem wp_tableGrow_cons :
+    wp m (.tableGrow tableIdx :: rest) Q st s env ↔
+    (match s.values with
+     | .i32 delta :: .funcref r :: vs =>
+       (match st.tables[tableIdx]? with
+        | none => Q (.Invalid s!"tableGrow: table index {tableIdx} out of range")
+        | some tbl =>
+          (match m.tables[tableIdx]? >>= (·.max) with
+           | none =>
+             wp m rest Q { st with tables := st.tables.set tableIdx (tbl ++ List.replicate delta.toNat r) }
+                         { s with values := .i32 (UInt32.ofNat tbl.length) :: vs } env
+           | some n =>
+             if tbl.length + delta.toNat ≤ n then
+               wp m rest Q { st with tables := st.tables.set tableIdx (tbl ++ List.replicate delta.toNat r) }
+                           { s with values := .i32 (UInt32.ofNat tbl.length) :: vs } env
+             else
+               wp m rest Q st { s with values := .i32 (0xFFFFFFFF : UInt32) :: vs } env))
+     | _ => Q (.Invalid "tableGrow: ill-shaped operand stack")) := by
+  wp_atomic
+
+@[simp, wp_simp] theorem wp_tableFill_cons :
+    wp m (.tableFill tableIdx :: rest) Q st s env ↔
+    (match s.values with
+     | .i32 len :: .funcref val :: .i32 idx :: vs =>
+       (match st.tables[tableIdx]? with
+        | none => Q (.Invalid s!"tableFill: table index {tableIdx} out of range")
+        | some tbl =>
+          if idx.toNat + len.toNat > tbl.length then
+            Q (.Trap st "out of bounds table access")
+          else
+            wp m rest Q { st with tables := st.tables.set tableIdx
+                                    (tbl.take idx.toNat ++ List.replicate len.toNat val ++ tbl.drop (idx.toNat + len.toNat)) }
+                        { s with values := vs } env)
+     | _ => Q (.Invalid "tableFill: ill-shaped operand stack")) := by
+  wp_atomic
+
+@[simp, wp_simp] theorem wp_tableCopy_cons :
+    wp m (.tableCopy dstTableIdx srcTableIdx :: rest) Q st s env ↔
+    (match s.values with
+     | .i32 len :: .i32 src :: .i32 dst :: vs =>
+       (match st.tables[dstTableIdx]? with
+        | none => Q (.Invalid s!"tableCopy: dst table index {dstTableIdx} out of range")
+        | some dstTbl =>
+          (match st.tables[srcTableIdx]? with
+           | none => Q (.Invalid s!"tableCopy: src table index {srcTableIdx} out of range")
+           | some srcTbl =>
+             if dst.toNat + len.toNat > dstTbl.length ∨ src.toNat + len.toNat > srcTbl.length then
+               Q (.Trap st "out of bounds table access")
+             else
+               wp m rest Q { st with tables := st.tables.set dstTableIdx
+                                       (dstTbl.take dst.toNat ++
+                                        (srcTbl.drop src.toNat).take len.toNat ++
+                                        dstTbl.drop (dst.toNat + len.toNat)) }
+                           { s with values := vs } env))
+     | _ => Q (.Invalid "tableCopy: ill-shaped operand stack")) := by
+  wp_atomic
+
 /-! ## Globals -/
 
 @[simp, wp_simp] theorem wp_globalGet_cons :
@@ -956,6 +1028,41 @@ macro "wp_atomic" : tactic => `(tactic|
      | none => Q (.Invalid s!"dataDrop: segment index {i} out of range")
      | some _ =>
        wp m rest Q { st with dataSegments := st.dataSegments.set i none } s env) := by
+  wp_atomic
+
+@[simp, wp_simp] theorem wp_tableInit_cons :
+    wp m (.tableInit tableIdx segIdx :: rest) Q st s env ↔
+    (match s.values with
+     | .i32 len :: .i32 src :: .i32 dst :: vs =>
+       (match st.tables[tableIdx]? with
+        | none => Q (.Invalid s!"tableInit: table index {tableIdx} out of range")
+        | some dstTbl =>
+          (match st.elementSegments[segIdx]? with
+           | none => Q (.Invalid s!"tableInit: segment index {segIdx} out of range")
+           | some none =>
+             if 0 < len.toNat ∨ dst.toNat + len.toNat > dstTbl.length then
+               Q (.Trap st "out of bounds table access")
+             else
+               wp m rest Q st { s with values := vs } env
+           | some (some funcs) =>
+             if src.toNat + len.toNat > funcs.length
+                ∨ dst.toNat + len.toNat > dstTbl.length then
+               Q (.Trap st "out of bounds table access")
+             else
+               wp m rest Q { st with tables := st.tables.set tableIdx
+                                       (dstTbl.take dst.toNat ++
+                                        (funcs.drop src.toNat).take len.toNat ++
+                                        dstTbl.drop (dst.toNat + len.toNat)) }
+                           { s with values := vs } env))
+     | _ => Q (.Invalid "tableInit: ill-shaped operand stack")) := by
+  wp_atomic
+
+@[simp, wp_simp] theorem wp_elemDrop_cons :
+    wp m (.elemDrop i :: rest) Q st s env ↔
+    (match st.elementSegments[i]? with
+     | none => Q (.Invalid s!"elemDrop: segment index {i} out of range")
+     | some _ =>
+       wp m rest Q { st with elementSegments := st.elementSegments.set i none } s env) := by
   wp_atomic
 
 /-! ## float constants -/

--- a/verifier/Verifier/Emit.lean
+++ b/verifier/Verifier/Emit.lean
@@ -235,6 +235,12 @@ private def emitInstrShort : Wasm.Instruction → String
   -- Tables
   | .tableGet t     => s!".tableGet {emitNat t}"
   | .tableSize t    => s!".tableSize {emitNat t}"
+  | .tableSet t     => s!".tableSet {emitNat t}"
+  | .tableGrow t    => s!".tableGrow {emitNat t}"
+  | .tableFill t    => s!".tableFill {emitNat t}"
+  | .tableCopy d s  => s!".tableCopy {emitNat d} {emitNat s}"
+  | .tableInit t e  => s!".tableInit {emitNat t} {emitNat e}"
+  | .elemDrop e     => s!".elemDrop {emitNat e}"
   -- Globals
   | .globalGet i    => s!".globalGet {emitNat i}"
   | .globalSet i    => s!".globalSet {emitNat i}"


### PR DESCRIPTION
Add six table instructions that were missing from the interpreter:
table.set, table.grow, table.fill, table.copy, table.init, and elem.drop.

Each instruction is wired through the full stack: constructor in the Instruction type, execution semantics, WP rewrite lemma for proofs, decoder support for WAT files, and verifier emitter arm.

Includes a TableSet.lean example with round-trip write/read proofs.

Why: these were the last table operations the decoder recognized but
could not execute. Programs using table mutation (grow, fill, copy, init from element segments) would fail at runtime.

Note: table_*.wast testsuite files still show failures because
they use multi-module linking (the register command), which is a separate unsupported feature.

lake build passes at 2993 jobs, zero sorries.

Generated with Claude Code