### PR TITLE
verifier: add `lift` subcommand to scaffold CodeLib files

### DIFF
--- a/justfile
+++ b/justfile
@@ -158,6 +158,13 @@ verifier-build *crates:
 verifier-emit *crates:
     just _verifier emit {{ crates }}
 
+# Scaffold codelib/CodeLib/RustStd/<Type>/<Name>.lean from one function of a crate's
+# module (verbatim body + Function record + wp-form theorem stub to fill in).
+# Example: just verifier-lift rust_std 0 U64 absDiff
+[group("verifier")]
+verifier-lift crate funcidx type name:
+    just _verifier lift {{ crate }} {{ funcidx }} {{ type }} {{ name }}
+
 # Run lake build on selected crates' Lean modules; omit names for all.
 [group("verifier")]
 verifier-prove *crates:

--- a/verifier/Verifier/Emit.lean
+++ b/verifier/Verifier/Emit.lean
@@ -492,4 +492,73 @@ def driftCheck (relWatPath : String) (watHash : UInt64) : String :=
     s!"      s!\"\{path} has drifted from Program.lean; re-run `lake exe verifier emit`.\""
   ]
 
+/-! ## CodeLib scaffolding (`lift`)
+
+Render a single function body as a ready-to-prove `CodeLib/RustStd/<Type>/`
+file: the verbatim body + `Function` record (so it matches the emitted module
+exactly — checked by `rfl` in the per-crate spec), plus a wp-form theorem stub
+in the house style. The post-condition (`Returns …`) and the proof are left as
+`sorry` for the human to fill, mirroring `CountOnes` / `AbsDiff`. -/
+
+private def valLeanType : Wasm.ValueType → String
+  | .i64 => "UInt64"
+  | .i32 => "UInt32"
+  | _    => "UInt32 /- TODO: unsupported value type -/"
+
+private def valCtor : Wasm.ValueType → String
+  | .i64 => ".i64"
+  | _    => ".i32"
+
+private def valZero : Wasm.ValueType → String
+  | .i64 => ".i64 0"
+  | _    => ".i32 0"
+
+private def paramName (i : Nat) : String := String.singleton (Char.ofNat (97 + i))
+
+/-- Full CodeLib scaffold file for function `f`, named `<funcName>`/`<bodyName>`
+under `namespace Wasm.RustStd.<typeNs>`. -/
+def codeLibScaffold (typeNs fnName bodyName funcName : String)
+    (f : Wasm.Function) : String :=
+  let binders := String.intercalate " "
+    (f.params.mapIdx fun i t => s!"({paramName i} : {valLeanType t})")
+  let paramLocals := "[" ++ String.intercalate ", "
+    (f.params.mapIdx fun i t => s!"{valCtor t} {paramName i}") ++ "]"
+  let zeroLocals := "[" ++ String.intercalate ", " (f.locals.map valZero) ++ "]"
+  let body := emitInstrList 0 f.body
+  String.intercalate "\n" [
+    "import CodeLib.RustStd.Frame",
+    "import Interpreter.Wasm.Wp.Tactic",
+    "import Interpreter.Wasm.Wp.Block",
+    "import CodeLib.Entry",
+    "",
+    s!"/-! AUTO-SCAFFOLDED by `verifier lift`. Fill in the `Returns` result and",
+    s!"the proof (see `CountOnes` / `AbsDiff` for templates), then delete this note. -/",
+    "",
+    s!"namespace Wasm.RustStd.{typeNs}",
+    "",
+    "open Wasm",
+    "",
+    s!"/-- Verbatim opt-0 body of `{fnName}`. -/",
+    s!"def {bodyName} : Program :=\n  {body}",
+    "",
+    s!"def {funcName} : Function :=",
+    s!"  \{ params := {emitValueTypes f.params}, locals := {emitValueTypes f.locals}" ++
+      s!", body := {bodyName}, results := {emitValueTypes f.results} }",
+    "",
+    "set_option maxRecDepth 4096 in",
+    s!"/-- TODO: state what `{fnName}` returns, then prove it. -/",
+    s!"theorem {fnName}_wp \{α} \{m : Module} \{env : HostEnv α} (st : Store α)",
+    s!"    (sp : UInt32) {binders} (vs : List Value)",
+    s!"    (hsp : st.globals.globals[0]? = some (.i32 sp))",
+    s!"    (hlo : 16 ≤ sp.toNat) (hhi : sp.toNat ≤ st.mem.pages * 65536) :",
+    s!"    wp m {bodyName}",
+    s!"      (Returns ((sorry : Value) :: vs)",
+    s!"        (fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages))",
+    s!"      st ⟨{paramLocals}, {zeroLocals}, vs⟩ env := by",
+    s!"  sorry",
+    "",
+    s!"end Wasm.RustStd.{typeNs}",
+    ""
+  ]
+
 end Verifier.Emit

