### PR TITLE
u64::div: reusable CodeLib theorem (tail-generic) + cross-crate reuse test

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -5,6 +5,7 @@ import CodeLib.UInt32
 import CodeLib.UInt64
 import CodeLib.RustStd.Frame
 import CodeLib.RustStd.U64.AbsDiff
+import CodeLib.RustStd.U64.Div
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib/RustStd/U64/Div.lean
+++ b/codelib/CodeLib/RustStd/U64/Div.lean
@@ -1,0 +1,84 @@
+import CodeLib.RustStd.Frame
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Block
+import CodeLib.Entry
+
+/-!
+# `u64::div` — reusable body theorem
+
+`u64::div a b = a / b`. At `opt-level = 0` the `/` operator is inlined directly
+into the export: no inner `call`, no stack frame, no memory spill. Unlike `+`,
+`-`, `*` — whose overflow checks are off under the corpus's release build
+(`[profile.release]` with `overflow-checks` defaulting off), so they compile to a
+bare wrapping `i64.{add,sub,mul}` — unsigned division is **always** guarded
+against a zero divisor, even with overflow checks off: dividing by zero is UB in
+LLVM, so rustc must emit the check unconditionally. Hence the body is a `block`
+that checks `b == 0` and, when true, breaks out to a panic stub
+(`const …; call …; unreachable`, "attempt to divide by zero"). Otherwise the
+guard falls through, `i64.div_u` does not trap, and the function returns the
+unsigned quotient `a / b` (exactly `UInt64` division).
+
+The panic stub's `const` (a `&Location` pointer) and `call` (the panic handler)
+indices are **crate-specific**: a `div` compiled into a different module gets a
+different tail. But with `b ≠ 0` that tail is never reached — the guard block
+returns first. So `div_wp` is stated over the shared guard `block` (`divGuard`)
+followed by an **arbitrary** `tail`, which lets the one CodeLib theorem be
+reused under `call` for *any* crate's `div`, regardless of its panic tail (see
+`Project.RustU64Tests`). `divBody`/`divFunc` instantiate `tail` at the verbatim
+`rust_u64` tail for the per-crate spec.
+
+Stated in `wp` form about the body. The post-condition keeps the
+`globals`/`mem.pages` frame (trivially preserved here, since `div` mutates no
+state) so the theorem composes under the `call` rule. Because the body uses
+neither the shadow stack nor memory, the `sp`/`hsp`/`hlo`/`hhi` hypotheses of
+the spill-frame template are dropped; the only hypothesis is the
+divisor-nonzero side-condition `hb`.
+-/
+
+namespace Wasm.RustStd.U64
+
+open Wasm
+
+/-- The crate-independent guard `block` every opt-0 `u64 / u64` compiles to:
+check `b == 0`, break to the panic tail when true, otherwise `i64.div_u` and
+return. This prefix is identical across crates; only the trailing panic stub
+differs. -/
+def divGuard : Instruction :=
+  .block 0 0 [
+    .localGet 1,
+    .constI64 (0 : UInt64),
+    .eqI64,
+    .const (1 : UInt32),
+    .and,
+    .br_if 0,
+    .localGet 0,
+    .localGet 1,
+    .divUI64,
+    .ret
+  ]
+
+/-- Verbatim opt-0 body of `rust_u64::div`: the shared guard followed by this
+crate's panic tail (`const`/`call`/`unreachable`). -/
+def divBody : Program :=
+  divGuard :: [.const (1048600 : UInt32), .call 56, .unreachable]
+
+def divFunc : Function :=
+  { params := [.i64, .i64], locals := [], body := divBody, results := [.i64] }
+
+set_option maxRecDepth 4096 in
+/-- `u64::div a b = a / b` (unsigned quotient; requires `b ≠ 0`, else the
+division traps). Generic in the panic `tail` after the guard `block`: that tail
+is unreachable when `b ≠ 0`, so the theorem composes under `call` for any
+crate's `div`. -/
+theorem div_wp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a : UInt64) (b : UInt64) (vs : List Value) (tail : Program) (hb : b ≠ 0) :
+    wp m (divGuard :: tail)
+      (Returns (.i64 (a / b) :: vs)
+        (fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages))
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env := by
+  unfold divGuard Returns
+  apply wp_block_cons
+  wp_run
+  simp [hb]
+
+end Wasm.RustStd.U64

--- a/programs/lean/Project.lean
+++ b/programs/lean/Project.lean
@@ -1,3 +1,4 @@
 import Project.NumInteger.Spec
 import Project.RustU64.Spec
+import Project.RustU64Tests.Spec
 import Project.TotalVariation.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -18,4 +18,20 @@ theorem abs_diff_correct : AbsDiffSpec := by
       (absDiff_wp «module».initialStore 1048576 a b [] rfl (by decide) (by decide))
       rfl).mono (fun _ _ h => h.1)
 
+/-- `div` is the wasm export at index 2; `a / b` is inlined (the body guards
+the `i64.div_u` against a zero divisor and panics otherwise). With `b ≠ 0`
+the guard falls through and the function returns the unsigned quotient. -/
+@[spec_of "rust-exported" "rust_u64::div"]
+def DivSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64), b ≠ 0 →
+    TerminatesWith env «module» 2 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i64 (a / b)])
+
+@[proves Project.RustU64.Spec.DivSpec]
+theorem div_correct : DivSpec := by
+  intro env a b hb
+  exact (TerminatesWith.of_returns_wp (f := divFunc)
+      (rs := [.i64 (a / b)]) rfl rfl
+      (div_wp «module».initialStore a b [] _ hb) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64Tests/Program.lean
+++ b/programs/lean/Project/RustU64Tests/Program.lean
@@ -6,59 +6,12 @@ import CodeLib
 
 set_option maxRecDepth 1048576
 
-namespace Project.RustU64
+namespace Project.RustU64Tests
 
 open Wasm
 
-def func0 : Wasm.Program :=
-  [
-  .globalGet 0,
-  .const (16 : UInt32),
-  .sub,
-  .localSet 2,
-  .block 0 0 [
-    .block 0 0 [
-      .localGet 0,
-      .localGet 1,
-      .ltUI64,
-      .const (1 : UInt32),
-      .and,
-      .br_if 0,
-      .localGet 2,
-      .localGet 0,
-      .localGet 1,
-      .subI64,
-      .store64 (8 : UInt32),
-      .br 1
-    ],
-    .localGet 2,
-    .localGet 1,
-    .localGet 0,
-    .subI64,
-    .store64 (8 : UInt32)
-  ],
-  .localGet 2,
-  .load64 (8 : UInt32),
-  .ret
-]
-
-def func0Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [.i32], body := func0, results := [.i64] }
-
-/-- export: abs_diff -/
-def func1 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .call 0,
-  .ret
-]
-
-def func1Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func1, results := [.i64] }
-
 /-- export: div -/
-def func2 : Wasm.Program :=
+def func0 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -72,85 +25,82 @@ def func2 : Wasm.Program :=
     .divUI64,
     .ret
   ],
-  .const (1048600 : UInt32),
-  .call 56,
+  .const (1048608 : UInt32),
+  .call 54,
   .unreachable
 ]
 
-def func2Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func2, results := [.i64] }
+def func0Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func0, results := [.i64] }
 
-/-- export: entrypoint -/
+/-- export: div_chain -/
+def func1 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 0,
+  .localGet 2,
+  .call 0,
+  .ret
+]
+
+def func1Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func1, results := [.i64] }
+
+def func2 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 19,
+  .ret
+]
+
+def func2Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func2, results := [.i32] }
+
 def func3 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 1,
-  .drop,
-  .localGet 0,
-  .localGet 1,
-  .call 2,
-  .drop,
+  .localGet 2,
+  .call 23,
   .ret
 ]
 
 def func3Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func3, results := [] }
+  { params := [.i32, .i32, .i32], locals := [], body := func3, results := [] }
 
 def func4 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 21,
-  .ret
-]
-
-def func4Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func4, results := [.i32] }
-
-def func5 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
   .localGet 2,
+  .localGet 3,
   .call 25,
   .ret
 ]
 
+def func4Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [], body := func4, results := [.i32] }
+
+def func5 : Wasm.Program :=
+  [
+  .ret
+]
+
 def func5Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func5, results := [] }
+  { params := [], locals := [], body := func5, results := [] }
 
 def func6 : Wasm.Program :=
   [
-  .localGet 0,
-  .localGet 1,
-  .localGet 2,
-  .localGet 3,
-  .call 27,
-  .ret
-]
-
-def func6Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [], body := func6, results := [.i32] }
-
-def func7 : Wasm.Program :=
-  [
-  .ret
-]
-
-def func7Def : Wasm.Function :=
-  { params := [], locals := [], body := func7, results := [] }
-
-def func8 : Wasm.Program :=
-  [
-  .call 24,
+  .call 22,
   .unreachable
 ]
 
-def func8Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func8, results := [.i32] }
+def func6Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func6, results := [.i32] }
 
-def func9 : Wasm.Program :=
+def func7 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -169,7 +119,7 @@ def func9 : Wasm.Program :=
     .br_if 0,
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .call 49,
+    .call 47,
     .unreachable
   ],
   .localGet 5,
@@ -209,7 +159,7 @@ def func9 : Wasm.Program :=
   .localGet 2,
   .localGet 3,
   .localGet 4,
-  .call 17,
+  .call 15,
   .block 0 0 [
     .localGet 5,
     .load32 (4 : UInt32),
@@ -220,7 +170,7 @@ def func9 : Wasm.Program :=
     .load32 (8 : UInt32),
     .localGet 5,
     .load32 (12 : UInt32),
-    .call 49,
+    .call 47,
     .unreachable
   ],
   .localGet 5,
@@ -238,10 +188,10 @@ def func9 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func9Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func9, results := [] }
+def func7Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func7, results := [] }
 
-def func10 : Wasm.Program :=
+def func8 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -253,14 +203,14 @@ def func10 : Wasm.Program :=
     .localGet 1,
     .localGet 0,
     .const (1 : UInt32),
-    .call 5
+    .call 3
   ]
 ]
 
-def func10Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func10, results := [] }
+def func8Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func8, results := [] }
 
-def func11 : Wasm.Program :=
+def func9 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -273,14 +223,14 @@ def func11 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 5
+    .call 3
   ]
 ]
 
-def func11Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func11, results := [] }
+def func9Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func9, results := [] }
 
-def func12 : Wasm.Program :=
+def func10 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -294,12 +244,42 @@ def func12 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 5
+    .call 3
   ]
 ]
 
