### PR TITLE
decoder: evaluate global.get / extended-const global initializers

### DIFF
--- a/interpreter/Interpreter/Runner.lean
+++ b/interpreter/Interpreter/Runner.lean
@@ -247,7 +247,16 @@ def runOnce (a : Args) : IO UInt32 := do
   -- so we reverse here to match the call convention. (Single-arg
   -- functions are order-insensitive, which masked this for older
   -- samples.)
-  match Wasm.run a.fuel m idx (m.initialStore (α := Unit)) vs.reverse with
+  --
+  -- Evaluate constant-expression global initializers (`global.get`,
+  -- extended-const arithmetic, GC `struct.new`/`array.new*`) into the
+  -- fresh store before running, the same way the testsuite driver does
+  -- at instantiation — otherwise those globals keep their zero
+  -- placeholder. There are no imports here, so `global.get` of an
+  -- imported global is unreachable; the import pre-flight above
+  -- rejects any module that would need one.
+  let store0 := m.runConstGlobals a.fuel (m.initialStore (α := Unit)) {}
+  match Wasm.run a.fuel m idx store0 vs.reverse with
   | .Success results _ =>
     for v in results.reverse do
       IO.println (renderValue v)

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -2208,6 +2208,25 @@ private def parseWatString (s : String) : Except Err (List UInt8) :=
   if !s.startsWith "\"" then .error s!"expected string literal, got: {s}"
   else decodeWatBytes (stripQuotes s).toList
 
+/- Whether a global-initializer sexpr mentions an instruction whose value
+depends on the store and so cannot be folded to a literal at decode time:
+`global.get` of an imported global (wasm 1.0), or the extended-const
+arithmetic ops (`i32.add`/`i32.sub`/`i32.mul`, i64 ditto). Recurses into
+folded operand forms (the flat form emitted by `wasm-tools print` is
+handled by the list case). -/
+mutual
+  /-- Scan a single sexpr; recurse into a `(…)` list via the list helper. -/
+  def initExprNeedsEval : Sexpr → Bool
+    | .atom a =>
+      a == "global.get"
+        || a ∈ #["i32.add", "i32.sub", "i32.mul", "i64.add", "i64.sub", "i64.mul"]
+    | .list ys => initExprNeedsEvalList ys
+  /-- Scan a sequence of sexprs (the operands of a folded instruction). -/
+  def initExprNeedsEvalList : List Sexpr → Bool
+    | [] => false
+    | y :: ys => initExprNeedsEval y || initExprNeedsEvalList ys
+end
+
 private def parseGlobalDecl (ctx : Ctx) (xs : List Sexpr) :
     Except Err Wasm.GlobalDecl := do
   let xs := match xs with
@@ -2245,6 +2264,22 @@ private def parseGlobalDecl (ctx : Ctx) (xs : List Sexpr) :
     -- The value can't be folded at decode time; stash a placeholder `init`
     -- and let `Module.runConstGlobals` evaluate `initExpr` at instantiation.
     return { init := .anyref none, initExpr := prog }
+  -- `global.get` of an imported global is a wasm 1.0 constant expression,
+  -- and `i32.add`/`i32.sub`/`i32.mul` (i64 ditto) are the extended-const
+  -- proposal. Neither can be folded to a single value at decode time — the
+  -- value depends on the store — so, like the GC allocator case above, keep
+  -- the const-expr program and let `Module.runConstGlobals` evaluate it at
+  -- instantiation once the imported globals are in place. The placeholder
+  -- `init` carries the declared value type for static type-checking.
+  --
+  -- `wasm-tools print` emits these as a *flat* instruction sequence
+  -- (`i32.const 20 i32.const 2 i32.mul …`), so detect by scanning every
+  -- atom (recursing into folded forms) for a `global.get` or arithmetic
+  -- op rather than looking only at the head. Plain const / ref / v128
+  -- initializers contain none of these and keep folding to a literal below.
+  if xs.any initExprNeedsEval then
+    let prog ← parseInstrSeq ctx xs
+    return { init := _vt.zero, initExpr := prog }
   -- The init expression is either wrapped in a `(...)` list or — in
   -- wasm-tools' canonical print — emitted as a bare sequence of atoms
   -- (for v128.const this is `v128.const <shape> <lanes...>`, six tokens).