--- a/verifier/Verifier/Emit.lean
+++ b/verifier/Verifier/Emit.lean
@@ -498,7 +498,7 @@ Render a single function body as a ready-to-prove `CodeLib/RustStd/<Type>/`
 file: the verbatim body + `Function` record (so it matches the emitted module
 exactly — checked by `rfl` in the per-crate spec), plus a wp-form theorem stub
 in the house style. The post-condition (`Returns …`) and the proof are left as
-`sorry` for the human to fill, mirroring `CountOnes` / `AbsDiff`. -/
+`sorry` for the human to fill, mirroring `AbsDiff`. -/
 
 private def valLeanType : Wasm.ValueType → String
   | .i64 => "UInt64"
@@ -513,6 +513,9 @@ private def valZero : Wasm.ValueType → String
   | .i64 => ".i64 0"
   | _    => ".i32 0"
 
+/-- Single-letter binder name `a`, `b`, … for the `i`-th parameter. Only valid
+for `i < 12`: it must stay clear of the theorem's `m : Module` binder (offset 12)
+and the printable-letter range (offset 26). Callers (`cmdLift`) guard the arity. -/
 private def paramName (i : Nat) : String := String.singleton (Char.ofNat (97 + i))
 
 /-- Full CodeLib scaffold file for function `f`, named `<funcName>`/`<bodyName>`
@@ -532,7 +535,10 @@ def codeLibScaffold (typeNs fnName bodyName funcName : String)
     "import CodeLib.Entry",
     "",
     s!"/-! AUTO-SCAFFOLDED by `verifier lift`. Fill in the `Returns` result and",
-    s!"the proof (see `CountOnes` / `AbsDiff` for templates), then delete this note. -/",
+    s!"the proof (see `AbsDiff` for a template), then delete this note.",
+    s!"The `sp`/`hsp`/`hlo`/`hhi` hypotheses and the frame post-condition follow the",
+    s!"shadow-stack (global 0 = SP) convention; drop them for a function that uses",
+    s!"neither the shadow stack nor memory. -/",
     "",
     s!"namespace Wasm.RustStd.{typeNs}",
     "",

--- a/verifier/Verifier/Main.lean
+++ b/verifier/Verifier/Main.lean
@@ -470,6 +470,16 @@ private def cmdLift (crate : String) (funcIdx : Nat) (typeNs fnName : String) : 
   | .ok m =>
     let some f := m.funcs[funcIdx]? |
       die s!"function index {funcIdx} out of range (module has {m.funcs.length} functions)"
+    -- The scaffold renders params/locals through i32/i64-only helpers and names
+    -- params with single letters; reject inputs it can't render faithfully
+    -- rather than emit subtly-wrong code.
+    let isI32I64 : Wasm.ValueType → Bool := fun
+      | .i32 | .i64 => true
+      | _           => false
+    unless (f.params ++ f.locals).all isI32I64 do
+      die s!"function {funcIdx} has a non-i32/i64 param or local; `lift` only supports i32/i64 today"
+    if f.params.length > 12 then
+      die s!"function {funcIdx} has {f.params.length} params; `lift`'s single-letter param naming only goes up to 12 — lift it by hand"
     let bodyName := fnName ++ "Body"
     let funcName := fnName ++ "Func"
     let content := Verifier.Emit.codeLibScaffold typeNs fnName bodyName funcName f