+def func10Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func10, results := [] }
+
+def func11 : Wasm.Program :=
+  [
+  .localGet 0,
+  .call 12,
+  .unreachable
+]
+
+def func11Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func11, results := [] }
+
+def func12 : Wasm.Program :=
+  [
+  .localGet 0,
+  .load32 (0 : UInt32),
+  .localGet 0,
+  .load32 (4 : UInt32),
+  .const (0 : UInt32),
+  .load32 (1049092 : UInt32),
+  .localSet 0,
+  .localGet 0,
+  .const (1 : UInt32),
+  .localGet 0,
+  .select,
+  .callIndirect 0 0,
+  .unreachable
+]
+
 def func12Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func12, results := [] }
+  { params := [.i32], locals := [], body := func12, results := [] }
 
 def func13 : Wasm.Program :=
   [
@@ -312,36 +292,6 @@ def func13Def : Wasm.Function :=
   { params := [.i32], locals := [], body := func13, results := [] }
 
 def func14 : Wasm.Program :=
-  [
-  .localGet 0,
-  .load32 (0 : UInt32),
-  .localGet 0,
-  .load32 (4 : UInt32),
-  .const (0 : UInt32),
-  .load32 (1049084 : UInt32),
-  .localSet 0,
-  .localGet 0,
-  .const (1 : UInt32),
-  .localGet 0,
-  .select,
-  .callIndirect 0 0,
-  .unreachable
-]
-
-def func14Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func14, results := [] }
-
-def func15 : Wasm.Program :=
-  [
-  .localGet 0,
-  .call 16,
-  .unreachable
-]
-
-def func15Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func15, results := [] }
-
-def func16 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -373,7 +323,7 @@ def func16 : Wasm.Program :=
     .localGet 2,
     .store32 (0 : UInt32),
     .localGet 1,
-    .const (1048640 : UInt32),
+    .const (1048648 : UInt32),
     .localGet 0,
     .load32 (4 : UInt32),
     .localGet 0,
@@ -383,7 +333,7 @@ def func16 : Wasm.Program :=
     .load8U (8 : UInt32),
     .localGet 0,
     .load8U (9 : UInt32),
-    .call 18,
+    .call 16,
     .unreachable
   ],
   .localGet 1,
@@ -393,7 +343,7 @@ def func16 : Wasm.Program :=
   .localGet 0,
   .store32 (12 : UInt32),
   .localGet 1,
-  .const (1048668 : UInt32),
+  .const (1048676 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
   .localGet 0,
@@ -403,14 +353,14 @@ def func16 : Wasm.Program :=
   .load8U (8 : UInt32),
   .localGet 0,
   .load8U (9 : UInt32),
-  .call 18,
+  .call 16,
   .unreachable
 ]
 
-def func16Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32], body := func16, results := [] }
+def func14Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32], body := func14, results := [] }
 
-def func17 : Wasm.Program :=
+def func15 : Wasm.Program :=
   [
   .const (1 : UInt32),
   .localSet 6,
@@ -461,7 +411,7 @@ def func17 : Wasm.Program :=
             .mul,
             .localGet 4,
             .localGet 3,
-            .call 6,
+            .call 4,
             .localSet 7,
             .br 1
           ],
@@ -472,10 +422,10 @@ def func17 : Wasm.Program :=
             .localSet 7,
             .br 2
           ],
-          .call 7,
+          .call 5,
           .localGet 3,
           .localGet 4,
-          .call 4,
+          .call 2,
           .localSet 7
         ],
         .localGet 7,
@@ -504,10 +454,10 @@ def func17 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func17Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func17, results := [] }
+def func15Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func15, results := [] }
 
-def func18 : Wasm.Program :=
+def func16 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -521,13 +471,13 @@ def func18 : Wasm.Program :=
         .block 0 0 [
           .block 0 0 [
             .const (1 : UInt32),
-            .call 34,
+            .call 32,
             .const (255 : UInt32),
             .and,
             .brTable [4, 1, 0] 1
           ],
           .const (0 : UInt32),
-          .load32 (1049088 : UInt32),
+          .load32 (1049096 : UInt32),
           .localSet 6,
           .localGet 6,
           .const (4294967295 : UInt32),
@@ -537,9 +487,9 @@ def func18 : Wasm.Program :=
           .localGet 6,
           .const (1 : UInt32),
           .add,
-          .store32 (1049088 : UInt32),
+          .store32 (1049096 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049092 : UInt32),
+          .load32 (1049100 : UInt32),
           .eqz,
           .br_if 1,
           .localGet 5,
@@ -563,12 +513,12 @@ def func18 : Wasm.Program :=
           .load64 (8 : UInt32),
           .store64 (16 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049092 : UInt32),
+          .load32 (1049100 : UInt32),
           .localGet 5,
           .const (16 : UInt32),
           .add,
           .const (0 : UInt32),
-          .load32 (1049096 : UInt32),
+          .load32 (1049104 : UInt32),
           .load32 (20 : UInt32),
           .callIndirect 0 0,
           .br 2
@@ -582,54 +532,54 @@ def func18 : Wasm.Program :=
       ],
       .const (2147483648 : UInt32),
       .localGet 5,
-      .call 10
+      .call 8
     ],
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049088 : UInt32),
+    .load32 (1049096 : UInt32),
     .const (4294967295 : UInt32),
     .add,
-    .store32 (1049088 : UInt32),
+    .store32 (1049096 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .store8 (1049080 : UInt32),
+    .store8 (1049088 : UInt32),
     .localGet 3,
     .eqz,
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 20,
+    .call 18,
     .unreachable
   ],
   .unreachable
 ]
 
-def func18Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func18, results := [] }
+def func16Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func16, results := [] }
 
-def func19 : Wasm.Program :=
+def func17 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .const (1 : UInt32),
-  .store8 (1049556 : UInt32)
+  .store8 (1049564 : UInt32)
 ]
 
-def func19Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func19, results := [] }
+def func17Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func17, results := [] }
 
-def func20 : Wasm.Program :=
+def func18 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 8,
+  .call 6,
   .drop,
   .unreachable
 ]
 
-def func20Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func20, results := [] }
+def func18Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func18, results := [] }
 
-def func21 : Wasm.Program :=
+def func19 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -638,17 +588,17 @@ def func21 : Wasm.Program :=
     .br_if 0,
     .localGet 1,
     .localGet 0,
-    .call 22,
+    .call 20,
     .ret
   ],
   .localGet 0,
-  .call 23
+  .call 21
 ]
 
-def func21Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func21, results := [.i32] }
+def func19Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func19, results := [.i32] }
 
-def func22 : Wasm.Program :=
+def func20 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -682,7 +632,7 @@ def func22 : Wasm.Program :=
     .add,
     .const (12 : UInt32),
     .add,
-    .call 23,
+    .call 21,
     .localSet 1,
     .localGet 1,
     .eqz,
@@ -791,7 +741,7 @@ def func22 : Wasm.Program :=
         .store32 (4 : UInt32),
         .localGet 2,
         .localGet 1,
-        .call 29,
+        .call 27,
         .br 1
       ],
       .localGet 2,
@@ -859,7 +809,7 @@ def func22 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 1,
       .localGet 3,
-      .call 29
+      .call 27
     ],
     .localGet 0,
     .const (8 : UInt32),
@@ -869,10 +819,10 @@ def func22 : Wasm.Program :=
   .localGet 2
 ]
 
-def func22Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func22, results := [.i32] }
+def func20Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func20, results := [.i32] }
 
-def func23 : Wasm.Program :=
+def func21 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -906,7 +856,7 @@ def func23 : Wasm.Program :=
           .and,
           .localSet 3,
           .const (0 : UInt32),
-          .load32 (1049516 : UInt32),
+          .load32 (1049524 : UInt32),
           .localSet 4,
           .localGet 4,
           .eqz,
@@ -945,7 +895,7 @@ def func23 : Wasm.Program :=
                 .block 0 0 [
                   .block 0 0 [
                     .const (0 : UInt32),
-                    .load32 (1049512 : UInt32),
+                    .load32 (1049520 : UInt32),
                     .localSet 6,
                     .localGet 6,
                     .const (16 : UInt32),
@@ -984,12 +934,12 @@ def func23 : Wasm.Program :=
                     .shl,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049248 : UInt32),
+                    .const (1049256 : UInt32),
                     .add,
                     .localSet 0,
                     .localGet 0,
                     .localGet 3,
-                    .const (1049256 : UInt32),
+                    .const (1049264 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 2,
@@ -1009,13 +959,13 @@ def func23 : Wasm.Program :=
                   ],
                   .localGet 3,
                   .const (0 : UInt32),
-                  .load32 (1049520 : UInt32),
+                  .load32 (1049528 : UInt32),
                   .leU,
                   .br_if 6,
                   .localGet 0,
                   .br_if 2,
                   .const (0 : UInt32),
-                  .load32 (1049516 : UInt32),
+                  .load32 (1049524 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .eqz,
@@ -1024,7 +974,7 @@ def func23 : Wasm.Program :=
                   .ctz,
                   .const (2 : UInt32),
                   .shl,
-                  .const (1049104 : UInt32),
+                  .const (1049112 : UInt32),
                   .add,
                   .load32 (0 : UInt32),
                   .localSet 8,
@@ -1141,7 +1091,7 @@ def func23 : Wasm.Program :=
                           .load32 (28 : UInt32),
                           .const (2 : UInt32),
                           .shl,
-                          .const (1049104 : UInt32),
+                          .const (1049112 : UInt32),
                           .add,
                           .localSet 8,
                           .localGet 8,
@@ -1238,7 +1188,7 @@ def func23 : Wasm.Program :=
                 .localGet 7,
                 .rotl,
                 .and,
-                .store32 (1049512 : UInt32)
+                .store32 (1049520 : UInt32)
               ],
               .localGet 2,
               .const (8 : UInt32),
@@ -1283,12 +1233,12 @@ def func23 : Wasm.Program :=
                 .shl,
                 .localSet 2,
                 .localGet 2,
-                .const (1049248 : UInt32),
+                .const (1049256 : UInt32),
                 .add,
                 .localSet 8,
                 .localGet 8,
                 .localGet 2,
-                .const (1049256 : UInt32),
+                .const (1049264 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 0,
@@ -1312,7 +1262,7 @@ def func23 : Wasm.Program :=
               .localGet 9,
               .rotl,
               .and,
-              .store32 (1049512 : UInt32)
+              .store32 (1049520 : UInt32)
             ],
             .localGet 0,
             .localGet 3,
@@ -1339,18 +1289,18 @@ def func23 : Wasm.Program :=
             .store32 (0 : UInt32),
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049520 : UInt32),
+              .load32 (1049528 : UInt32),
               .localSet 2,
               .localGet 2,
               .eqz,
               .br_if 0,
               .const (0 : UInt32),
-              .load32 (1049528 : UInt32),
+              .load32 (1049536 : UInt32),
               .localSet 3,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049512 : UInt32),
+                  .load32 (1049520 : UInt32),
                   .localSet 7,
                   .localGet 7,
                   .const (1 : UInt32),
@@ -1366,11 +1316,11 @@ def func23 : Wasm.Program :=
                   .localGet 7,
                   .localGet 9,
                   .or,
