### PR TITLE
decoder: fix double-counted imported globals in collectGlobalNames

### DIFF
--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -1966,10 +1966,6 @@ private def collectGlobalNames (fields : List Sexpr)
     | _ => pure ()
   for f in fields do
     match f with
-    | .list [.atom "import", _, _, .list (.atom "global" :: _)] => i := i + 1
-    | _ => pure ()
-  for f in fields do
-    match f with
     | .list (.atom "global" :: body) =>
       match body with
       | .atom a :: _ =>

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -28,6 +28,7 @@ import Interpreter.Wasm.Examples.ClzPopcnt
 import Interpreter.Wasm.Examples.HostDispatch
 import Interpreter.Wasm.Examples.Counter
 import Interpreter.Wasm.Examples.DecoderImport
+import Interpreter.Wasm.Examples.DecoderImportedGlobal
 import Interpreter.Wasm.Examples.FloatOps
 
 /-! # Wasm.Examples.Basic

--- a/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
+++ b/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
@@ -1,0 +1,73 @@
+import Interpreter.Wasm.Decoder.Wat
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Call
+
+/-! ## Example: imported-global index offset in the WAT decoder
+
+    Regression test for `collectGlobalNames`. Per the wasm spec, imported
+    globals occupy the low indices (`0 … N-1`) and a module's own declared
+    globals follow (`N …`). A `global.get $declared` must therefore resolve
+    to `N`, not `0` (under-count: imports ignored) and not `2N` (over-count:
+    imports counted twice).
+
+    Nothing in the Rust corpus imports globals, so this offset is invisible
+    to ordinary builds. This module exercises one imported + one declared
+    global end-to-end so a future miscount fails the build. -/
+
+namespace Wasm
+namespace DecoderImportedGlobal
+
+/-- A `.wat` module with one imported global `spectest.ig : i32` (unified
+index `0`) and one declared global `$d` (index `1`) initialised to `99`.
+`getD` reads `$d`; its decoded body must be `global.get 1`. -/
+def importedGlobalWat : String := "
+(module
+  (import \"spectest\" \"ig\" (global $ig i32))
+  (global $d i32 (i32.const 99))
+  (func $getD (export \"getD\") (result i32)
+    global.get $d))
+"
+
+private def decoded : Wasm.Module :=
+  match Wasm.Decoder.Wat.decode importedGlobalWat with
+  | .ok m    => m
+  | .error _ => default
+
+/-- One imported global at index `0`, one declared global at index `1`. -/
+theorem importedGlobalWat_global_layout :
+    decoded.importedGlobals = [("spectest", "ig")] ∧
+    decoded.globals.length = 2 ∧
+    decoded.globals.getLast?.map (·.init) = some (.i32 99) := by
+  native_decide
+
+/-- Index baked into the first `global.get` of the first function, if any.
+Projected to `Option Nat` because `Instruction` has no `DecidableEq`. -/
+private def firstGlobalGetIdx (m : Module) : Option Nat :=
+  match m.funcs.head?.map (·.body) with
+  | some (Instruction.globalGet i :: _) => some i
+  | _                                   => none
+
+/-- The crux: `global.get $d` resolves to index `1` (`importedGlobals.length
++ 0`). A double-counted import would bake in `2`, a dropped import `0`. -/
+theorem importedGlobalWat_getD_index :
+    firstGlobalGetIdx decoded = some 1 := by
+  native_decide
+
+/-- End-to-end: running `getD` reads the declared global and returns `99`.
+A wrong index would read the import's zero slot (`0`) or trap out of
+bounds (empty result). -/
+private def emptyEnv : HostEnv Unit := { funcs := [] }
+
+private def runVals (m : Module) (env : HostEnv Unit) (idx : Nat)
+    (st : Store Unit) (args : List Value) : List Value :=
+  match run 10 m idx st args env with
+  | .Success vs _ => vs
+  | _ => []
+
+theorem importedGlobalWat_getD_returns_99 :
+    runVals decoded emptyEnv 0 (decoded.initialStore (α := Unit)) []
+      = [.i32 99] := by
+  native_decide
+
+end DecoderImportedGlobal
+end Wasm


### PR DESCRIPTION
## What

1. Removes a redundant imported-global counting loop in `collectGlobalNames` ([Wat.lean](interpreter/Interpreter/Wasm/Decoder/Wat.lean)).
2. Adds a regression test ([Examples/DecoderImportedGlobal.lean](interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean)) that exercises imported + declared globals.

## Why

[#73](https://github.com/cajal-technologies/talos/pull/73) already fixed the imported-global index offset by adding a first pass that counts imported globals **and** records their `$name → index` bindings. [#76](https://github.com/cajal-technologies/talos/pull/76) was written against a pre-#73 base and, when merged on top, re-added an equivalent counting pass.

With both passes present, every imported global is counted twice, so declared globals start at index `2N` instead of `N` (where `N` = number of imported globals) — off by `N`. `global.get`/`global.set` on declared globals then reference the wrong slot or trap.

The Rust `wasm32-unknown-unknown` corpus never imports globals (`N = 0`), so it was unaffected — but spec-testsuite modules with imported globals decode with wrong declared-global indices.

## Fix

Drop the redundant loop; #73's pass already handles both the count and the name binding. Net `-4` lines in the decoder, restoring the single import-count + declared-globals structure.

## Regression test

`DecoderImportedGlobal` decodes a module with one imported global (`spectest.ig`, index `0`) and one declared global `$d` (index `1`, init `99`), then asserts via `native_decide`:

- `importedGlobals = [("spectest", "ig")]`, `globals.length = 2`, last global init `= 99`;
- `global.get $d` bakes in index **`1`** (under-count would give `0`, double-count `2`);
- running `getD` returns `[99]` (a wrong index reads the import's zero slot or traps out of bounds).

Bundled via `Examples.Basic`. Since nothing in the Rust corpus imports globals, this is the first build-visible coverage of the offset — it fails under either miscount direction.

## Verification

`lake build Interpreter.Wasm.Examples.DecoderImportedGlobal` passes clean (2982/2982).

🤖 Generated with [Claude Code](https://claude.com/claude-code)