### PR TITLE
interpreter: trap on a null array operand in array.copy

### DIFF
--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -330,6 +330,10 @@ def execGcOp (m : Module) (st : Store α) (s : Locals) : GcOp → Continuation �
             else dstElems[i]!
           .Fallthrough { st with gcHeap := st.gcHeap.set dstAddr (.array dty dstElems') } { s with values := vs }
       | _, _ => .Invalid "arrayCopy: not an array"
+    -- A null source or destination array reference traps, even when n = 0,
+    -- mirroring every other array op (arrayGet/Set/Fill/...).
+    | .i32 _ :: .i32 _ :: .anyref none :: _ => .Trap st "null array reference"
+    | .i32 _ :: .i32 _ :: _ :: .i32 _ :: .anyref none :: _ => .Trap st "null array reference"
     | _ => .Invalid "arrayCopy: ill-shaped operand stack"
   -- `array.new_data $t $d`: [off, n] → array of n elements read from data
   -- segment `d` (little-endian, sized by the element storage type).

--- a/testsuite_report.txt
+++ b/testsuite_report.txt
@@ -1179,8 +1179,8 @@ array_copy.wast:18 assert_invalid skipped:assert_invalid: not rejected
 array_copy.wast:30 assert_invalid skipped:assert_invalid: not rejected
 array_copy.wast:42 assert_invalid skipped:assert_invalid: not rejected
 array_copy.wast:54 module pass
-array_copy.wast:97 assert_trap interpreter_error
-array_copy.wast:98 assert_trap interpreter_error
+array_copy.wast:97 assert_trap pass
+array_copy.wast:98 assert_trap pass
 array_copy.wast:101 assert_trap pass
 array_copy.wast:102 assert_trap pass
 array_copy.wast:105 assert_trap pass


### PR DESCRIPTION
`array.copy` with a null source or destination array returns `Invalid` instead of trapping. Per the GC spec a null array operand traps even when `n = 0`.

```wat
(module (type $a (array (mut i32)))
  (func (export "f") (result i32)
    (array.copy $a $a (array.new_default $a (i32.const 1)) (i32.const 0)
                      (ref.null $a) (i32.const 0) (i32.const 0))
    (i32.const 9)))
```

Before: `Invalid: arrayCopy: ill-shaped operand stack`. After: traps.

The `.arrayCopy` arm matched only non-null operands and fell through to `Invalid`; every sibling array op (`arrayGet` / `arraySet` / `arrayFill` / …) already has the null-trap arm. This adds it for both the source and destination operands.

Tested against **wasmtime 43** and **V8 (Node 26)** as references — both trap with a null-reference error; the patched interpreter now matches. Coverage checked: null at source / destination / both with `n = 0` and `n = 1` → trap; out-of-bounds copy → unchanged; valid copies (`n = 0`, `n = 3`) → unchanged.