-                  .store32 (1049512 : UInt32),
+                  .store32 (1049520 : UInt32),
                   .localGet 2,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049248 : UInt32),
+                  .const (1049256 : UInt32),
                   .add,
                   .localSet 2,
                   .localGet 2,
@@ -1382,11 +1332,11 @@ def func23 : Wasm.Program :=
                 .and,
                 .localSet 2,
                 .localGet 2,
-                .const (1049248 : UInt32),
+                .const (1049256 : UInt32),
                 .add,
                 .localSet 7,
                 .localGet 2,
-                .const (1049256 : UInt32),
+                .const (1049264 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 2
@@ -1410,21 +1360,21 @@ def func23 : Wasm.Program :=
             .localSet 0,
             .const (0 : UInt32),
             .localGet 6,
-            .store32 (1049528 : UInt32),
+            .store32 (1049536 : UInt32),
             .const (0 : UInt32),
             .localGet 8,
-            .store32 (1049520 : UInt32),
+            .store32 (1049528 : UInt32),
             .br 4
           ],
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049516 : UInt32),
+          .load32 (1049524 : UInt32),
           .const (4294967294 : UInt32),
           .localGet 6,
           .load32 (28 : UInt32),
           .rotl,
           .and,
-          .store32 (1049516 : UInt32)
+          .store32 (1049524 : UInt32)
         ],
         .block 0 0 [
           .block 0 0 [
@@ -1453,18 +1403,18 @@ def func23 : Wasm.Program :=
               .localGet 2,
               .store32 (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049520 : UInt32),
+              .load32 (1049528 : UInt32),
               .localSet 7,
               .localGet 7,
               .eqz,
               .br_if 1,
               .const (0 : UInt32),
-              .load32 (1049528 : UInt32),
+              .load32 (1049536 : UInt32),
               .localSet 0,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049512 : UInt32),
+                  .load32 (1049520 : UInt32),
                   .localSet 9,
                   .localGet 9,
                   .const (1 : UInt32),
@@ -1480,11 +1430,11 @@ def func23 : Wasm.Program :=
                   .localGet 9,
                   .localGet 5,
                   .or,
-                  .store32 (1049512 : UInt32),
+                  .store32 (1049520 : UInt32),
                   .localGet 7,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049248 : UInt32),
+                  .const (1049256 : UInt32),
                   .add,
                   .localSet 7,
                   .localGet 7,
@@ -1496,11 +1446,11 @@ def func23 : Wasm.Program :=
                 .and,
                 .localSet 7,
                 .localGet 7,
-                .const (1049248 : UInt32),
+                .const (1049256 : UInt32),
                 .add,
                 .localSet 9,
                 .localGet 7,
-                .const (1049256 : UInt32),
+                .const (1049264 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 7
@@ -1542,10 +1492,10 @@ def func23 : Wasm.Program :=
           ],
           .const (0 : UInt32),
           .localGet 8,
-          .store32 (1049528 : UInt32),
+          .store32 (1049536 : UInt32),
           .const (0 : UInt32),
           .localGet 2,
-          .store32 (1049520 : UInt32)
+          .store32 (1049528 : UInt32)
         ],
         .localGet 6,
         .const (8 : UInt32),
@@ -1567,7 +1517,7 @@ def func23 : Wasm.Program :=
               .localGet 5,
               .const (2 : UInt32),
               .shl,
-              .const (1049104 : UInt32),
+              .const (1049112 : UInt32),
               .add,
               .load32 (0 : UInt32),
               .localSet 6,
@@ -1687,7 +1637,7 @@ def func23 : Wasm.Program :=
             .ctz,
             .const (2 : UInt32),
             .shl,
-            .const (1049104 : UInt32),
+            .const (1049112 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 0
@@ -1755,7 +1705,7 @@ def func23 : Wasm.Program :=
       .br_if 0,
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049520 : UInt32),
+        .load32 (1049528 : UInt32),
         .localSet 0,
         .localGet 0,
         .localGet 3,
@@ -1862,7 +1812,7 @@ def func23 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049104 : UInt32),
+              .const (1049112 : UInt32),
               .add,
               .localSet 6,
               .localGet 6,