@@ -677,7 +687,7 @@ def liftCmd : Cmd := `[Cli|
 
   ARGS:
     crate   : String; "Crate name (snake_case)."
-    funcIdx : String; "Function index in the emitted module (func0, func1, …)."
+    funcIdx : String; "Index among the module's defined functions (the emitted func0, func1, …; excludes imports)."
     type    : String; "Type namespace under CodeLib/RustStd (e.g. U64)."
     name    : String; "lowerCamel base (absDiff → absDiffBody/absDiffFunc/absDiff_wp, file AbsDiff.lean)."
 ]

--- a/verifier/Verifier/Main.lean
+++ b/verifier/Verifier/Main.lean
@@ -447,6 +447,42 @@ private def cmdEmit (names : List String) (forceEmit : Bool) : IO Unit := do
   printCrateBanner crates
   emitPrograms projectDir crates forceEmit
 
+/-- Capitalize the first character (for `absDiff` → `AbsDiff.lean`). -/
+private def capFirst (s : String) : String :=
+  match s.toList with
+  | []      => s
+  | c :: cs => String.ofList (c.toUpper :: cs)
+
+/-- `lift`: scaffold a `CodeLib/RustStd/<Type>/<Name>.lean` from one function of
+a crate's decoded module. Copies the body verbatim (so it matches the emitted
+module — `rfl`-checked downstream) and leaves the post-condition + proof as
+`sorry` to fill in. -/
+private def cmdLift (crate : String) (funcIdx : Nat) (typeNs fnName : String) : IO Unit := do
+  let projectDir ← projectDirFromCwd
+  let crates ← discoverSelected projectDir [crate]
+  let some c := crates[0]? | die s!"crate `{crate}` not found in this project"
+  let watFile := projectDir / "rust" / "build" / c.name / "program.wat"
+  unless ← System.FilePath.pathExists watFile do
+    die s!"{c.name}: {watFile} not found — run `verifier build {c.name}` first"
+  let watText ← IO.FS.readFile watFile
+  match Wasm.Decoder.Wat.decode watText with
+  | .error e => die s!"{c.name}: wat decoder rejected the module: {e}"
+  | .ok m =>
+    let some f := m.funcs[funcIdx]? |
+      die s!"function index {funcIdx} out of range (module has {m.funcs.length} functions)"
+    let bodyName := fnName ++ "Body"
+    let funcName := fnName ++ "Func"
+    let content := Verifier.Emit.codeLibScaffold typeNs fnName bodyName funcName f
+    let some repoRoot := projectDir.parent | die "could not locate repo root from project dir"
+    let dst := repoRoot / "codelib" / "CodeLib" / "RustStd" / typeNs / (capFirst fnName ++ ".lean")
+    if ← System.FilePath.pathExists dst then
+      die s!"{dst} already exists — refusing to overwrite"
+    if let some parent := dst.parent then IO.FS.createDirAll parent
+    IO.FS.writeFile dst content
+    IO.println s!"    scaffolded {dst}"
+    IO.println s!"    next: fill the `Returns` result + proof, then add"
+    IO.println s!"          `import CodeLib.RustStd.{typeNs}.{capFirst fnName}` to codelib/CodeLib.lean"
+
 private def cmdProve (names : List String) : IO Unit := do
   let projectDir ← projectDirFromCwd
   let crates ← discoverSelected projectDir names
@@ -520,6 +556,14 @@ def runBuild (p : Parsed) : IO UInt32 := do
 
 def runEmit (p : Parsed) : IO UInt32 := do
   cmdEmit (p.variableArgs.map (·.as! String) |>.toList) (p.hasFlag "force-emit")
+  pure 0
+
+def runLift (p : Parsed) : IO UInt32 := do
+  let crate := p.positionalArg! "crate" |>.as! String
+  let idxStr := p.positionalArg! "funcIdx" |>.as! String
+  let some idx := idxStr.toNat? | die s!"funcIdx must be a number, got `{idxStr}`"
+  cmdLift crate idx (p.positionalArg! "type" |>.as! String)
+    (p.positionalArg! "name" |>.as! String)
   pure 0
 
 def runProve (p : Parsed) : IO UInt32 := do
@@ -627,6 +671,17 @@ def emitCmd : Cmd := `[Cli|
     ...crates : String; "Crate names; default: all."
 ]
 
+def liftCmd : Cmd := `[Cli|
+  lift VIA runLift;
+  "Scaffold codelib/CodeLib/RustStd/<Type>/<Name>.lean from one function of a crate's module."
+
+  ARGS:
+    crate   : String; "Crate name (snake_case)."
+    funcIdx : String; "Function index in the emitted module (func0, func1, …)."
+    type    : String; "Type namespace under CodeLib/RustStd (e.g. U64)."
+    name    : String; "lowerCamel base (absDiff → absDiffBody/absDiffFunc/absDiff_wp, file AbsDiff.lean)."
+]
+
 def proveCmd : Cmd := `[Cli|
   prove VIA runProve;
   "Run `lake build` on selected crates' Lean modules (omit names for all)."
@@ -681,6 +736,7 @@ def mainCmd : Cmd := `[Cli|
     delCmd;
     buildCmd;
     emitCmd;
+    liftCmd;
     proveCmd;
     checkCmd;
     extractCmd;


### PR DESCRIPTION
Adds a `lift` subcommand to the verifier that scaffolds a `CodeLib/RustStd/<Type>/<Name>.lean` from one function of a crate's decoded module.

`just verifier-lift <crate> <funcIdx> <Type> <name>`:
- copies the function body **verbatim** out of the emitted module (so the lifted body is guaranteed to match — re-checked by `rfl` in the per-crate spec),
- emits a `wp`-form theorem stub with the post-condition (`Returns …`) and proof left as `sorry` for the human to fill,
- writes the file under `codelib/CodeLib/RustStd/<Type>/`.

It's a thin code generator: it decides nothing about the spec or proof, and nothing is trusted from it — Lean re-checks the lifted body. Self-contained; no behaviour change to existing subcommands.

Files: `verifier/Verifier/Emit.lean` (`codeLibScaffold`), `verifier/Verifier/Main.lean` (`cmdLift`/`liftCmd`), `justfile` (recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)