### PR TITLE
codelib: drop duplicate UInt{32,64}.toNat_sub_of_le lemmas

### DIFF
--- a/codelib/CodeLib/RustStd/Frame.lean
+++ b/codelib/CodeLib/RustStd/Frame.lean
@@ -16,8 +16,10 @@ form that does not care about the concrete spill address:
 * `Mem.read{32,64}_write{32,64}_same` — read-after-write at the same
   address returns the value (no bound on the address needed).
 * `Mem.write{32,64}_pages` — a store leaves the page count unchanged.
-* `UInt32.toNat_sub_of_le` — frame-pointer arithmetic (`sp - 16`) without
-  underflow, needed for the in-bounds (no-trap) obligation.
+
+The in-bounds (no-trap) obligation also needs `sp - 16` not to underflow;
+that is `UInt32.toNat_sub_of_le`, which Lean core already provides
+(`Init.Data.UInt.Lemmas`), so it is used directly rather than re-proved here.
 
 The four `Mem.*` lemmas are intentionally global `@[simp]` — confluent,
 terminating rewrites used corpus-wide. Op-specific lemmas (e.g. `popcnt`
@@ -58,17 +60,5 @@ returns the stored value. -/
 
 @[simp] theorem Mem.write64_pages (m : Mem) (a : UInt32) (v : UInt64) :
     (m.write64 a v).pages = m.pages := rfl
-
-/-! ## Frame-pointer arithmetic -/
-
-/-- `sp - 16` does not underflow when `16 ≤ sp`. -/
-theorem UInt32.toNat_sub_of_le (a b : UInt32) (h : b ≤ a) :
-    (a - b).toNat = a.toNat - b.toNat := by
-  rw [UInt32.toNat_sub]
-  have hle : b.toNat ≤ a.toNat := UInt32.le_iff_toNat_le.mp h
-  have hlt : a.toNat < 2 ^ 32 := a.toNat_lt
-  have hkey : 2 ^ 32 - b.toNat + a.toNat = 2 ^ 32 + (a.toNat - b.toNat) := by omega
-  rw [hkey, Nat.add_mod_left]
-  exact Nat.mod_eq_of_lt (by omega)
 
 end Wasm

--- a/codelib/CodeLib/UInt64.lean
+++ b/codelib/CodeLib/UInt64.lean
@@ -335,17 +335,6 @@ theorem UInt64.shr_ctz_toNat_odd (a : UInt64) (ha : a ≠ 0) :
   rw [UInt64.shr_ctz_toNat a ha]
   exact UInt64.ctz64_shr_odd a ha
 
-/-! ## No-wrap subtraction -/
-
-theorem UInt64.toNat_sub_of_le (a b : UInt64) (h : b ≤ a) :
-    (a - b).toNat = a.toNat - b.toNat := by
-  rw [UInt64.toNat_sub]
-  have hle : b.toNat ≤ a.toNat := UInt64.le_iff_toNat_le.mp h
-  have hlt : a.toNat < 2^64 := a.toNat_lt
-  have hkey : 2^64 - b.toNat + a.toNat = 2^64 + (a.toNat - b.toNat) := by omega
-  rw [hkey, Nat.add_mod_left]
-  exact Nat.mod_eq_of_lt (by omega)
-
 /-! ## Nat-level Stein identity -/
 
 private theorem _aux_coprime_two_pow_of_odd (k m : Nat) (hm : m % 2 = 1) :


### PR DESCRIPTION
## What

Removes two hand-written lemmas that duplicate the Lean standard library:

- `Wasm.UInt32.toNat_sub_of_le` in `codelib/CodeLib/RustStd/Frame.lean`
- `Wasm.UInt64.toNat_sub_of_le` in `codelib/CodeLib/UInt64.lean`

Both were verbatim re-proofs of lemmas Lean core already ships in `Init.Data.UInt.Lemmas` (always in scope, no Mathlib needed), with **identical** signatures:

```
UInt32.toNat_sub_of_le : ∀ (a b : UInt32), b ≤ a → (a - b).toNat = a.toNat - b.toNat
UInt64.toNat_sub_of_le : ∀ (a b : UInt64), b ≤ a → (a - b).toNat = a.toNat - b.toNat
```

## Why it's safe

Because the core lemmas share the same root name, every call site rebinds to them automatically once the local copies are removed — **no call-site edits required**. The affected references (`AbsDiff.lean`, `UInt64.lean`'s internal Stein lemmas, and `NumInteger/Spec.lean`) all resolve to core.

Verified by building both `codelib` (3001 jobs) and `programs/lean` (3009 jobs) with the duplicates gone — green.

## What's kept

The four `Mem.read/write` framing lemmas in `Frame.lean` stay: `Mem` is the repo's own type, those lemmas have no stdlib equivalent, and removing them breaks the consumers (confirmed). The `Frame.lean` docstring is updated to note that the frame-pointer no-underflow fact now comes from core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)