@@ -1929,13 +1879,13 @@ def func23 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049516 : UInt32),
+        .load32 (1049524 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 8,
         .load32 (28 : UInt32),
         .rotl,
         .and,
-        .store32 (1049516 : UInt32)
+        .store32 (1049524 : UInt32)
       ],
       .block 0 0 [
         .block 0 0 [
@@ -1969,13 +1919,13 @@ def func23 : Wasm.Program :=
             .br_if 0,
             .localGet 0,
             .localGet 2,
-            .call 33,
+            .call 31,
             .br 2
           ],
           .block 0 0 [
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049512 : UInt32),
+              .load32 (1049520 : UInt32),
               .localSet 6,
               .localGet 6,
               .const (1 : UInt32),
@@ -1991,11 +1941,11 @@ def func23 : Wasm.Program :=
               .localGet 6,
               .localGet 7,
               .or,
-              .store32 (1049512 : UInt32),
+              .store32 (1049520 : UInt32),
               .localGet 2,
               .const (248 : UInt32),
               .and,
-              .const (1049248 : UInt32),
+              .const (1049256 : UInt32),
               .add,
               .localSet 2,
               .localGet 2,
@@ -2007,11 +1957,11 @@ def func23 : Wasm.Program :=
             .and,
             .localSet 2,
             .localGet 2,
-            .const (1049248 : UInt32),
+            .const (1049256 : UInt32),
             .add,
             .localSet 6,
             .localGet 2,
-            .const (1049256 : UInt32),
+            .const (1049264 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 2
@@ -2064,7 +2014,7 @@ def func23 : Wasm.Program :=
             .block 0 0 [
               .block 0 0 [
                 .const (0 : UInt32),
-                .load32 (1049520 : UInt32),
+                .load32 (1049528 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
@@ -2072,7 +2022,7 @@ def func23 : Wasm.Program :=
                 .br_if 0,
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049524 : UInt32),
+                  .load32 (1049532 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 3,
@@ -2081,13 +2031,13 @@ def func23 : Wasm.Program :=
                   .localGet 1,
                   .const (4 : UInt32),
                   .add,
-                  .const (1049556 : UInt32),
+                  .const (1049564 : UInt32),
                   .localGet 3,
                   .const (65583 : UInt32),
                   .add,
                   .const (4294901760 : UInt32),
                   .and,
-                  .call 48,
+                  .call 46,
                   .block 0 0 [
                     .localGet 1,
                     .load32 (4 : UInt32),
@@ -2103,7 +2053,7 @@ def func23 : Wasm.Program :=
                   .localSet 5,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049536 : UInt32),
+                  .load32 (1049544 : UInt32),
                   .localGet 1,
                   .load32 (8 : UInt32),
                   .localSet 9,
@@ -2111,28 +2061,28 @@ def func23 : Wasm.Program :=
                   .add,
                   .localSet 0,
                   .localGet 0,
-                  .store32 (1049536 : UInt32),
+                  .store32 (1049544 : UInt32),
                   .const (0 : UInt32),
                   .localGet 0,
                   .const (0 : UInt32),
-                  .load32 (1049540 : UInt32),
+                  .load32 (1049548 : UInt32),
                   .localSet 2,
                   .localGet 2,
                   .localGet 0,
                   .localGet 2,
                   .gtU,
                   .select,
-                  .store32 (1049540 : UInt32),
+                  .store32 (1049548 : UInt32),
                   .block 0 0 [
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049532 : UInt32),
+                        .load32 (1049540 : UInt32),
                         .localSet 2,
                         .localGet 2,
                         .eqz,
                         .br_if 0,
-                        .const (1049232 : UInt32),
+                        .const (1049240 : UInt32),
                         .localSet 0,
                         .loop 0 0 [
                           .localGet 6,
@@ -2158,7 +2108,7 @@ def func23 : Wasm.Program :=
                       .block 0 0 [
                         .block 0 0 [
                           .const (0 : UInt32),
-                          .load32 (1049548 : UInt32),
+                          .load32 (1049556 : UInt32),
                           .localSet 0,
                           .localGet 0,
                           .eqz,
@@ -2170,29 +2120,23 @@ def func23 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049548 : UInt32)
+                        .store32 (1049556 : UInt32)
                       ],
                       .const (0 : UInt32),
                       .const (4095 : UInt32),
-                      .store32 (1049552 : UInt32),
+                      .store32 (1049560 : UInt32),
                       .const (0 : UInt32),
                       .localGet 5,
-                      .store32 (1049244 : UInt32),
+                      .store32 (1049252 : UInt32),
                       .const (0 : UInt32),
                       .localGet 9,
-                      .store32 (1049236 : UInt32),
+                      .store32 (1049244 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
-                      .store32 (1049232 : UInt32),
-                      .const (0 : UInt32),
-                      .const (1049248 : UInt32),
-                      .store32 (1049260 : UInt32),
+                      .store32 (1049240 : UInt32),
                       .const (0 : UInt32),
                       .const (1049256 : UInt32),
                       .store32 (1049268 : UInt32),
-                      .const (0 : UInt32),
-                      .const (1049248 : UInt32),
-                      .store32 (1049256 : UInt32),
                       .const (0 : UInt32),
                       .const (1049264 : UInt32),
                       .store32 (1049276 : UInt32),
@@ -2236,11 +2180,11 @@ def func23 : Wasm.Program :=
                       .const (1049304 : UInt32),
                       .store32 (1049312 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049312 : UInt32),
-                      .store32 (1049320 : UInt32),
-                      .const (0 : UInt32),
                       .const (1049320 : UInt32),
                       .store32 (1049332 : UInt32),
+                      .const (0 : UInt32),
+                      .const (1049312 : UInt32),
+                      .store32 (1049320 : UInt32),
                       .const (0 : UInt32),
                       .const (1049320 : UInt32),
                       .store32 (1049328 : UInt32),
@@ -2284,11 +2228,11 @@ def func23 : Wasm.Program :=
                       .const (1049376 : UInt32),
                       .store32 (1049388 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049384 : UInt32),
-                      .store32 (1049396 : UInt32),
-                      .const (0 : UInt32),
                       .const (1049376 : UInt32),
                       .store32 (1049384 : UInt32),
+                      .const (0 : UInt32),
+                      .const (1049384 : UInt32),
+                      .store32 (1049396 : UInt32),
                       .const (0 : UInt32),
                       .const (1049392 : UInt32),
                       .store32 (1049404 : UInt32),
@@ -2374,6 +2318,12 @@ def func23 : Wasm.Program :=
                       .const (1049488 : UInt32),
                       .store32 (1049496 : UInt32),
                       .const (0 : UInt32),
+                      .const (1049504 : UInt32),
+                      .store32 (1049516 : UInt32),
+                      .const (0 : UInt32),
+                      .const (1049496 : UInt32),
+                      .store32 (1049504 : UInt32),
+                      .const (0 : UInt32),
                       .localGet 6,
                       .const (15 : UInt32),
                       .add,
@@ -2385,10 +2335,10 @@ def func23 : Wasm.Program :=
                       .add,
                       .localSet 2,
                       .localGet 2,
-                      .store32 (1049532 : UInt32),
+                      .store32 (1049540 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049496 : UInt32),
-                      .store32 (1049504 : UInt32),
+                      .const (1049504 : UInt32),
+                      .store32 (1049512 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
                       .localGet 0,
@@ -2403,7 +2353,7 @@ def func23 : Wasm.Program :=
                       .add,
                       .localSet 8,
                       .localGet 8,
-                      .store32 (1049524 : UInt32),
+                      .store32 (1049532 : UInt32),
                       .localGet 2,
                       .localGet 8,
                       .const (1 : UInt32),
@@ -2416,7 +2366,7 @@ def func23 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .const (0 : UInt32),
                       .const (2097152 : UInt32),
-                      .store32 (1049544 : UInt32),
+                      .store32 (1049552 : UInt32),
                       .br 8
                     ],
                     .localGet 2,
@@ -2443,7 +2393,7 @@ def func23 : Wasm.Program :=
                   ],
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049548 : UInt32),
+                  .load32 (1049556 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 6,
@@ -2451,12 +2401,12 @@ def func23 : Wasm.Program :=
                   .localGet 6,
                   .ltU,
                   .select,
-                  .store32 (1049548 : UInt32),
+                  .store32 (1049556 : UInt32),
                   .localGet 6,
                   .localGet 9,
                   .add,
                   .localSet 8,
-                  .const (1049232 : UInt32),
+                  .const (1049240 : UInt32),
                   .localSet 0,
                   .block 0 0 [
                     .block 0 0 [
@@ -2491,7 +2441,7 @@ def func23 : Wasm.Program :=
                       .eq,
                       .br_if 1
                     ],
-                    .const (1049232 : UInt32),
+                    .const (1049240 : UInt32),
                     .localSet 0,
                     .block 0 0 [
                       .loop 0 0 [
@@ -2531,7 +2481,7 @@ def func23 : Wasm.Program :=
                     .add,
                     .localSet 7,
                     .localGet 7,
-                    .store32 (1049532 : UInt32),
+                    .store32 (1049540 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
                     .localGet 0,
@@ -2546,7 +2496,7 @@ def func23 : Wasm.Program :=
                     .add,
                     .localSet 4,
                     .localGet 4,
-                    .store32 (1049524 : UInt32),
+                    .store32 (1049532 : UInt32),
                     .localGet 7,
                     .localGet 4,
                     .const (1 : UInt32),
@@ -2559,7 +2509,7 @@ def func23 : Wasm.Program :=
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
                     .const (2097152 : UInt32),
-                    .store32 (1049544 : UInt32),
+                    .store32 (1049552 : UInt32),
                     .localGet 2,
                     .localGet 8,
                     .const (4294967264 : UInt32),
@@ -2581,13 +2531,13 @@ def func23 : Wasm.Program :=
                     .const (27 : UInt32),
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
-                    .load64 (1049232 : UInt32),
+                    .load64 (1049240 : UInt32),
                     .localSet 10,
                     .localGet 7,
                     .const (16 : UInt32),
                     .add,
                     .const (0 : UInt32),
-                    .load64 (1049240 : UInt32),
+                    .load64 (1049248 : UInt32),
                     .store64 (0 : UInt32),
                     .localGet 7,
                     .const (8 : UInt32),
@@ -2598,16 +2548,16 @@ def func23 : Wasm.Program :=
                     .store64 (0 : UInt32),
                     .const (0 : UInt32),
                     .localGet 5,
-                    .store32 (1049244 : UInt32),
+                    .store32 (1049252 : UInt32),
                     .const (0 : UInt32),
                     .localGet 9,
-                    .store32 (1049236 : UInt32),
+                    .store32 (1049244 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
-                    .store32 (1049232 : UInt32),
+                    .store32 (1049240 : UInt32),
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049240 : UInt32),
+                    .store32 (1049248 : UInt32),
                     .localGet 7,
                     .const (28 : UInt32),
                     .add,
@@ -2654,13 +2604,13 @@ def func23 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 0,
-                      .call 33,
+                      .call 31,
                       .br 8
                     ],
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049512 : UInt32),
+                        .load32 (1049520 : UInt32),
                         .localSet 8,
                         .localGet 8,
                         .const (1 : UInt32),
@@ -2676,11 +2626,11 @@ def func23 : Wasm.Program :=
                         .localGet 8,
                         .localGet 6,
                         .or,
-                        .store32 (1049512 : UInt32),
+                        .store32 (1049520 : UInt32),
                         .localGet 0,
                         .const (248 : UInt32),
                         .and,
-                        .const (1049248 : UInt32),
+                        .const (1049256 : UInt32),
                         .add,
                         .localSet 0,
                         .localGet 0,
@@ -2692,11 +2642,11 @@ def func23 : Wasm.Program :=
                       .and,
                       .localSet 0,
                       .localGet 0,
-                      .const (1049248 : UInt32),
+                      .const (1049256 : UInt32),
                       .add,
                       .localSet 8,
                       .localGet 0,
-                      .const (1049256 : UInt32),
+                      .const (1049264 : UInt32),
                       .add,
                       .load32 (0 : UInt32),
                       .localSet 0
@@ -2755,12 +2705,12 @@ def func23 : Wasm.Program :=
                   .localSet 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049532 : UInt32),
+                  .load32 (1049540 : UInt32),
                   .eq,
                   .br_if 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049528 : UInt32),
+                  .load32 (1049536 : UInt32),
                   .eq,
                   .br_if 4,
                   .block 0 0 [
@@ -2779,7 +2729,7 @@ def func23 : Wasm.Program :=
                     .and,
                     .localSet 6,
                     .localGet 6,
-                    .call 28,
+                    .call 26,
                     .localGet 6,
                     .localGet 3,
                     .add,
@@ -2814,13 +2764,13 @@ def func23 : Wasm.Program :=
                     .br_if 0,
                     .localGet 0,
                     .localGet 3,
-                    .call 33,
+                    .call 31,
                     .br 6
                   ],
                   .block 0 0 [
                     .block 0 0 [
                       .const (0 : UInt32),
-                      .load32 (1049512 : UInt32),
+                      .load32 (1049520 : UInt32),
                       .localSet 2,
                       .localGet 2,
                       .const (1 : UInt32),
@@ -2836,11 +2786,11 @@ def func23 : Wasm.Program :=
                       .localGet 2,
                       .localGet 6,
                       .or,
-                      .store32 (1049512 : UInt32),
+                      .store32 (1049520 : UInt32),
                       .localGet 3,
                       .const (248 : UInt32),
                       .and,
-                      .const (1049248 : UInt32),
+                      .const (1049256 : UInt32),
                       .add,
                       .localSet 3,
                       .localGet 3,
@@ -2852,11 +2802,11 @@ def func23 : Wasm.Program :=
                     .and,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049248 : UInt32),
+                    .const (1049256 : UInt32),
                     .add,
                     .localSet 2,
                     .localGet 3,
-                    .const (1049256 : UInt32),
+                    .const (1049264 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 3
@@ -2881,17 +2831,17 @@ def func23 : Wasm.Program :=
                 .sub,
                 .localSet 2,
                 .localGet 2,
-                .store32 (1049524 : UInt32),
+                .store32 (1049532 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049532 : UInt32),
+                .load32 (1049540 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
                 .add,
                 .localSet 8,
                 .localGet 8,
-                .store32 (1049532 : UInt32),
+                .store32 (1049540 : UInt32),
                 .localGet 8,
                 .localGet 2,
                 .const (1 : UInt32),
@@ -2909,7 +2859,7 @@ def func23 : Wasm.Program :=
                 .br 6
               ],
               .const (0 : UInt32),
-              .load32 (1049528 : UInt32),
+              .load32 (1049536 : UInt32),
               .localSet 2,
               .block 0 0 [
                 .block 0 0 [
@@ -2923,10 +2873,10 @@ def func23 : Wasm.Program :=
                   .br_if 0,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
+                  .store32 (1049536 : UInt32),
+                  .const (0 : UInt32),
+                  .const (0 : UInt32),
                   .store32 (1049528 : UInt32),
-                  .const (0 : UInt32),
-                  .const (0 : UInt32),
-                  .store32 (1049520 : UInt32),
                   .localGet 2,
                   .localGet 0,
                   .const (3 : UInt32),
@@ -2946,14 +2896,14 @@ def func23 : Wasm.Program :=
                 ],
                 .const (0 : UInt32),
                 .localGet 8,
-                .store32 (1049520 : UInt32),
+                .store32 (1049528 : UInt32),
                 .const (0 : UInt32),
                 .localGet 2,
                 .localGet 3,
                 .add,
                 .localSet 6,
                 .localGet 6,
-                .store32 (1049528 : UInt32),
+                .store32 (1049536 : UInt32),
                 .localGet 6,
                 .localGet 8,
                 .const (1 : UInt32),
@@ -2983,7 +2933,7 @@ def func23 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049532 : UInt32),
+            .load32 (1049540 : UInt32),
             .localSet 0,
             .localGet 0,
             .const (15 : UInt32),
@@ -2996,13 +2946,13 @@ def func23 : Wasm.Program :=
             .add,
             .localSet 8,
             .localGet 8,
-            .store32 (1049532 : UInt32),
+            .store32 (1049540 : UInt32),
             .const (0 : UInt32),
             .localGet 0,
             .localGet 2,
             .sub,
             .const (0 : UInt32),
-            .load32 (1049524 : UInt32),
+            .load32 (1049532 : UInt32),
             .localGet 9,
             .add,
             .localSet 2,
@@ -3012,7 +2962,7 @@ def func23 : Wasm.Program :=
             .add,
             .localSet 6,
             .localGet 6,
-            .store32 (1049524 : UInt32),
+            .store32 (1049532 : UInt32),
             .localGet 8,
             .localGet 6,
             .const (1 : UInt32),
@@ -3025,20 +2975,20 @@ def func23 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (2097152 : UInt32),
-            .store32 (1049544 : UInt32),
+            .store32 (1049552 : UInt32),
             .br 3
           ],
           .const (0 : UInt32),
           .localGet 0,
-          .store32 (1049532 : UInt32),
+          .store32 (1049540 : UInt32),
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049524 : UInt32),
+          .load32 (1049532 : UInt32),
           .localGet 3,
           .add,
           .localSet 3,
           .localGet 3,
-          .store32 (1049524 : UInt32),
+          .store32 (1049532 : UInt32),
           .localGet 0,
           .localGet 3,
           .const (1 : UInt32),
@@ -3048,15 +2998,15 @@ def func23 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049528 : UInt32),
+        .store32 (1049536 : UInt32),
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049520 : UInt32),
+        .load32 (1049528 : UInt32),
         .localGet 3,
         .add,
         .localSet 3,
         .localGet 3,
-        .store32 (1049520 : UInt32),
+        .store32 (1049528 : UInt32),
         .localGet 0,
         .localGet 3,
         .const (1 : UInt32),
@@ -3077,7 +3027,7 @@ def func23 : Wasm.Program :=
     .const (0 : UInt32),
     .localSet 0,
     .const (0 : UInt32),
-    .load32 (1049524 : UInt32),
+    .load32 (1049532 : UInt32),
     .localSet 2,
     .localGet 2,
     .localGet 3,
@@ -3089,17 +3039,17 @@ def func23 : Wasm.Program :=
     .sub,
     .localSet 2,
     .localGet 2,
-    .store32 (1049524 : UInt32),
+    .store32 (1049532 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049532 : UInt32),
+    .load32 (1049540 : UInt32),
     .localSet 0,
     .localGet 0,
     .localGet 3,
     .add,
     .localSet 8,
     .localGet 8,
-    .store32 (1049532 : UInt32),
+    .store32 (1049540 : UInt32),
     .localGet 8,
     .localGet 2,
     .const (1 : UInt32),
@@ -3122,18 +3072,18 @@ def func23 : Wasm.Program :=
   .localGet 0
 ]
 
-def func23Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func23, results := [.i32] }
+def func21Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func21, results := [.i32] }
 
-def func24 : Wasm.Program :=
+def func22 : Wasm.Program :=
   [
   .unreachable
 ]
 
-def func24Def : Wasm.Function :=
-  { params := [], locals := [], body := func24, results := [] }
+def func22Def : Wasm.Function :=
+  { params := [], locals := [], body := func22, results := [] }
 
-def func25 : Wasm.Program :=
+def func23 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3171,26 +3121,26 @@ def func25 : Wasm.Program :=
         .br_if 2
       ],
       .localGet 0,
