### PR TITLE
interpreter: apply active element segments stored in the const-expr form

### DIFF
--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -119,27 +119,6 @@ def readStorageLE (storage : StorageType) (bytes : List UInt8) (off : Nat) : Val
   | .val .f64 => .f64 (UInt64.ofNat n)
   | .val _    => .i32 0
 
-/-- Evaluate a simple element-segment item constant expression to its
-reference value (GC proposal). Covers the forms element segments use:
-`ref.func`, `ref.null`, `ref.i31` of a constant, and scalar constants.
-Heap-allocating items (`struct.new`) are not handled here. -/
-def evalConstRef : Program → Option Value
-  | [.refFunc f]                 => some (.funcref (some f))
-  | [.refNull]                   => some (.funcref none)
-  | [.refNullExtern]             => some (.externref none)
-  | [.gc .refNullAny]            => some (.anyref none)
-  | [.const n]                   => some (.i32 n)
-  | [.constI64 n]                => some (.i64 n)
-  | [.const n, .gc .refI31]      => some (.anyref (some (.i31 (n &&& 0x7fffffff))))
-  | _                            => none
-
-/-- The reference values a (passive, non-dropped) element segment yields,
-preferring decoded GC const-expr items and falling back to funcref
-indices. -/
-def ElementSegment.values (seg : ElementSegment) : List Value :=
-  if seg.exprs.isEmpty then seg.funcs.map Value.funcref
-  else seg.exprs.map (fun e => (evalConstRef e).getD (.anyref none))
-
 /-- Execute one GC-proposal instruction. These never consume fuel or
 recurse into `exec`/`run` — `struct.new`/`array.new` allocate on
 `st.gcHeap`, the accessors read/update it, and `ref.test`/`ref.cast` decide

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -804,6 +804,27 @@ def listWriteAt (l : List α) (off : Nat) (vs : List α) : List α :=
     | []      => []
     | x :: xs => x :: listWriteAt xs i vs
 
+/-- Evaluate a simple element-segment item constant expression to its
+reference value (GC proposal). Covers the forms element segments use:
+`ref.func`, `ref.null`, `ref.i31` of a constant, and scalar constants.
+Heap-allocating items (`struct.new`) are not handled here. -/
+def evalConstRef : Program → Option Value
+  | [.refFunc f]                 => some (.funcref (some f))
+  | [.refNull]                   => some (.funcref none)
+  | [.refNullExtern]             => some (.externref none)
+  | [.gc .refNullAny]            => some (.anyref none)
+  | [.const n]                   => some (.i32 n)
+  | [.constI64 n]                => some (.i64 n)
+  | [.const n, .gc .refI31]      => some (.anyref (some (.i31 (n &&& 0x7fffffff))))
+  | _                            => none
+
+/-- The reference values a (passive, non-dropped) element segment yields,
+preferring decoded GC const-expr items and falling back to funcref
+indices. -/
+def ElementSegment.values (seg : ElementSegment) : List Value :=
+  if seg.exprs.isEmpty then seg.funcs.map Value.funcref
+  else seg.exprs.map (fun e => (evalConstRef e).getD (.anyref none))
+
 /-- Build the initial store for a module: evaluate each global's `init`
 into `Globals.globals`; allocate a memory with `pagesMin` pages and
 write each *active* data segment at its declared offset; track all
@@ -854,7 +875,7 @@ def Module.initialStore [Inhabited α] (m : Module) : Store α :=
       match seg.tableIdx, seg.offset with
       | some t, some off =>
         match acc[t]? with
-        | some tbl => listSetAt acc t (listWriteAt tbl off (seg.funcs.map Value.funcref))
+        | some tbl => listSetAt acc t (listWriteAt tbl off seg.values)
         | none     => acc
       | _, _ => acc)
     baseTables


### PR DESCRIPTION
Active element segments stored as const-expr items (`ref.func`, `ref.null`) get ignored at instantiation — `initialStore` only reads `seg.funcs`, so the table is left full of nulls. The binary format uses this form for typed function tables (`(table N (ref null $ft))`) and GC reference tables, so those come up empty when built from an elem segment.

```wat
(module
  (type $ft (func (result i32)))
  (func $h (type $ft) (i32.const 16))
  (table 1 (ref null $ft))
  (elem (i32.const 0) (ref null $ft) (ref.func $h))
  (func (export "f") (result i32)
    (call_ref $ft (table.get (i32.const 0)))))
```

- wasmtime 43 → `16`
- V8 (Node 26) → `16`
- Talos before → `Invalid: callRef: ill-shaped operand stack`

`ElementSegment.values` already handles both the `funcs` and `exprs` forms — init just wasn't using it. Moved it (and `evalConstRef`) next to `initialStore`, called it there.