@@ -2286,7 +2321,6 @@ private def parseGlobalDecl (ctx : Ctx) (xs : List Sexpr) :
       match parseV128Const tail with
       | .ok (bits, _) => .ok (.v128 bits)
       | .error e      => .error e
-    | some "global.get", _ => .ok (.i32 0)
     | _, _ => .error "global init expression must be i32.const or i64.const"
   .ok { init }
 

--- a/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
@@ -1,0 +1,64 @@
+import Interpreter.Wasm.Decoder.Wat
+import Interpreter.Wasm.Wp.Tactic
+
+/-! ## Example: constant-expression global initializers in the WAT decoder
+
+    A global initializer is a constant expression, not just a single
+    `*.const`. The wasm 1.0 core spec permits `global.get` of an imported
+    global, and the extended-const proposal adds `i32.add`/`i32.sub`/`i32.mul`
+    (i64 ditto). Talos keeps such initializers as a program in `GlobalDecl.
+    initExpr` and evaluates them at instantiation via `Module.runConstGlobals`
+    rather than folding them to a literal at decode time.
+
+    This module exercises a nested arithmetic initializer end-to-end so a
+    regression — the initializer collapsing to its first operand, or the
+    placeholder zero leaking through — fails the build. -/
+
+namespace Wasm
+namespace GlobalInitExpr
+
+/-- A module whose only global is initialised with an extended-const
+expression: `(20 * 3) - 18 = 42`. -/
+def globalInitExprWat : String := "
+(module
+  (global $g i32 (i32.sub (i32.mul (i32.const 20) (i32.const 3)) (i32.const 18)))
+  (func $getG (export \"getG\") (result i32)
+    global.get $g))
+"
+
+private def decoded : Wasm.Module :=
+  match Wasm.Decoder.Wat.decode globalInitExprWat with
+  | .ok m    => m
+  | .error _ => default
+
+/-- The initializer is kept as a program rather than folded to a single
+literal: the global's `initExpr` is non-empty. -/
+theorem decoded_global_keeps_initExpr :
+    (decoded.globals[0]?.map (·.initExpr.isEmpty)).getD true = false := by
+  native_decide
+
+/-- `runConstGlobals` evaluates the arithmetic initializer against the
+fresh store and writes `42` into the global slot. -/
+theorem runConstGlobals_evaluates_initExpr :
+    (decoded.runConstGlobals 64 (decoded.initialStore (α := Unit)) {}).globals.globals[0]?
+      = some (.i32 42) := by
+  native_decide
+
+private def emptyEnv : HostEnv Unit := { funcs := [] }
+
+private def runVals (idx : Nat) (st : Store Unit) (args : List Value) :
+    List Value :=
+  match run 64 decoded idx st args emptyEnv with
+  | .Success vs _ => vs
+  | _ => []
+
+/-- End-to-end: running `getG` after initialising the globals returns `42`.
+The old behaviour — placeholder `0` from `ValueType.zero`, or the first
+operand `20` — would return `0` or `20` instead. -/
+theorem getG_returns_42 :
+    runVals 0 (decoded.runConstGlobals 64 (decoded.initialStore (α := Unit)) {}) []
+      = [.i32 42] := by
+  native_decide
+
+end GlobalInitExpr
+end Wasm

--- a/testsuite_report.txt
+++ b/testsuite_report.txt
@@ -17339,12 +17339,12 @@ global.wast:206 assert_return pass
 global.wast:207 assert_return pass
 global.wast:208 assert_return pass
 global.wast:209 assert_return pass
-global.wast:210 assert_return fail
-global.wast:211 assert_return fail
-global.wast:212 assert_return fail
-global.wast:213 assert_return fail
-global.wast:214 assert_return fail
-global.wast:215 assert_return fail
+global.wast:210 assert_return pass
+global.wast:211 assert_return pass
+global.wast:212 assert_return pass
+global.wast:213 assert_return pass
+global.wast:214 assert_return pass
+global.wast:215 assert_return pass
 global.wast:217 assert_return pass
 global.wast:218 assert_return pass
 global.wast:219 assert_return pass
@@ -17508,7 +17508,7 @@ i31.wast:136 assert_return module_unavailable
 i31.wast:137 assert_return module_unavailable
 i31.wast:138 assert_return module_unavailable
 i31.wast:140 module pass
-i31.wast:148 assert_return interpreter_error
+i31.wast:148 assert_return pass
 i31.wast:150 module pass
 i31.wast:164 assert_return pass
 i31.wast:165 action pass
@@ -19359,7 +19359,7 @@ linking.wast:364 module pass
 linking.wast:370 module pass
 linking.wast:371 register pass
 linking.wast:372 module pass
-linking.wast:376 assert_return fail
+linking.wast:376 assert_return pass
 linking.wast:379 assert_uninstantiable skipped:assert_uninstantiable
 linking.wast:388 assert_unlinkable skipped:assert_unlinkable
 linking.wast:397 assert_trap pass


### PR DESCRIPTION
## Problem

Global initializers that are not a single `*.const` were mishandled in the WAT decoder:

- `global.get` of an imported global — a **wasm 1.0 core** constant expression — was silently replaced with a zero placeholder (`Wat.lean`: `| some "global.get", _ => .ok (.i32 0)`). Any global derived from an imported global got the wrong value.
- Extended-const arithmetic initializers (`i32.add`/`i32.sub`/`i32.mul`, i64 ditto) were rejected outright with `"global init expression must be i32.const or i64.const"`.

This surfaced as 8 failing spec-testsuite assertions:

```
global.wast:210-215   (z1-z6: global.get + extended-const arithmetic)
i31.wast:148          (ref.i31 of global.get in a global initializer)
linking.wast:376      (global.get of an imported global in an initializer)
```

Example (`global.wast`):
```wat
(global (import "spectest" "global_i32") i32)        ; imported global 0 = 666
(global $z1 i32 (global.get 0))                       ; expected 666, got 0
(global $z5 i32 (i32.add (global.get 0) (i32.const 42)))  ; expected 708, rejected
(global $z3 i32 (i32.sub (i32.mul (i32.const 20) (i32.const 3)) (i32.const 18)))  ; expected 42, rejected
```

## Fix

Route these initializers through the **existing** `GlobalDecl.initExpr` mechanism so `Module.runConstGlobals` evaluates them at instantiation (once imported globals are in the store) — exactly like the GC `struct.new`/`array.new*` case that already used this path. The placeholder `init` keeps the declared value type for static type-checking (`Value.toValueType`).

Detection (`initExprNeedsEval`, mutual over `Sexpr`/`List Sexpr`) scans the initializer for a `global.get` or arithmetic op, **recursing into folded forms** and covering the **flat instruction sequence** that `wasm-tools print` emits (`i32.const 20 i32.const 2 i32.mul …`). Plain const / ref / v128 initializers contain none of these and stay on their literal-folding path unchanged.

The runner now also applies `runConstGlobals` to the fresh store before running, matching the testsuite instantiation path — otherwise constant-expression globals kept their zero placeholder when run via `lake exe runner`.

## Verification

- `lake build Interpreter` — clean (all proofs + `native_decide` examples pass), including the new `Examples/GlobalInitExpr.lean` regression proof.
- `scripts/runner-smoke.sh` — all 5 checks pass.
- `just testsuite-report` (pinned `wasm-tools 1.251.0`) — regenerated `testsuite_report.txt`: **+8 pass, 0 regressions** (all 8 failing lines above flipped to `pass`; no other line changed).

The new example module decodes `(i32.sub (i32.mul (i32.const 20) (i32.const 3)) (i32.const 18))` and proves, via `native_decide`, that `runConstGlobals` writes `42` into the slot and `getG` returns `42` — locking in the behaviour against a future regression to the placeholder-zero or first-operand value.

## Scope

One logical change (global initializer evaluation), touching the decoder, the runner's store setup, the committed testsuite report, and a new example. No semantics or proof structure changed; the `initExpr`/`runConstGlobals` infrastructure was already in place for GC.

---

AI disclosure: the code in this PR was written with Claude Code. I have read and understood every change and am accountable for it; happy to address review feedback.