-      .call 26,
+      .call 24,
       .ret
     ],
-    .const (1048771 : UInt32),
+    .const (1048779 : UInt32),
     .const (46 : UInt32),
-    .const (1048820 : UInt32),
-    .call 52,
+    .const (1048828 : UInt32),
+    .call 50,
     .unreachable
   ],
-  .const (1048836 : UInt32),
+  .const (1048844 : UInt32),
   .const (46 : UInt32),
-  .const (1048884 : UInt32),
-  .call 52,
+  .const (1048892 : UInt32),
+  .call 50,
   .unreachable
 ]
 
-def func25Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func25, results := [] }
+def func23Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func23, results := [] }
 
-def func26 : Wasm.Program :=
+def func24 : Wasm.Program :=
   [
   .localGet 0,
   .const (4294967288 : UInt32),
@@ -3234,7 +3184,7 @@ def func26 : Wasm.Program :=
         .localSet 1,
         .localGet 1,
         .const (0 : UInt32),
-        .load32 (1049528 : UInt32),
+        .load32 (1049536 : UInt32),
         .ne,
         .br_if 0,
         .localGet 3,
@@ -3246,7 +3196,7 @@ def func26 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049520 : UInt32),
+        .store32 (1049528 : UInt32),
         .localGet 3,
         .localGet 3,
         .load32 (4 : UInt32),
@@ -3265,7 +3215,7 @@ def func26 : Wasm.Program :=
       ],
       .localGet 1,
       .localGet 2,
-      .call 28
+      .call 26
     ],
     .block 0 0 [
       .block 0 0 [
@@ -3284,12 +3234,12 @@ def func26 : Wasm.Program :=
                     .br_if 0,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049532 : UInt32),
+                    .load32 (1049540 : UInt32),
                     .eq,
                     .br_if 2,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049528 : UInt32),
+                    .load32 (1049536 : UInt32),
                     .eq,
                     .br_if 3,
                     .localGet 3,
@@ -3298,7 +3248,7 @@ def func26 : Wasm.Program :=
                     .and,
                     .localSet 2,
                     .localGet 2,
-                    .call 28,
+                    .call 26,
                     .localGet 1,
                     .localGet 2,
                     .localGet 0,
@@ -3315,12 +3265,12 @@ def func26 : Wasm.Program :=
                     .store32 (0 : UInt32),
                     .localGet 1,
                     .const (0 : UInt32),
-                    .load32 (1049528 : UInt32),
+                    .load32 (1049536 : UInt32),
                     .ne,
                     .br_if 1,
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049520 : UInt32),
+                    .store32 (1049528 : UInt32),
                     .ret
                   ],
                   .localGet 3,
@@ -3345,19 +3295,19 @@ def func26 : Wasm.Program :=
                 .br_if 4,
                 .localGet 1,
                 .localGet 0,
-                .call 33,
+                .call 31,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049552 : UInt32),
+                .load32 (1049560 : UInt32),
                 .const (4294967295 : UInt32),
                 .add,
                 .localSet 1,
                 .localGet 1,
-                .store32 (1049552 : UInt32),
+                .store32 (1049560 : UInt32),
                 .localGet 1,
                 .br_if 6,
                 .const (0 : UInt32),
-                .load32 (1049240 : UInt32),
+                .load32 (1049248 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .br_if 2,
@@ -3367,15 +3317,15 @@ def func26 : Wasm.Program :=
               ],
               .const (0 : UInt32),
               .localGet 1,
-              .store32 (1049532 : UInt32),
+              .store32 (1049540 : UInt32),
               .const (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049524 : UInt32),
+              .load32 (1049532 : UInt32),
               .localGet 0,
               .add,
               .localSet 0,
               .localGet 0,
-              .store32 (1049524 : UInt32),
+              .store32 (1049532 : UInt32),
               .localGet 1,
               .localGet 0,
               .const (1 : UInt32),
@@ -3384,37 +3334,37 @@ def func26 : Wasm.Program :=
               .block 0 0 [
                 .localGet 1,
                 .const (0 : UInt32),
-                .load32 (1049528 : UInt32),
+                .load32 (1049536 : UInt32),
                 .ne,
                 .br_if 0,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049520 : UInt32),
+                .store32 (1049528 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049528 : UInt32)
+                .store32 (1049536 : UInt32)
               ],
               .localGet 0,
               .const (0 : UInt32),
-              .load32 (1049544 : UInt32),
+              .load32 (1049552 : UInt32),
               .localSet 2,
               .localGet 2,
               .leU,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049532 : UInt32),
+              .load32 (1049540 : UInt32),
               .localSet 0,
               .localGet 0,
               .eqz,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049524 : UInt32),
+              .load32 (1049532 : UInt32),
               .localSet 4,
               .localGet 4,
               .const (41 : UInt32),
               .ltU,
               .br_if 4,
-              .const (1049232 : UInt32),
+              .const (1049240 : UInt32),
               .localSet 1,
               .loop 0 0 [
                 .block 0 0 [
@@ -3441,15 +3391,15 @@ def func26 : Wasm.Program :=
             ],
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049528 : UInt32),
+            .store32 (1049536 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049520 : UInt32),
+            .load32 (1049528 : UInt32),
             .localGet 0,
             .add,
             .localSet 0,
             .localGet 0,
-            .store32 (1049520 : UInt32),
+            .store32 (1049528 : UInt32),
             .localGet 1,
             .localGet 0,
             .const (1 : UInt32),
@@ -3485,13 +3435,13 @@ def func26 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049552 : UInt32),
+        .store32 (1049560 : UInt32),
         .ret
       ],
       .block 0 0 [
         .block 0 0 [
           .const (0 : UInt32),
-          .load32 (1049512 : UInt32),
+          .load32 (1049520 : UInt32),
           .localSet 3,
           .localGet 3,
           .const (1 : UInt32),
@@ -3507,11 +3457,11 @@ def func26 : Wasm.Program :=
           .localGet 3,
           .localGet 2,
           .or,
-          .store32 (1049512 : UInt32),
+          .store32 (1049520 : UInt32),
           .localGet 0,
           .const (248 : UInt32),
           .and,
-          .const (1049248 : UInt32),
+          .const (1049256 : UInt32),
           .add,
           .localSet 0,
           .localGet 0,
@@ -3523,11 +3473,11 @@ def func26 : Wasm.Program :=
         .and,
         .localSet 0,
         .localGet 0,
-        .const (1049248 : UInt32),
+        .const (1049256 : UInt32),
         .add,
         .localSet 3,
         .localGet 0,
-        .const (1049256 : UInt32),
+        .const (1049264 : UInt32),
         .add,
         .load32 (0 : UInt32),
         .localSet 0
@@ -3549,7 +3499,7 @@ def func26 : Wasm.Program :=
     .block 0 0 [
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049240 : UInt32),
+        .load32 (1049248 : UInt32),
         .localSet 0,
         .localGet 0,
         .br_if 0,
@@ -3580,21 +3530,21 @@ def func26 : Wasm.Program :=
     ],
     .const (0 : UInt32),
     .localGet 1,
-    .store32 (1049552 : UInt32),
+    .store32 (1049560 : UInt32),
     .localGet 4,
     .localGet 2,
     .leU,
     .br_if 0,
     .const (0 : UInt32),
     .const (4294967295 : UInt32),
-    .store32 (1049544 : UInt32)
+    .store32 (1049552 : UInt32)
   ]
 ]
 
-def func26Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func26, results := [] }
+def func24Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func24, results := [] }
 
-def func27 : Wasm.Program :=
+def func25 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3649,7 +3599,7 @@ def func27 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 3,
-                      .call 22,
+                      .call 20,
                       .localSet 2,
                       .localGet 2,
                       .br_if 1,
@@ -3712,13 +3662,13 @@ def func27 : Wasm.Program :=
                         .br_if 0,
                         .localGet 7,
                         .const (0 : UInt32),
-                        .load32 (1049532 : UInt32),
+                        .load32 (1049540 : UInt32),
                         .eq,
                         .br_if 1,
                         .block 0 0 [
                           .localGet 7,
                           .const (0 : UInt32),
-                          .load32 (1049528 : UInt32),
+                          .load32 (1049536 : UInt32),
                           .eq,
                           .br_if 0,
                           .localGet 7,
@@ -3742,7 +3692,7 @@ def func27 : Wasm.Program :=
                           .br_if 9,
                           .localGet 7,
                           .localGet 9,
-                          .call 28,
+                          .call 26,
                           .block 0 0 [
                             .localGet 5,
                             .localGet 1,
@@ -3783,7 +3733,7 @@ def func27 : Wasm.Program :=
                             .store32 (4 : UInt32),
                             .localGet 1,
                             .localGet 7,
-                            .call 29,
+                            .call 27,
                             .br 9
                           ],
                           .localGet 4,
@@ -3809,7 +3759,7 @@ def func27 : Wasm.Program :=
                           .br 8
                         ],
                         .const (0 : UInt32),
