### PR TITLE
docs: add Telegram channel call to action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thanks for your interest. This document covers how the project is structured, how to build and test it, and how to contribute.
 
+## Join the discussion
+
+Talos is under active development and we'd love your help shaping it. Join the conversation on our Telegram channel — [**@TalosDev**](https://t.me/TalosDev) — to ask questions, propose ideas, coordinate on contributions, and stay in the loop on where the project is headed.
+
 ## Architecture overview
 
 The codebase has five main parts — described at a level that shouldn't go stale as features are added:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Talos
 
 [![Lean](https://img.shields.io/badge/Lean-v4.30.0-blue?logo=lean)](lean-toolchain)
+[![Telegram](https://img.shields.io/badge/Telegram-Join%20the%20discussion-2CA5E0?logo=telegram&logoColor=white)](https://t.me/TalosDev)
 
 **Talos** is a WebAssembly interpreter written in Lean 4, named after the bronze giant of Greek mythology who guarded Crete — a mechanical guardian, built to enforce rules.
 


### PR DESCRIPTION
## What changed

- **README.md** — added a Telegram badge alongside the existing Lean badge, linking to the [@TalosDev](https://t.me/TalosDev) channel.
- **CONTRIBUTING.md** — added a "Join the discussion" section near the top inviting contributors to participate via the [@TalosDev](https://t.me/TalosDev) Telegram channel.

## Why

Give newcomers and prospective contributors a clear, visible call to action to join the conversation and help shape the project's development.

## Notes for reviewers

Both links point to `https://t.me/TalosDev`. If the channel should use a different URL (e.g. a private invite link), let me know and I'll update both spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)