### PR TITLE
Add CODEOWNERS: require owner (@mfornet) approval to merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for this repository.
+#
+# Owners listed here are automatically requested for review on pull requests
+# that modify files they own, and (with branch protection's "Require review
+# from Code Owners" enabled) their approval is required before merging.
+#
+# See: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository.
+* @mfornet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,1 @@
-# Code owners for this repository.
-#
-# Owners listed here are automatically requested for review on pull requests
-# that modify files they own, and (with branch protection's "Require review
-# from Code Owners" enabled) their approval is required before merging.
-#
-# See: https://docs.github.com/articles/about-code-owners
-
-# Default owner for everything in the repository.
 * @mfornet


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @mfornet`, making @mfornet the owner of the whole repository.

Combined with the branch protection on `main` (now: **Require a pull request before merging → Require review from Code Owners → 1 required approval**), this means every PR into `main` requires @mfornet's approval before it can be merged.

Note: CODEOWNERS is read from the base branch, so the owner-review requirement starts applying to PRs opened **after** this one lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)