-                        .load32 (1049520 : UInt32),
+                        .load32 (1049528 : UInt32),
                         .localGet 6,
                         .add,
                         .localSet 7,
@@ -3886,10 +3836,10 @@ def func27 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 1,
-                        .store32 (1049528 : UInt32),
+                        .store32 (1049536 : UInt32),
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049520 : UInt32),
+                        .store32 (1049528 : UInt32),
                         .br 7
                       ],
                       .localGet 6,
@@ -3926,11 +3876,11 @@ def func27 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .localGet 1,
                       .localGet 6,
-                      .call 29,
+                      .call 27,
                       .br 6
                     ],
                     .const (0 : UInt32),
-                    .load32 (1049524 : UInt32),
+                    .load32 (1049532 : UInt32),
                     .localGet 6,
                     .add,
                     .localSet 7,
@@ -3983,28 +3933,28 @@ def func27 : Wasm.Program :=
                   .localGet 8,
                   .leU,
                   .br_if 6,
-                  .const (1048836 : UInt32),
+                  .const (1048844 : UInt32),
                   .const (46 : UInt32),
-                  .const (1048884 : UInt32),
-                  .call 52,
+                  .const (1048892 : UInt32),
+                  .call 50,
                   .unreachable
                 ],
-                .const (1048771 : UInt32),
+                .const (1048779 : UInt32),
                 .const (46 : UInt32),
-                .const (1048820 : UInt32),
-                .call 52,
+                .const (1048828 : UInt32),
+                .call 50,
                 .unreachable
               ],
-              .const (1048836 : UInt32),
+              .const (1048844 : UInt32),
               .const (46 : UInt32),
-              .const (1048884 : UInt32),
-              .call 52,
+              .const (1048892 : UInt32),
+              .call 50,
               .unreachable
             ],
-            .const (1048771 : UInt32),
+            .const (1048779 : UInt32),
             .const (46 : UInt32),
-            .const (1048820 : UInt32),
-            .call 52,
+            .const (1048828 : UInt32),
+            .call 50,
             .unreachable
           ],
           .localGet 4,
@@ -4031,10 +3981,10 @@ def func27 : Wasm.Program :=
           .store32 (4 : UInt32),
           .const (0 : UInt32),
           .localGet 1,
-          .store32 (1049524 : UInt32),
+          .store32 (1049532 : UInt32),
           .const (0 : UInt32),
           .localGet 5,
-          .store32 (1049532 : UInt32)
+          .store32 (1049540 : UInt32)
         ],
         .localGet 8,
         .eqz,
@@ -4043,7 +3993,7 @@ def func27 : Wasm.Program :=
         .ret
       ],
       .localGet 3,
-      .call 23,
+      .call 21,
       .localSet 1,
       .localGet 1,
       .eqz,
@@ -4082,15 +4032,15 @@ def func27 : Wasm.Program :=
       .localSet 2
     ],
     .localGet 0,
-    .call 26
+    .call 24
   ],
   .localGet 2
 ]
 
-def func27Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func27, results := [.i32] }
+def func25Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func25, results := [.i32] }
 
-def func28 : Wasm.Program :=
+def func26 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (12 : UInt32),
@@ -4192,7 +4142,7 @@ def func28 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049104 : UInt32),
+              .const (1049112 : UInt32),
               .add,
               .localSet 1,
               .localGet 1,
@@ -4244,14 +4194,14 @@ def func28 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049512 : UInt32),
+        .load32 (1049520 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 1,
         .const (3 : UInt32),
         .shrU,
         .rotl,
         .and,
-        .store32 (1049512 : UInt32),
+        .store32 (1049520 : UInt32),
         .ret
       ],
       .localGet 2,
@@ -4289,19 +4239,19 @@ def func28 : Wasm.Program :=
   ],
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049516 : UInt32),
+  .load32 (1049524 : UInt32),
   .const (4294967294 : UInt32),
   .localGet 0,
   .load32 (28 : UInt32),
   .rotl,
   .and,
-  .store32 (1049516 : UInt32)
+  .store32 (1049524 : UInt32)
 ]
 
-def func28Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func28, results := [] }
+def func26Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func26, results := [] }
 
-def func29 : Wasm.Program :=
+def func27 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4335,7 +4285,7 @@ def func29 : Wasm.Program :=
         .localSet 0,
         .localGet 0,
         .const (0 : UInt32),
-        .load32 (1049528 : UInt32),
+        .load32 (1049536 : UInt32),
         .ne,
         .br_if 0,
         .localGet 2,
@@ -4347,7 +4297,7 @@ def func29 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049520 : UInt32),
+        .store32 (1049528 : UInt32),
         .localGet 2,
         .localGet 2,
         .load32 (4 : UInt32),
@@ -4366,7 +4316,7 @@ def func29 : Wasm.Program :=
       ],
       .localGet 0,
       .localGet 3,
-      .call 28
+      .call 26
     ],
     .block 0 0 [
       .block 0 0 [
@@ -4381,12 +4331,12 @@ def func29 : Wasm.Program :=
             .br_if 0,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049532 : UInt32),
+            .load32 (1049540 : UInt32),
             .eq,
             .br_if 2,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049528 : UInt32),
+            .load32 (1049536 : UInt32),
             .eq,
             .br_if 3,
             .localGet 2,
@@ -4395,7 +4345,7 @@ def func29 : Wasm.Program :=
             .and,
             .localSet 3,
             .localGet 3,
-            .call 28,
+            .call 26,
             .localGet 0,
             .localGet 3,
             .localGet 1,
@@ -4412,12 +4362,12 @@ def func29 : Wasm.Program :=
             .store32 (0 : UInt32),
             .localGet 0,
             .const (0 : UInt32),
-            .load32 (1049528 : UInt32),
+            .load32 (1049536 : UInt32),
             .ne,
             .br_if 1,
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049520 : UInt32),
+            .store32 (1049528 : UInt32),
             .ret
           ],
           .localGet 2,
@@ -4443,13 +4393,13 @@ def func29 : Wasm.Program :=
           .br_if 0,
           .localGet 0,
           .localGet 1,
-          .call 33,
+          .call 31,
           .ret
         ],
         .block 0 0 [
           .block 0 0 [
             .const (0 : UInt32),
-            .load32 (1049512 : UInt32),
+            .load32 (1049520 : UInt32),
             .localSet 2,
             .localGet 2,
             .const (1 : UInt32),
@@ -4465,11 +4415,11 @@ def func29 : Wasm.Program :=
             .localGet 2,
             .localGet 3,
             .or,
-            .store32 (1049512 : UInt32),
+            .store32 (1049520 : UInt32),
             .localGet 1,
             .const (248 : UInt32),
             .and,
-            .const (1049248 : UInt32),
+            .const (1049256 : UInt32),
             .add,
             .localSet 1,
             .localGet 1,
@@ -4481,11 +4431,11 @@ def func29 : Wasm.Program :=
           .and,
           .localSet 1,
           .localGet 1,
-          .const (1049248 : UInt32),
+          .const (1049256 : UInt32),
           .add,
           .localSet 2,
           .localGet 1,
-          .const (1049256 : UInt32),
+          .const (1049264 : UInt32),
           .add,
           .load32 (0 : UInt32),
           .localSet 1
@@ -4506,15 +4456,15 @@ def func29 : Wasm.Program :=
       ],
       .const (0 : UInt32),
       .localGet 0,
-      .store32 (1049532 : UInt32),
+      .store32 (1049540 : UInt32),
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .load32 (1049524 : UInt32),
+      .load32 (1049532 : UInt32),
       .localGet 1,
       .add,
       .localSet 1,
       .localGet 1,
-      .store32 (1049524 : UInt32),
+      .store32 (1049532 : UInt32),
       .localGet 0,
       .localGet 1,
       .const (1 : UInt32),
@@ -4522,28 +4472,28 @@ def func29 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 0,
       .const (0 : UInt32),
-      .load32 (1049528 : UInt32),
+      .load32 (1049536 : UInt32),
       .ne,
       .br_if 1,
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .store32 (1049520 : UInt32),
-      .const (0 : UInt32),
-      .const (0 : UInt32),
       .store32 (1049528 : UInt32),
+      .const (0 : UInt32),
+      .const (0 : UInt32),
+      .store32 (1049536 : UInt32),
       .ret
     ],
     .const (0 : UInt32),
     .localGet 0,
-    .store32 (1049528 : UInt32),
+    .store32 (1049536 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049520 : UInt32),
+    .load32 (1049528 : UInt32),
     .localGet 1,
     .add,
     .localSet 1,
     .localGet 1,
-    .store32 (1049520 : UInt32),
+    .store32 (1049528 : UInt32),
     .localGet 0,
     .localGet 1,
     .const (1 : UInt32),
@@ -4558,10 +4508,10 @@ def func29 : Wasm.Program :=
   ]
 ]
 
-def func29Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func29, results := [] }
+def func27Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func27, results := [] }
 
-def func30 : Wasm.Program :=
+def func28 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4581,25 +4531,25 @@ def func30 : Wasm.Program :=
   .localGet 1,
   .const (4 : UInt32),
   .add,
-  .call 15,
+  .call 13,
   .unreachable
 ]
 
-def func30Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i64], body := func30, results := [] }
+def func28Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i64], body := func28, results := [] }
 
-def func31 : Wasm.Program :=
+def func29 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 32,
+  .call 30,
   .unreachable
 ]
 
-def func31Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func31, results := [] }
+def func29Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func29, results := [] }
 
-def func32 : Wasm.Program :=
+def func30 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4616,14 +4566,14 @@ def func32 : Wasm.Program :=
   .localGet 2,
   .const (8 : UInt32),
   .add,
-  .call 13,
+  .call 11,
   .unreachable
 ]
 
-def func32Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32], body := func32, results := [] }
+def func30Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32], body := func30, results := [] }
 
-def func33 : Wasm.Program :=
+def func31 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -4668,12 +4618,12 @@ def func33 : Wasm.Program :=
   .localGet 2,
   .const (2 : UInt32),
   .shl,
-  .const (1049104 : UInt32),
+  .const (1049112 : UInt32),
   .add,
   .localSet 3,
   .block 0 0 [
     .const (0 : UInt32),
-    .load32 (1049516 : UInt32),
+    .load32 (1049524 : UInt32),
     .const (1 : UInt32),
     .localGet 2,
     .shl,
@@ -4695,10 +4645,10 @@ def func33 : Wasm.Program :=
     .store32 (8 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049516 : UInt32),
+    .load32 (1049524 : UInt32),
     .localGet 4,
     .or,
-    .store32 (1049516 : UInt32),
+    .store32 (1049524 : UInt32),
     .ret
   ],
   .block 0 0 [
@@ -4797,21 +4747,21 @@ def func33 : Wasm.Program :=
   .store32 (8 : UInt32)
 ]
 
-def func33Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func33, results := [] }
+def func31Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func31, results := [] }
 
-def func34 : Wasm.Program :=
+def func32 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 1,
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049100 : UInt32),
+  .load32 (1049108 : UInt32),
   .localSet 2,
   .localGet 2,
   .const (1 : UInt32),
   .add,
-  .store32 (1049100 : UInt32),
+  .store32 (1049108 : UInt32),
   .block 0 0 [
     .localGet 2,
     .const (0 : UInt32),
@@ -4820,57 +4770,57 @@ def func34 : Wasm.Program :=
     .const (1 : UInt32),
     .localSet 1,
     .const (0 : UInt32),
-    .load8U (1049080 : UInt32),
+    .load8U (1049088 : UInt32),
     .br_if 0,
     .const (0 : UInt32),
     .localGet 0,
-    .store8 (1049080 : UInt32),
+    .store8 (1049088 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049076 : UInt32),
+    .load32 (1049084 : UInt32),
     .const (1 : UInt32),
     .add,
-    .store32 (1049076 : UInt32),
+    .store32 (1049084 : UInt32),
     .const (2 : UInt32),
     .localSet 1
   ],
   .localGet 1
 ]
 
-def func34Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32], body := func34, results := [.i32] }
+def func32Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32], body := func32, results := [.i32] }
 
-def func35 : Wasm.Program :=
+def func33 : Wasm.Program :=
   [
+  .localGet 0,
+  .const (0 : UInt32),
+  .load64 (1048728 : UInt32),
+  .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
   .load64 (1048720 : UInt32),
-  .store64 (8 : UInt32),
-  .localGet 0,
-  .const (0 : UInt32),
-  .load64 (1048712 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func35Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func35, results := [] }
+def func33Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func33, results := [] }
 
-def func36 : Wasm.Program :=
+def func34 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048704 : UInt32),
+  .load64 (1048712 : UInt32),
   .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048696 : UInt32),
+  .load64 (1048704 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func36Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func36, results := [] }
+def func34Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func34, results := [] }
 
-def func37 : Wasm.Program :=
+def func35 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -4883,7 +4833,7 @@ def func37 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 0,
     .load32 (8 : UInt32),
-    .call 55,
+    .call 53,
     .ret
   ],
   .localGet 1,
@@ -4898,26 +4848,26 @@ def func37 : Wasm.Program :=
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 54
+  .call 52
 ]
 
-def func37Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func37, results := [.i32] }
+def func35Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func35, results := [.i32] }
 
-def func38 : Wasm.Program :=
+def func36 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048900 : UInt32),
+  .const (1048908 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func38Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func38, results := [] }
+def func36Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func36, results := [] }
 
-def func39 : Wasm.Program :=
+def func37 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4925,10 +4875,10 @@ def func39 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func39Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func39, results := [] }
+def func37Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func37, results := [] }
 
-def func40 : Wasm.Program :=
+def func38 : Wasm.Program :=
   [
   .localGet 1,
   .load32 (4 : UInt32),
@@ -4936,17 +4886,17 @@ def func40 : Wasm.Program :=
   .localGet 1,
   .load32 (0 : UInt32),
   .localSet 3,
-  .call 7,
+  .call 5,
   .block 0 0 [
     .const (8 : UInt32),
     .const (4 : UInt32),
-    .call 4,
+    .call 2,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (8 : UInt32),
-    .call 50,
+    .call 48,
     .unreachable
   ],
   .localGet 1,
@@ -4956,30 +4906,30 @@ def func40 : Wasm.Program :=
   .localGet 3,
   .store32 (0 : UInt32),
   .localGet 0,
-  .const (1048900 : UInt32),
+  .const (1048908 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func40Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func40, results := [] }
+def func38Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func38, results := [] }
 
-def func41 : Wasm.Program :=
+def func39 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 55
+  .call 53
 ]
 
-def func41Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func41, results := [.i32] }
+def func39Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func39, results := [.i32] }
 
-def func42 : Wasm.Program :=
+def func40 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (8 : UInt32),
@@ -5026,7 +4976,7 @@ def func42 : Wasm.Program :=
     .localGet 3,
     .const (1 : UInt32),
     .const (1 : UInt32),
-    .call 9,
+    .call 7,
     .localGet 0,
     .load32 (8 : UInt32),
     .localSet 4
@@ -5129,10 +5079,10 @@ def func42 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func42Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func42, results := [.i32] }
+def func40Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func40, results := [.i32] }
 
-def func43 : Wasm.Program :=
+def func41 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5152,7 +5102,7 @@ def func43 : Wasm.Program :=
         .localGet 2,
         .const (1 : UInt32),
         .const (1 : UInt32),
-        .call 9,
+        .call 7,
         .localGet 0,
         .load32 (8 : UInt32),
         .localSet 3,
@@ -5181,10 +5131,10 @@ def func43 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func43Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func43, results := [.i32] }
+def func41Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func41, results := [.i32] }
 
-def func44 : Wasm.Program :=
+def func42 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5210,7 +5160,7 @@ def func44 : Wasm.Program :=
     .localGet 2,
     .const (20 : UInt32),
     .add,
-    .const (1048616 : UInt32),
+    .const (1048624 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5218,7 +5168,7 @@ def func44 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 54,
+    .call 52,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5240,7 +5190,7 @@ def func44 : Wasm.Program :=
     .store64 (0 : UInt32)
   ],
   .localGet 0,
-  .const (1048916 : UInt32),
+  .const (1048924 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5251,10 +5201,10 @@ def func44 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func44Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func44, results := [] }
+def func42Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func42, results := [] }
 
-def func45 : Wasm.Program :=
+def func43 : Wasm.Program :=
   [
   .globalGet 0,
   .const (48 : UInt32),
@@ -5280,7 +5230,7 @@ def func45 : Wasm.Program :=
     .localGet 2,
     .const (36 : UInt32),
     .add,
-    .const (1048616 : UInt32),
+    .const (1048624 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5288,7 +5238,7 @@ def func45 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 54,
+    .call 52,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5327,17 +5277,17 @@ def func45 : Wasm.Program :=
   .localGet 2,
   .localGet 4,
   .store64 (8 : UInt32),
-  .call 7,
+  .call 5,
   .block 0 0 [
     .const (12 : UInt32),
     .const (4 : UInt32),
-    .call 4,
+    .call 2,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (12 : UInt32),
-    .call 50,
+    .call 48,
     .unreachable
   ],
   .localGet 1,
@@ -5349,7 +5299,7 @@ def func45 : Wasm.Program :=
   .load64 (8 : UInt32),
   .store64 (0 : UInt32),
   .localGet 0,
-  .const (1048916 : UInt32),
+  .const (1048924 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5360,32 +5310,32 @@ def func45 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func45Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func45, results := [] }
+def func43Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func43, results := [] }
 
-def func46 : Wasm.Program :=
+def func44 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
   .store32 (0 : UInt32)
 ]
 
-def func46Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func46, results := [] }
+def func44Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func44, results := [] }
 
-def func47 : Wasm.Program :=
+def func45 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048616 : UInt32),
+  .const (1048624 : UInt32),
   .localGet 1,
   .localGet 2,
-  .call 54
+  .call 52
 ]
 
-def func47Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func47, results := [.i32] }
+def func45Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func45, results := [.i32] }
 
-def func48 : Wasm.Program :=
+def func46 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5443,10 +5393,10 @@ def func48 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func48Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func48, results := [] }
+def func46Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func46, results := [] }
 
-def func49 : Wasm.Program :=
+def func47 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5454,40 +5404,40 @@ def func49 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 50,
+    .call 48,
     .unreachable
   ],
+  .call 49,
+  .unreachable
+]
+
+def func47Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func47, results := [] }
+
+def func48 : Wasm.Program :=
+  [
+  .localGet 1,
+  .localGet 0,
+  .call 29,
+  .unreachable
+]
+
+def func48Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func48, results := [] }
+
+def func49 : Wasm.Program :=
+  [
+  .const (1049021 : UInt32),
+  .const (35 : UInt32),
+  .const (1049040 : UInt32),
   .call 51,
   .unreachable
 ]
 
 def func49Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func49, results := [] }
+  { params := [], locals := [], body := func49, results := [] }
 
 def func50 : Wasm.Program :=
-  [
-  .localGet 1,
-  .localGet 0,
-  .call 31,
-  .unreachable
-]
-
-def func50Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func50, results := [] }
-
-def func51 : Wasm.Program :=
-  [
-  .const (1049013 : UInt32),
-  .const (35 : UInt32),
-  .const (1049032 : UInt32),
-  .call 53,
-  .unreachable
-]
-
-def func51Def : Wasm.Function :=
-  { params := [], locals := [], body := func51, results := [] }
-
-def func52 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5496,14 +5446,14 @@ def func52 : Wasm.Program :=
   .const (1 : UInt32),
   .or,
   .localGet 2,
-  .call 53,
+  .call 51,
   .unreachable
 ]
 
-def func52Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func52, results := [] }
+def func50Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func50, results := [] }
 
-def func53 : Wasm.Program :=
+def func51 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5531,14 +5481,14 @@ def func53 : Wasm.Program :=
   .localGet 3,
   .const (20 : UInt32),
   .add,
-  .call 30,
+  .call 28,
   .unreachable
 ]
 
-def func53Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func53, results := [] }
+def func51Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func51, results := [] }
 
-def func54 : Wasm.Program :=
+def func52 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -5846,10 +5796,10 @@ def func54 : Wasm.Program :=
   .localGet 5
 ]
 
-def func54Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func54, results := [.i32] }
+def func52Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func52, results := [.i32] }
 
-def func55 : Wasm.Program :=
+def func53 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -5861,20 +5811,20 @@ def func55 : Wasm.Program :=
   .callIndirect 1 0
 ]
 
-def func55Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func55, results := [.i32] }
+def func53Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func53, results := [.i32] }
 
-def func56 : Wasm.Program :=
+def func54 : Wasm.Program :=
   [
-  .const (1049048 : UInt32),
+  .const (1049056 : UInt32),
   .const (51 : UInt32),
   .localGet 0,
-  .call 53,
+  .call 51,
   .unreachable
 ]
 
-def func56Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func56, results := [] }
+def func54Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func54, results := [] }
 
 def «module» : Wasm.Module :=
 {
@@ -5934,21 +5884,18 @@ def «module» : Wasm.Module :=
     func51Def,
     func52Def,
     func53Def,
-    func54Def,
-    func55Def,
-    func56Def
+    func54Def
   ],
   exports := [
-    { name := "abs_diff", funcIdx := 1 },
-    { name := "div", funcIdx := 2 },
-    { name := "entrypoint", funcIdx := 3 }
+    { name := "div", funcIdx := 0 },
+    { name := "div_chain", funcIdx := 1 }
   ],
   memory := some { pagesMin := (17 : UInt32), pagesMax := none, data := [
-    { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (152 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (152 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (100 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
+    { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (95 : UInt8), (116 : UInt8), (101 : UInt8), (115 : UInt8), (116 : UInt8), (115 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (160 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (160 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (108 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
   ] },
   globals := [
     { init := .i32 (1048576 : UInt32) },
-    { init := .i32 (1049557 : UInt32) },
+    { init := .i32 (1049565 : UInt32) },
     { init := .i32 (1049568 : UInt32) }
   ],
   types := [
@@ -5956,7 +5903,7 @@ def «module» : Wasm.Module :=
     { params := [.i32, .i32, .i32], results := [.i32] },
     { params := [.i32, .i32], results := [.i32] },
     { params := [.i64, .i64], results := [.i64] },
-    { params := [.i64, .i64], results := [] },
+    { params := [.i64, .i64, .i64], results := [.i64] },
     { params := [.i32, .i32, .i32], results := [] },
     { params := [.i32, .i32, .i32, .i32], results := [.i32] },
     { params := [], results := [] },
@@ -5969,8 +5916,8 @@ def «module» : Wasm.Module :=
     { min := 17, max := some 17, elemType := .funcref }
   ],
   elements := [
-    { tableIdx := some 0, offset := some 1, funcs := [some 19, some 11, some 43, some 42, some 47, some 41, some 40, some 38, some 39, some 12, some 37, some 45, some 44, some 46, some 36, some 35] }
+    { tableIdx := some 0, offset := some 1, funcs := [some 17, some 9, some 41, some 40, some 45, some 39, some 38, some 36, some 37, some 10, some 35, some 43, some 42, some 44, some 34, some 33] }
   ]
 }
 
-end Project.RustU64
+end Project.RustU64Tests

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -1,0 +1,62 @@
+import Project.RustU64Tests.Program
+import Interpreter.Wasm.Wp.Call
+
+/-!
+# Reuse tests for the `CodeLib/RustStd/U64` corpus
+
+One module exercising each proven u64 std theorem through the `call` rule.
+Each section reuses a CodeLib `…_wp` theorem as a black box (via
+`of_returns_wp` + `wp_call_tw`) — none of the std bodies are re-proven here.
+Add a new section per CodeLib function as the corpus grows.
+-/
+
+namespace Project.RustU64Tests.Spec
+
+open Wasm Wasm.RustStd.U64
+
+/-! ## `u64::div` — `div_chain a b c = (a / b) / c`
+
+`div` (export idx 0) inlines the guarded `i64.div_u`. Its opt-0 body shares the
+`divGuard` block with CodeLib's `divFunc`; only the (unreachable, since the
+divisors are nonzero) panic tail differs. `div_wp` is generic in that tail, so
+each `.call 0` in `div_chain` reuses it. -/
+
+/-- `div` specialized to a call site (operands `b :: a :: rest` on the stack,
+divisor `b ≠ 0`). No `hsp`/`hhi` side-conditions: `div` touches neither the
+shadow stack nor memory, so `div_wp` carries no frame hypotheses. The panic
+`tail` of this crate's `div` (idx 0) is inferred from `func0Def.body`. -/
+private theorem div_call {env : HostEnv Unit} (st : Store Unit) (a b : UInt64)
+    (rest : List Value) (hb : b ≠ 0) :
+    TerminatesWith env «module» 0 st (.i64 b :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (a / b) :: rest
+        ∧ st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := func0Def)
+    (rs := [.i64 (a / b)]) rfl rfl
+    (div_wp st a b [] _ hb) rfl   -- ★ REUSE: the proven CodeLib theorem
+
+@[spec_of "rust-exported" "rust_u64_tests::div_chain"]
+def DivChainSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 → c ≠ 0 →
+    TerminatesWith env «module» 1 «module».initialStore [.i64 c, .i64 b, .i64 a]
+      (fun _ rs => rs = [.i64 (a / b / c)])
+
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.DivChainSpec]
+theorem div_chain_correct : DivChainSpec := by
+  intro env a b c hb hc
+  apply TerminatesWith.of_wp_entry_for (f := func1Def) rfl
+  unfold func1Def func1
+  wp_run
+  apply wp_call_tw (div_call «module».initialStore a b [] hb)        -- ★ REUSE: div(a, b)
+  intro st1 vs1 h1
+  obtain ⟨hvs1, hg1, hp1⟩ := h1
+  subst hvs1
+  wp_run
+  apply wp_call_tw (div_call st1 (a / b) c [] hc)                    -- ★ REUSE: div(a/b, c)
+  intro st2 vs2 h2
+  obtain ⟨hvs2, _, _⟩ := h2
+  subst hvs2
+  wp_run
+  simp
+
+end Project.RustU64Tests.Spec

--- a/programs/rust/Cargo.lock
+++ b/programs/rust/Cargo.lock
@@ -38,5 +38,9 @@ name = "rust_u64"
 version = "0.1.0"
 
 [[package]]
+name = "rust_u64_tests"
+version = "0.1.0"
+
+[[package]]
 name = "total_variation"
 version = "0.1.0"

--- a/programs/rust/Cargo.toml
+++ b/programs/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "rust_u64_tests",
   "num_integer",
   "rust_u64",
   "total_variation",

--- a/programs/rust/rust_u64/src/exports.rs
+++ b/programs/rust/rust_u64/src/exports.rs
@@ -3,8 +3,14 @@ pub extern "C" fn abs_diff(a: u64, b: u64) -> u64 {
     a.abs_diff(b)
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn div(a: u64, b: u64) -> u64 {
+    a / b
+}
+
 
 #[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(a: u64, b: u64) {
     let _ = abs_diff(a, b);
+    let _ = div(a, b);
 }

--- a/programs/rust/rust_u64_tests/Cargo.toml
+++ b/programs/rust/rust_u64_tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_u64_tests"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]

--- a/programs/rust/rust_u64_tests/src/exports.rs
+++ b/programs/rust/rust_u64_tests/src/exports.rs
@@ -1,0 +1,31 @@
+//! Reuse tests for the `CodeLib/RustStd/U64` corpus.
+//!
+//! One crate accumulating *non-trivial* uses of the u64 std functions proven
+//! in CodeLib, so each new CodeLib theorem gets exercised through the `call`
+//! rule in a single emitted module (`Project.RustU64Tests.Spec`) instead of a
+//! crate per function. Mirrors how `rust_u64` accumulates the corpus itself.
+//!
+//! Convention per std function:
+//!   * if the std fn compiles to a real *called* function (e.g. `abs_diff`),
+//!     call it directly — the `.call` reuses its CodeLib theorem;
+//!   * if the std fn *inlines* at opt-0 (e.g. `+` → `i64.add`), expose a local
+//!     `#[no_mangle] extern "C"` shim with the same body (so its emitted
+//!     `Function` record equals the CodeLib `…Func`), then call the shim.
+
+// ─── u64::div (inlines the guarded i64.div_u at opt-0) ─────────────────────
+// Shim: identical source/codegen to `rust_u64::div`. Division-by-zero is always
+// checked (even in release), so the opt-0 body is a `block` guarding the
+// `i64.div_u`, followed by a crate-specific panic tail. The guard/divide prefix
+// is identical to CodeLib `divFunc`; only the trailing panic `const`/`call`
+// indices are resolved per crate (`div_wp` is reused tail-generically).
+#[unsafe(no_mangle)]
+pub extern "C" fn div(a: u64, b: u64) -> u64 {
+    a / b
+}
+
+/// Test for `u64::div`: a non-trivial chain `(a / b) / c` (two `div` calls;
+/// requires `b != 0` and `c != 0`).
+#[unsafe(no_mangle)]
+pub extern "C" fn div_chain(a: u64, b: u64, c: u64) -> u64 {
+    div(div(a, b), c)
+}

--- a/programs/rust/rust_u64_tests/src/lib.rs
+++ b/programs/rust/rust_u64_tests/src/lib.rs
@@ -1,0 +1,1 @@
+mod exports;


### PR DESCRIPTION
## What

Verifies `u64::div` end-to-end through the std pipeline (`docs/std_guide.md`): proves `u64::div a b = a / b` once in CodeLib (`wp` form about the body) and reuses it under `call`.

## How `div` compiles (and why it's different from add/sub/mul)

At `opt-level = 0` the `/` operator is **inlined** directly into the export — no inner `call`, no stack frame, no memory spill — so this lifts the export's own index (idx `2` off main), tagged `rust-exported "rust_u64::div"`.

Unlike `+`/`-`/`*` (which wrap silently in the release profile), **division-by-zero is always checked** — it's UB in LLVM even in release. So the body is a `block` that guards the `i64.div_u` and, when `b == 0`, breaks out to a per-crate panic stub (`const <&Location>; call <panic>; unreachable`, "attempt to divide by zero"). The spec therefore carries a `b ≠ 0` precondition.

## The reusability wrinkle — tail-generic `div_wp`

The panic stub's `const`/`call` indices are **crate-specific**: the same `div` compiled into a different module gets a different tail (e.g. `rust_u64`: `const 1048600; call 56`; `rust_u64_tests`: `const 1048608; call 54`). A byte-identical-body reuse (like `add`'s shim trick) would therefore fail.

But with `b ≠ 0` that tail is **unreachable** — the guard block returns first. So `div_wp` is stated over the shared guard `block` (`divGuard`) followed by an **arbitrary `tail`**, which lets the single CodeLib theorem reuse under `call` for *any* crate's `div`. `divBody`/`divFunc` instantiate `tail` at the verbatim `rust_u64` body for the per-crate spec. This is also robust to the panic index shifting when more functions land on `main`.

## Changes

- **`codelib/CodeLib/RustStd/U64/Div.lean`** (new): `divGuard`, `divBody`, `divFunc`, and `div_wp` — `unfold divGuard Returns; apply wp_block_cons; wp_run; simp [hb]`.
- **`Project/RustU64/Spec.lean`**: `DivSpec` / `div_correct` (`rust-exported "rust_u64::div"`, idx 2, `b ≠ 0`).
- **`rust_u64_tests`** (new accumulating reuse crate + `Project.RustU64Tests`): `div_chain a b c = (a / b) / c` reuses `div_wp` twice via `of_returns_wp` + `wp_call_tw`; the shim shares `divGuard` but has its own panic tail, inferred from `func0Def.body`.
- `rust_u64/src/exports.rs`, `CodeLib.lean`, `Project.lean`, `Cargo.{toml,lock}`: wire-up.

## Verification

`just verifier-prove rust_u64` and `just verifier-prove rust_u64_tests` both build green, **0 sorry**; full `programs` lib builds green.

## Note for rebase

If add/sub/mul merge first, the `div` export index (`2`) in `Project/RustU64/Spec.lean` and `divBody`'s panic-tail literal will renumber — re-emit, bump the idx, and refresh the tail. The tail-generic `div_wp` proof itself is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)