### PR TITLE
u64: comparisons (eq..ge) + Ord (min/max/clamp)

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -20,6 +20,7 @@ import CodeLib.RustStd.U64.Shl
 import CodeLib.RustStd.U64.Shr
 import CodeLib.RustStd.U64.Eq
 import CodeLib.RustStd.U64.Ne
+import CodeLib.RustStd.U64.Lt
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -23,6 +23,7 @@ import CodeLib.RustStd.U64.Ne
 import CodeLib.RustStd.U64.Lt
 import CodeLib.RustStd.U64.Le
 import CodeLib.RustStd.U64.Gt
+import CodeLib.RustStd.U64.Ge
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -21,6 +21,7 @@ import CodeLib.RustStd.U64.Shr
 import CodeLib.RustStd.U64.Eq
 import CodeLib.RustStd.U64.Ne
 import CodeLib.RustStd.U64.Lt
+import CodeLib.RustStd.U64.Le
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -19,6 +19,7 @@ import CodeLib.RustStd.U64.Not
 import CodeLib.RustStd.U64.Shl
 import CodeLib.RustStd.U64.Shr
 import CodeLib.RustStd.U64.Eq
+import CodeLib.RustStd.U64.Ne
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -24,6 +24,9 @@ import CodeLib.RustStd.U64.Lt
 import CodeLib.RustStd.U64.Le
 import CodeLib.RustStd.U64.Gt
 import CodeLib.RustStd.U64.Ge
+import CodeLib.RustStd.U64.Max
+import CodeLib.RustStd.U64.Min
+import CodeLib.RustStd.U64.Clamp
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -22,6 +22,7 @@ import CodeLib.RustStd.U64.Eq
 import CodeLib.RustStd.U64.Ne
 import CodeLib.RustStd.U64.Lt
 import CodeLib.RustStd.U64.Le
+import CodeLib.RustStd.U64.Gt
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -18,6 +18,7 @@ import CodeLib.RustStd.U64.BitXor
 import CodeLib.RustStd.U64.Not
 import CodeLib.RustStd.U64.Shl
 import CodeLib.RustStd.U64.Shr
+import CodeLib.RustStd.U64.Eq
 import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env

--- a/codelib/CodeLib/RustStd/Frame.lean
+++ b/codelib/CodeLib/RustStd/Frame.lean
@@ -53,6 +53,38 @@ returns the stored value. -/
              Nat.reduceEqDiff]
   bv_decide
 
+/-- A `write64` leaves every byte outside its 8-byte range `[a, a+8)`
+untouched. -/
+theorem Mem.write64_bytes_outside (m : Mem) (a : UInt32) (v : UInt64) (i : Nat)
+    (h : i < a.toNat ∨ a.toNat + 8 ≤ i) : (m.write64 a v).bytes i = m.bytes i := by
+  simp only [Mem.write64]
+  have h0 : ¬ (i = a.toNat)     := by omega
+  have h1 : ¬ (i = a.toNat + 1) := by omega
+  have h2 : ¬ (i = a.toNat + 2) := by omega
+  have h3 : ¬ (i = a.toNat + 3) := by omega
+  have h4 : ¬ (i = a.toNat + 4) := by omega
+  have h5 : ¬ (i = a.toNat + 5) := by omega
+  have h6 : ¬ (i = a.toNat + 6) := by omega
+  have h7 : ¬ (i = a.toNat + 7) := by omega
+  simp only [h0, h1, h2, h3, h4, h5, h6, h7, ↓reduceIte]
+
+/-- Reading a 64-bit word from a range disjoint from a preceding `write64`
+returns the original (pre-write) value. The companion to
+`read64_write64_same` for multi-spill frames (`min`/`max`) that store two
+operands at adjacent 8-byte slots. -/
+theorem Mem.read64_write64_disjoint (m : Mem) (a b : UInt32) (v : UInt64)
+    (h : a.toNat + 8 ≤ b.toNat ∨ b.toNat + 8 ≤ a.toNat) :
+    (m.write64 b v).read64 a = m.read64 a := by
+  simp only [Mem.read64]
+  rw [Mem.write64_bytes_outside m b v a.toNat (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 1) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 2) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 3) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 4) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 5) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 6) (by omega),
+      Mem.write64_bytes_outside m b v (a.toNat + 7) (by omega)]
+
 /-! ## Stores preserve the page count -/
 
 @[simp] theorem Mem.write32_pages (m : Mem) (a v : UInt32) :

--- a/codelib/CodeLib/RustStd/U64/Clamp.lean
+++ b/codelib/CodeLib/RustStd/U64/Clamp.lean
@@ -1,0 +1,92 @@
+import CodeLib.RustStd.Frame
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Block
+import CodeLib.Entry
+
+/-! `u64::clamp` — `core::cmp::Ord::clamp`, the framed inner function the exported
+`clamp` wrapper `call`s. Panics if `lo > hi` (a `block` guard, like `div`); under
+`lo ≤ hi` it computes `if a < lo then lo else if a > hi then hi else a` via a
+nested-block select, spilling the result. It saves/restores the global stack
+pointer, so its post only asserts `mem.pages` is preserved (sufficient for the
+wrapper, which reuses this via the call rule). -/
+
+set_option linter.unusedSimpArgs false
+
+namespace Wasm.RustStd.U64
+open Wasm
+
+/-- Verbatim opt-0 body of `core::cmp::Ord::clamp` for `u64`. The panic-handler
+call index (`panicIdx`) is a parameter: it differs per crate, but the panic is
+unreachable under `lo ≤ hi`, so the proof is generic over it — letting one
+`clamp_wp` serve `rust_u64`'s inner (`call 76`) and any client crate's copy. -/
+def clampBody (panicIdx : Nat) : Program :=
+  [ .globalGet 0, .const (80 : UInt32), .sub, .localSet 4, .localGet 4, .globalSet 0,
+    .block 0 0 [
+      .localGet 1, .localGet 2, .leUI64, .const (1 : UInt32), .and, .br_if 0,
+      .localGet 4, .localGet 1, .store64 (16 : UInt32),
+      .localGet 4, .localGet 2, .store64 (24 : UInt32),
+      .localGet 4, .localGet 4, .const (16 : UInt32), .add, .store32 (64 : UInt32),
+      .localGet 4, .const (1 : UInt32), .store32 (68 : UInt32),
+      .localGet 4, .localGet 4, .load64 (64 : UInt32), .store64 (48 : UInt32),
+      .localGet 4, .localGet 4, .const (24 : UInt32), .add, .store32 (72 : UInt32),
+      .localGet 4, .const (1 : UInt32), .store32 (76 : UInt32),
+      .localGet 4, .localGet 4, .load64 (72 : UInt32), .store64 (56 : UInt32),
+      .localGet 4, .const (32 : UInt32), .add, .localGet 4, .load64 (48 : UInt32), .store64 (0 : UInt32),
+      .localGet 4, .const (32 : UInt32), .add, .const (8 : UInt32), .add,
+        .localGet 4, .load64 (56 : UInt32), .store64 (0 : UInt32),
+      .const (1048576 : UInt32), .localGet 4, .const (32 : UInt32), .add, .localGet 3, .call panicIdx, .unreachable ],
+    .block 0 0 [
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .block 0 0 [
+              .localGet 0, .localGet 1, .ltUI64, .const (1 : UInt32), .and, .br_if 0,
+              .localGet 0, .localGet 2, .gtUI64, .const (1 : UInt32), .and, .br_if 2,
+              .br 1 ],
+            .localGet 4, .localGet 1, .store64 (8 : UInt32), .br 3 ],
+          .localGet 4, .localGet 0, .store64 (8 : UInt32), .br 1 ],
+        .localGet 4, .localGet 2, .store64 (8 : UInt32) ] ],
+    .localGet 4, .load64 (8 : UInt32), .localSet 5,
+    .localGet 4, .const (80 : UInt32), .add, .globalSet 0,
+    .localGet 5, .ret ]
+
+def clampFunc (panicIdx : Nat) : Function :=
+  { params := [.i64, .i64, .i64, .i32], locals := [.i32, .i64], body := clampBody panicIdx, results := [.i64] }
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 1000000 in
+theorem clamp_wp {α} {m : Module} {env : HostEnv α} (st : Store α) (panicIdx : Nat)
+    (sp : UInt32) (a lo hi : UInt64) (loc : UInt32) (vs : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 sp))
+    (hlo : 80 ≤ sp.toNat) (hhi : sp.toNat ≤ st.mem.pages * 65536) (hlohi : lo ≤ hi) :
+    wp m (clampBody panicIdx)
+      (Returns (.i64 (if a < lo then lo else if a > hi then hi else a) :: vs)
+        (fun st' => st'.mem.pages = st.mem.pages))
+      st ⟨[.i64 a, .i64 lo, .i64 hi, .i32 loc], [.i32 0, .i64 0], vs⟩ env := by
+  unfold clampBody Returns
+  have hle80 : (80 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using hlo)
+  have hsub80 : (sp - 80).toNat = sp.toNat - 80 := UInt32.toNat_sub_of_le sp 80 hle80
+  have hnt8 : ¬ ((sp - 80).toNat + 8 + 8 > st.mem.pages * 65536) := by rw [hsub80]; omega
+  have h8 : (8 : UInt32).toNat = 8 := rfl
+  have h11 : (1 : UInt32) &&& 1 = 1 := by decide
+  have hgset : (st.globals.globals.set 0 (Value.i32 (sp - 80)))[0]? = some (Value.i32 (sp - 80)) := by
+    cases hg : st.globals.globals with
+    | nil => simp [hg] at hsp
+    | cons x xs => simp [hg]
+  simp only [wp_simp, Locals.get, Locals.set?, Function.toLocals,
+    Function.numParams, Function.numLocals, List.take, List.drop, List.replicate, List.length,
+    List.map, ValueType.zero, List.headD, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, List.set_cons_zero, List.set_cons_succ,
+    Nat.reduceAdd, Nat.reduceLT, Nat.reduceSub, reduceIte, hsp, hlohi, hnt8, h8, Mem.write64_pages]
+  apply wp_block_cons
+  simp [hlohi, h11]
+  apply wp_block_cons
+  apply wp_block_cons
+  apply wp_block_cons
+  apply wp_block_cons
+  apply wp_block_cons
+  by_cases hlt : a < lo <;> by_cases hgt : hi < a <;>
+    simp [hlt, hgt, hnt8, h8, Mem.read64_write64_same, Mem.write64_pages]
+  all_goals exact ⟨by omega, by simp [hgset]⟩
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Div.lean
+++ b/codelib/CodeLib/RustStd/U64/Div.lean
@@ -18,7 +18,7 @@ theorem div_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
 def divBody : Program :=
   [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
                  .localGet 0, .localGet 1, .divUI64, .ret ],
-    .const 1048600, .call 66, .unreachable ]
+    .const 1048600, .call 72, .unreachable ]
 
 set_option maxRecDepth 4096 in
 /-- Export-body theorem for `rust_u64::div` (divisor ≠ 0): peel the zero-divisor

--- a/codelib/CodeLib/RustStd/U64/Div.lean
+++ b/codelib/CodeLib/RustStd/U64/Div.lean
@@ -18,7 +18,7 @@ theorem div_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
 def divBody : Program :=
   [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
                  .localGet 0, .localGet 1, .divUI64, .ret ],
-    .const 1048600, .call 72, .unreachable ]
+    .const 1048648, .call 83, .unreachable ]
 
 set_option maxRecDepth 4096 in
 /-- Export-body theorem for `rust_u64::div` (divisor ≠ 0): peel the zero-divisor

--- a/codelib/CodeLib/RustStd/U64/Eq.lean
+++ b/codelib/CodeLib/RustStd/U64/Eq.lean
@@ -1,0 +1,39 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::eq` (`a == b`) — inlined to `i64.eq; i32.const 1; i32.and` (an `i64.eq`
+whose `0/1` result is `bool`-normalised by a redundant `& 1`). Chunk fact + export
+body, reusing the trunk's `CmpChunk`/`cmpBodyWp`. This file is the **exemplar** for
+the comparison (`cmp`) shape — `ne`/`lt`/`le`/`gt`/`ge` mirror it with their own
+opcode. -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined comparison chunk `[.eqI64, .const 1, .and]` computes the `i32`
+boolean `if a = b then 1 else 0` on stack operands (the `& 1` mask is a no-op on
+the already-`0/1` `i64.eq` result, discharged here). Reusable wherever `a == b`
+is inlined. -/
+theorem eq_chunk : CmpChunk (T := UInt64) [.eqI64, .const 1, .and] (fun a b => if a = b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a = b then 1 else 0) = (if a = b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_eqI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::eq`, built by reusing `eq_chunk`. -/
+theorem eqBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.eqI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a = b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp eq_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `eq_chunk` (matches the emitted opcodes for `rw`
+at an inlined `a == b`), proven *by reusing* the polymorphic `eq_chunk`. -/
+theorem eq_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.eqI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a = b then 1 else 0) :: vs⟩ env :=
+  eq_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Ge.lean
+++ b/codelib/CodeLib/RustStd/U64/Ge.lean
@@ -1,0 +1,34 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::ge` (`a >= b`) — inlined to `i64.ge_u; i32.const 1; i32.and`. Reuses the
+trunk's `CmpChunk`/`cmpBodyWp` (the `cmp` shape, exemplar `U64/Eq.lean`). -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined chunk `[.geUI64, .const 1, .and]` computes the `i32` boolean
+`if a ≥ b then 1 else 0` on stack operands (the `& 1` mask discharged here). -/
+theorem ge_chunk : CmpChunk (T := UInt64) [.geUI64, .const 1, .and] (fun a b => if a ≥ b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a ≥ b then 1 else 0) = (if a ≥ b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_geUI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::ge`, built by reusing `ge_chunk`. -/
+theorem geBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.geUI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a ≥ b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp ge_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `ge_chunk` (matches emitted opcodes for `rw` at
+an inlined `a >= b`), proven *by reusing* the polymorphic `ge_chunk`. -/
+theorem ge_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.geUI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a ≥ b then 1 else 0) :: vs⟩ env :=
+  ge_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Gt.lean
+++ b/codelib/CodeLib/RustStd/U64/Gt.lean
@@ -1,0 +1,34 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::gt` (`a > b`) — inlined to `i64.gt_u; i32.const 1; i32.and`. Reuses the
+trunk's `CmpChunk`/`cmpBodyWp` (the `cmp` shape, exemplar `U64/Eq.lean`). -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined chunk `[.gtUI64, .const 1, .and]` computes the `i32` boolean
+`if a > b then 1 else 0` on stack operands (the `& 1` mask discharged here). -/
+theorem gt_chunk : CmpChunk (T := UInt64) [.gtUI64, .const 1, .and] (fun a b => if a > b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a > b then 1 else 0) = (if a > b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_gtUI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::gt`, built by reusing `gt_chunk`. -/
+theorem gtBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.gtUI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a > b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp gt_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `gt_chunk` (matches emitted opcodes for `rw` at
+an inlined `a > b`), proven *by reusing* the polymorphic `gt_chunk`. -/
+theorem gt_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.gtUI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a > b then 1 else 0) :: vs⟩ env :=
+  gt_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Le.lean
+++ b/codelib/CodeLib/RustStd/U64/Le.lean
@@ -1,0 +1,34 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::le` (`a <= b`) — inlined to `i64.le_u; i32.const 1; i32.and`. Reuses the
+trunk's `CmpChunk`/`cmpBodyWp` (the `cmp` shape, exemplar `U64/Eq.lean`). -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined chunk `[.leUI64, .const 1, .and]` computes the `i32` boolean
+`if a ≤ b then 1 else 0` on stack operands (the `& 1` mask discharged here). -/
+theorem le_chunk : CmpChunk (T := UInt64) [.leUI64, .const 1, .and] (fun a b => if a ≤ b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a ≤ b then 1 else 0) = (if a ≤ b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_leUI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::le`, built by reusing `le_chunk`. -/
+theorem leBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.leUI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a ≤ b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp le_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `le_chunk` (matches emitted opcodes for `rw` at
+an inlined `a <= b`), proven *by reusing* the polymorphic `le_chunk`. -/
+theorem le_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.leUI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a ≤ b then 1 else 0) :: vs⟩ env :=
+  le_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Lt.lean
+++ b/codelib/CodeLib/RustStd/U64/Lt.lean
@@ -1,0 +1,34 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::lt` (`a < b`) — inlined to `i64.lt_u; i32.const 1; i32.and`. Reuses the
+trunk's `CmpChunk`/`cmpBodyWp` (the `cmp` shape, exemplar `U64/Eq.lean`). -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined chunk `[.ltUI64, .const 1, .and]` computes the `i32` boolean
+`if a < b then 1 else 0` on stack operands (the `& 1` mask discharged here). -/
+theorem lt_chunk : CmpChunk (T := UInt64) [.ltUI64, .const 1, .and] (fun a b => if a < b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a < b then 1 else 0) = (if a < b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_ltUI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::lt`, built by reusing `lt_chunk`. -/
+theorem ltBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.ltUI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a < b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp lt_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `lt_chunk` (matches emitted opcodes for `rw` at
+an inlined `a < b`), proven *by reusing* the polymorphic `lt_chunk`. -/
+theorem lt_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.ltUI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a < b then 1 else 0) :: vs⟩ env :=
+  lt_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Max.lean
+++ b/codelib/CodeLib/RustStd/U64/Max.lean
@@ -1,0 +1,75 @@
+import CodeLib.RustStd.Frame
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Block
+import CodeLib.Entry
+
+/-! `u64::max` — `core::cmp::Ord::max`, the framed inner function the exported
+`max` wrapper `call`s. opt-0 spills both operands to the shadow stack, compares,
+and spills the winner. Reusable via the call rule (`wp_call_tw`), like `abs_diff`. -/
+
+set_option linter.unusedSimpArgs false
+
+namespace Wasm.RustStd.U64
+open Wasm
+
+/-- Verbatim opt-0 body of `core::cmp::Ord::max` for `u64`. -/
+def maxBody : Program :=
+  [ .globalGet 0, .const (32 : UInt32), .sub, .localSet 2,
+    .localGet 2, .localGet 0, .store64 (8 : UInt32),
+    .localGet 2, .localGet 1, .store64 (16 : UInt32),
+    .block 0 0 [
+      .block 0 0 [
+        .localGet 2, .load64 (16 : UInt32), .localGet 2, .load64 (8 : UInt32), .ltUI64,
+        .const (1 : UInt32), .and, .br_if 0,
+        .localGet 2, .localGet 2, .load64 (16 : UInt32), .store64 (24 : UInt32), .br 1 ],
+      .localGet 2, .localGet 2, .load64 (8 : UInt32), .store64 (24 : UInt32) ],
+    .localGet 2, .load64 (24 : UInt32), .ret ]
+
+def maxFunc : Function :=
+  { params := [.i64, .i64], locals := [.i32], body := maxBody, results := [.i64] }
+
+set_option maxRecDepth 4096 in
+theorem max_wp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (sp : UInt32) (a b : UInt64) (vs : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 sp))
+    (hlo : 32 ≤ sp.toNat) (hhi : sp.toNat ≤ st.mem.pages * 65536) :
+    wp m maxBody
+      (Returns (.i64 (if b < a then a else b) :: vs)
+        (fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages))
+      st ⟨[.i64 a, .i64 b], [.i32 0], vs⟩ env := by
+  unfold maxBody Returns
+  have hle  : (32 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using hlo)
+  have hle24 : (24 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using (by omega : 24 ≤ sp.toNat))
+  have hle16 : (16 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using (by omega : 16 ≤ sp.toNat))
+  have hsub   : (sp - 32).toNat = sp.toNat - 32 := UInt32.toNat_sub_of_le sp 32 hle
+  have hsub24 : (sp - 24).toNat = sp.toNat - 24 := UInt32.toNat_sub_of_le sp 24 hle24
+  have hsub16 : (sp - 16).toNat = sp.toNat - 16 := UInt32.toNat_sub_of_le sp 16 hle16
+  have h8  : (8  : UInt32).toNat = 8  := rfl
+  have h16 : (16 : UInt32).toNat = 16 := rfl
+  have h24 : (24 : UInt32).toNat = 24 := rfl
+  have hnt8  : ¬ ((sp - 32).toNat + 8  + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have hnt16 : ¬ ((sp - 32).toNat + 16 + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have hnt24 : ¬ ((sp - 32).toNat + 24 + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have e8  : (sp - 32) + 8  = sp - 24 := by bv_decide
+  have e16 : (sp - 32) + 16 = sp - 16 := by bv_decide
+  have hd : ((sp - 32) + 8).toNat + 8 ≤ ((sp - 32) + 16).toNat := by
+    rw [e8, e16, hsub24, hsub16]; omega
+  have hr16 : ((st.mem.write64 ((sp - 32) + 8) a).write64 ((sp - 32) + 16) b).read64 ((sp - 32) + 16) = b :=
+    Mem.read64_write64_same _ _ _
+  have hr8 : ((st.mem.write64 ((sp - 32) + 8) a).write64 ((sp - 32) + 16) b).read64 ((sp - 32) + 8) = a := by
+    rw [Mem.read64_write64_disjoint _ ((sp - 32) + 8) ((sp - 32) + 16) b (Or.inl hd)]
+    exact Mem.read64_write64_same _ _ _
+  simp only [wp_simp, Locals.get, Locals.set?, Function.toLocals,
+    Function.numParams, Function.numLocals, List.take, List.drop, List.replicate, List.length,
+    List.map, ValueType.zero, List.headD, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, List.set_cons_zero, List.set_cons_succ,
+    Nat.reduceAdd, Nat.reduceLT, Nat.reduceSub, reduceIte, hsp, hnt8, hnt16,
+    h8, h16, h24, Mem.write64_pages]
+  apply wp_block_cons
+  apply wp_block_cons
+  by_cases hba : b < a <;>
+    simp [hba, hnt8, hnt16, hnt24, h8, h16, h24, hr8, hr16, Mem.read64_write64_same,
+      Mem.write64_pages] <;>
+    omega
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Min.lean
+++ b/codelib/CodeLib/RustStd/U64/Min.lean
@@ -1,0 +1,75 @@
+import CodeLib.RustStd.Frame
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Wp.Block
+import CodeLib.Entry
+
+/-! `u64::min` — `core::cmp::Ord::min`, the framed inner function the exported
+`min` wrapper `call`s. Same shape as `max` (spill both operands, compare, spill
+the loser); only the two branch stores swap. Reusable via the call rule. -/
+
+set_option linter.unusedSimpArgs false
+
+namespace Wasm.RustStd.U64
+open Wasm
+
+/-- Verbatim opt-0 body of `core::cmp::Ord::min` for `u64`. -/
+def minBody : Program :=
+  [ .globalGet 0, .const (32 : UInt32), .sub, .localSet 2,
+    .localGet 2, .localGet 0, .store64 (8 : UInt32),
+    .localGet 2, .localGet 1, .store64 (16 : UInt32),
+    .block 0 0 [
+      .block 0 0 [
+        .localGet 2, .load64 (16 : UInt32), .localGet 2, .load64 (8 : UInt32), .ltUI64,
+        .const (1 : UInt32), .and, .br_if 0,
+        .localGet 2, .localGet 2, .load64 (8 : UInt32), .store64 (24 : UInt32), .br 1 ],
+      .localGet 2, .localGet 2, .load64 (16 : UInt32), .store64 (24 : UInt32) ],
+    .localGet 2, .load64 (24 : UInt32), .ret ]
+
+def minFunc : Function :=
+  { params := [.i64, .i64], locals := [.i32], body := minBody, results := [.i64] }
+
+set_option maxRecDepth 4096 in
+theorem min_wp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (sp : UInt32) (a b : UInt64) (vs : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 sp))
+    (hlo : 32 ≤ sp.toNat) (hhi : sp.toNat ≤ st.mem.pages * 65536) :
+    wp m minBody
+      (Returns (.i64 (if b < a then b else a) :: vs)
+        (fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages))
+      st ⟨[.i64 a, .i64 b], [.i32 0], vs⟩ env := by
+  unfold minBody Returns
+  have hle  : (32 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using hlo)
+  have hle24 : (24 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using (by omega : 24 ≤ sp.toNat))
+  have hle16 : (16 : UInt32) ≤ sp := UInt32.le_iff_toNat_le.mpr (by simpa using (by omega : 16 ≤ sp.toNat))
+  have hsub   : (sp - 32).toNat = sp.toNat - 32 := UInt32.toNat_sub_of_le sp 32 hle
+  have hsub24 : (sp - 24).toNat = sp.toNat - 24 := UInt32.toNat_sub_of_le sp 24 hle24
+  have hsub16 : (sp - 16).toNat = sp.toNat - 16 := UInt32.toNat_sub_of_le sp 16 hle16
+  have h8  : (8  : UInt32).toNat = 8  := rfl
+  have h16 : (16 : UInt32).toNat = 16 := rfl
+  have h24 : (24 : UInt32).toNat = 24 := rfl
+  have hnt8  : ¬ ((sp - 32).toNat + 8  + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have hnt16 : ¬ ((sp - 32).toNat + 16 + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have hnt24 : ¬ ((sp - 32).toNat + 24 + 8 > st.mem.pages * 65536) := by rw [hsub]; omega
+  have e8  : (sp - 32) + 8  = sp - 24 := by bv_decide
+  have e16 : (sp - 32) + 16 = sp - 16 := by bv_decide
+  have hd : ((sp - 32) + 8).toNat + 8 ≤ ((sp - 32) + 16).toNat := by
+    rw [e8, e16, hsub24, hsub16]; omega
+  have hr16 : ((st.mem.write64 ((sp - 32) + 8) a).write64 ((sp - 32) + 16) b).read64 ((sp - 32) + 16) = b :=
+    Mem.read64_write64_same _ _ _
+  have hr8 : ((st.mem.write64 ((sp - 32) + 8) a).write64 ((sp - 32) + 16) b).read64 ((sp - 32) + 8) = a := by
+    rw [Mem.read64_write64_disjoint _ ((sp - 32) + 8) ((sp - 32) + 16) b (Or.inl hd)]
+    exact Mem.read64_write64_same _ _ _
+  simp only [wp_simp, Locals.get, Locals.set?, Function.toLocals,
+    Function.numParams, Function.numLocals, List.take, List.drop, List.replicate, List.length,
+    List.map, ValueType.zero, List.headD, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, List.set_cons_zero, List.set_cons_succ,
+    Nat.reduceAdd, Nat.reduceLT, Nat.reduceSub, reduceIte, hsp, hnt8, hnt16,
+    h8, h16, h24, Mem.write64_pages]
+  apply wp_block_cons
+  apply wp_block_cons
+  by_cases hba : b < a <;>
+    simp [hba, hnt8, hnt16, hnt24, h8, h16, h24, hr8, hr16, Mem.read64_write64_same,
+      Mem.write64_pages] <;>
+    omega
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Ne.lean
+++ b/codelib/CodeLib/RustStd/U64/Ne.lean
@@ -1,0 +1,34 @@
+import CodeLib.RustStd.U64.Basic
+
+/-! `u64::ne` (`a != b`) — inlined to `i64.ne; i32.const 1; i32.and`. Reuses the
+trunk's `CmpChunk`/`cmpBodyWp` (the `cmp` shape, exemplar `U64/Eq.lean`). -/
+
+namespace Wasm.RustStd.U64
+open Wasm Wasm.RustStd
+
+/-- The inlined chunk `[.neI64, .const 1, .and]` computes the `i32` boolean
+`if a ≠ b then 1 else 0` on stack operands (the `& 1` mask discharged here). -/
+theorem ne_chunk : CmpChunk (T := UInt64) [.neI64, .const 1, .and] (fun a b => if a ≠ b then 1 else 0) := by
+  intro α m env Q st P L rest a b vs
+  have hmask : (1 : UInt32) &&& (if a ≠ b then 1 else 0) = (if a ≠ b then 1 else 0) := by
+    split <;> decide
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_neI64_cons, wp_const_cons,
+    wp_and_cons, hmask]
+
+set_option maxRecDepth 4096 in
+/-- Export-body theorem for `rust_u64::ne`, built by reusing `ne_chunk`. -/
+theorem neBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
+    (a b : UInt64) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ [.neI64, .const 1, .and] ++ [.ret])
+      (Returns (.i32 (if a ≠ b then 1 else 0) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  cmpBodyWp ne_chunk st a b vs
+
+/-- Concrete-`i64` restatement of `ne_chunk` (matches emitted opcodes for `rw` at
+an inlined `a != b`), proven *by reusing* the polymorphic `ne_chunk`. -/
+theorem ne_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
+    wp m (.neI64 :: .const 1 :: .and :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
+      wp m rest Q st ⟨P, L, .i32 (if a ≠ b then 1 else 0) :: vs⟩ env :=
+  ne_chunk a b vs
+
+end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Rem.lean
+++ b/codelib/CodeLib/RustStd/U64/Rem.lean
@@ -17,7 +17,7 @@ theorem rem_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
 def remBody : Program :=
   [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
                  .localGet 0, .localGet 1, .remUI64, .ret ],
-    .const 1048616, .call 73, .unreachable ]
+    .const 1048664, .call 84, .unreachable ]
 
 set_option maxRecDepth 4096 in
 /-- Export-body theorem for `rust_u64::rem` (divisor ≠ 0): peel the guard, then

--- a/codelib/CodeLib/RustStd/U64/Rem.lean
+++ b/codelib/CodeLib/RustStd/U64/Rem.lean
@@ -17,7 +17,7 @@ theorem rem_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
 def remBody : Program :=
   [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
                  .localGet 0, .localGet 1, .remUI64, .ret ],
-    .const 1048616, .call 67, .unreachable ]
+    .const 1048616, .call 73, .unreachable ]
 
 set_option maxRecDepth 4096 in
 /-- Export-body theorem for `rust_u64::rem` (divisor ≠ 0): peel the guard, then

--- a/codelib/CodeLib/RustStd/UInt.lean
+++ b/codelib/CodeLib/RustStd/UInt.lean
@@ -61,6 +61,22 @@ abbrev UnChunk (frag : Program) (op : T → T) : Prop :=
     wp m (frag ++ rest) Q st ⟨P, L, toV a :: vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a) :: vs⟩ env
 
+/-- Chunk shape for a comparison / boolean-returning op: with `toV b :: toV a ::
+vs` on the stack, running `frag` then `rest` equals running `rest` with the `i32`
+result `res a b` on the stack. The result is an `i32` (the wasm `bool`), **not** a
+`toV`-carried `T`, which is what distinguishes this from `BinChunk`.
+
+At `opt-0` a comparison `a OP b` compiles to `[cmpOp, i32.const 1, i32.and]` — the
+`i64.cmp` already yields `0/1`, and the `& 1` is a redundant `bool` normalisation.
+So for the six comparisons `res a b = if a OP b then 1 else 0`, and the mask is
+discharged *inside* the per-op chunk proof, leaving this clean `i32` result that
+`cmpBodyWp` and inlined client sites both reuse. -/
+abbrev CmpChunk (frag : Program) (res : T → T → UInt32) : Prop :=
+  ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
+    {P L : List Value} {rest : Program} (a b : T) (vs : List Value),
+    wp m (frag ++ rest) Q st ⟨P, L, toV b :: toV a :: vs⟩ env ↔
+    wp m rest Q st ⟨P, L, .i32 (res a b) :: vs⟩ env
+
 /-- Turn a binary chunk into the opt-0 export-body theorem
 `[localGet 0, localGet 1] ++ frag ++ [ret]` — by **reusing the chunk** (the
 opaque `frag` means `wp_run` can't bypass it). The per-crate spec feeds this to
@@ -89,6 +105,23 @@ theorem unBodyWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
   wp_run
   simp
   rw [chunk a vs]
+  simp
+
+/-- Turn a comparison chunk into the opt-0 export-body theorem
+`[localGet 0, localGet 1] ++ frag ++ [ret]` — by **reusing the chunk**. Mirrors
+`binBodyWp`, but the result lands as the `i32` boolean `res a b` (a `bool`
+return), not a `toV`-carried `T`. The per-crate spec feeds this to
+`of_returns_wp`. -/
+theorem cmpBodyWp {frag : Program} {res : T → T → UInt32} (chunk : CmpChunk frag res)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α) (a b : T) (vs : List Value) :
+    wp m ([.localGet 0, .localGet 1] ++ frag ++ [.ret])
+      (Returns (.i32 (res a b) :: vs) (framePost st))
+      st ⟨[toV a, toV b], [], vs⟩ env := by
+  unfold Returns framePost
+  simp only [List.cons_append, List.nil_append]
+  wp_run
+  simp
+  rw [chunk a b vs]
   simp
 
 end

--- a/programs/lean/Project/RustU64/Program.lean
+++ b/programs/lean/Project/RustU64/Program.lean
@@ -13,6 +13,272 @@ open Wasm
 def func0 : Wasm.Program :=
   [
   .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .localGet 0,
+  .store64 (8 : UInt32),
+  .localGet 2,
+  .localGet 1,
+  .store64 (16 : UInt32),
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .ltUI64,
+      .const (1 : UInt32),
+      .and,
+      .br_if 0,
+      .localGet 2,
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .store64 (24 : UInt32),
+      .br 1
+    ],
+    .localGet 2,
+    .localGet 2,
+    .load64 (8 : UInt32),
+    .store64 (24 : UInt32)
+  ],
+  .localGet 2,
+  .load64 (24 : UInt32),
+  .ret
+]
+
+def func0Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [.i32], body := func0, results := [.i64] }
+
+def func1 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .localGet 0,
+  .store64 (8 : UInt32),
+  .localGet 2,
+  .localGet 1,
+  .store64 (16 : UInt32),
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .ltUI64,
+      .const (1 : UInt32),
+      .and,
+      .br_if 0,
+      .localGet 2,
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .store64 (24 : UInt32),
+      .br 1
+    ],
+    .localGet 2,
+    .localGet 2,
+    .load64 (16 : UInt32),
+    .store64 (24 : UInt32)
+  ],
+  .localGet 2,
+  .load64 (24 : UInt32),
+  .ret
+]
+
+def func1Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [.i32], body := func1, results := [.i64] }
+
+def func2 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (80 : UInt32),
+  .sub,
+  .localSet 4,
+  .localGet 4,
+  .globalSet 0,
+  .block 0 0 [
+    .localGet 1,
+    .localGet 2,
+    .leUI64,
+    .const (1 : UInt32),
+    .and,
+    .br_if 0,
+    .localGet 4,
+    .localGet 1,
+    .store64 (16 : UInt32),
+    .localGet 4,
+    .localGet 2,
+    .store64 (24 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .const (16 : UInt32),
+    .add,
+    .store32 (64 : UInt32),
+    .localGet 4,
+    .const (1 : UInt32),
+    .store32 (68 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .load64 (64 : UInt32),
+    .store64 (48 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .const (24 : UInt32),
+    .add,
+    .store32 (72 : UInt32),
+    .localGet 4,
+    .const (1 : UInt32),
+    .store32 (76 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .load64 (72 : UInt32),
+    .store64 (56 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .localGet 4,
+    .load64 (48 : UInt32),
+    .store64 (0 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .const (8 : UInt32),
+    .add,
+    .localGet 4,
+    .load64 (56 : UInt32),
+    .store64 (0 : UInt32),
+    .const (1048576 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .localGet 3,
+    .call 76,
+    .unreachable
+  ],
+  .block 0 0 [
+    .block 0 0 [
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 0,
+            .localGet 1,
+            .ltUI64,
+            .const (1 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 0,
+            .localGet 2,
+            .gtUI64,
+            .const (1 : UInt32),
+            .and,
+            .br_if 2,
+            .br 1
+          ],
+          .localGet 4,
+          .localGet 1,
+          .store64 (8 : UInt32),
+          .br 3
+        ],
+        .localGet 4,
+        .localGet 0,
+        .store64 (8 : UInt32),
+        .br 1
+      ],
+      .localGet 4,
+      .localGet 2,
+      .store64 (8 : UInt32)
+    ]
+  ],
+  .localGet 4,
+  .load64 (8 : UInt32),
+  .localSet 5,
+  .localGet 4,
+  .const (80 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 5,
+  .ret
+]
+
+def func2Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i32], locals := [.i32, .i64], body := func2, results := [.i64] }
+
+def func3 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .block 0 0 [
+    .block 0 0 [
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 1,
+            .load32 (8 : UInt32),
+            .const (33554432 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 1,
+            .load32 (8 : UInt32),
+            .const (67108864 : UInt32),
+            .and,
+            .eqz,
+            .br_if 1,
+            .br 2
+          ],
+          .localGet 2,
+          .localGet 0,
+          .localGet 1,
+          .call 85,
+          .const (1 : UInt32),
+          .and,
+          .store8 (15 : UInt32),
+          .br 3
+        ],
+        .localGet 2,
+        .localGet 0,
+        .localGet 1,
+        .call 77,
+        .const (1 : UInt32),
+        .and,
+        .store8 (15 : UInt32),
+        .br 1
+      ],
+      .localGet 2,
+      .localGet 0,
+      .localGet 1,
+      .call 86,
+      .const (1 : UInt32),
+      .and,
+      .store8 (15 : UInt32)
+    ]
+  ],
+  .localGet 2,
+  .load8U (15 : UInt32),
+  .const (1 : UInt32),
+  .and,
+  .localSet 3,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 3,
+  .ret
+]
+
+def func3Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func3, results := [.i32] }
+
+def func4 : Wasm.Program :=
+  [
+  .globalGet 0,
   .const (16 : UInt32),
   .sub,
   .localSet 2,
@@ -42,23 +308,23 @@ def func0 : Wasm.Program :=
   .ret
 ]
 
-def func0Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [.i32], body := func0, results := [.i64] }
+def func4Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [.i32], body := func4, results := [.i64] }
 
 /-- export: abs_diff -/
-def func1 : Wasm.Program :=
+def func5 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 0,
+  .call 4,
   .ret
 ]
 
-def func1Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func1, results := [.i64] }
+def func5Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func5, results := [.i64] }
 
 /-- export: add -/
-def func2 : Wasm.Program :=
+def func6 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -66,11 +332,11 @@ def func2 : Wasm.Program :=
   .ret
 ]
 
-def func2Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func2, results := [.i64] }
+def func6Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func6, results := [.i64] }
 
 /-- export: bitand -/
-def func3 : Wasm.Program :=
+def func7 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -78,11 +344,11 @@ def func3 : Wasm.Program :=
   .ret
 ]
 
-def func3Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func3, results := [.i64] }
+def func7Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func7, results := [.i64] }
 
 /-- export: bitor -/
-def func4 : Wasm.Program :=
+def func8 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -90,11 +356,11 @@ def func4 : Wasm.Program :=
   .ret
 ]
 
-def func4Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func4, results := [.i64] }
+def func8Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func8, results := [.i64] }
 
 /-- export: bitxor -/
-def func5 : Wasm.Program :=
+def func9 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -102,11 +368,25 @@ def func5 : Wasm.Program :=
   .ret
 ]
 
-def func5Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func5, results := [.i64] }
+def func9Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func9, results := [.i64] }
+
+/-- export: clamp -/
+def func10 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .localGet 2,
+  .const (1048632 : UInt32),
+  .call 2,
+  .ret
+]
+
+def func10Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func10, results := [.i64] }
 
 /-- export: div -/
-def func6 : Wasm.Program :=
+def func11 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -120,24 +400,44 @@ def func6 : Wasm.Program :=
     .divUI64,
     .ret
   ],
-  .const (1048600 : UInt32),
-  .call 72,
+  .const (1048648 : UInt32),
+  .call 83,
   .unreachable
 ]
 
-def func6Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func6, results := [.i64] }
+def func11Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func11, results := [.i64] }
 
 /-- export: entrypoint -/
-def func7 : Wasm.Program :=
+def func12 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 1,
+  .call 5,
   .drop,
   .localGet 0,
   .localGet 1,
-  .call 2,
+  .call 6,
+  .drop,
+  .localGet 0,
+  .localGet 1,
+  .call 13,
+  .drop,
+  .localGet 0,
+  .localGet 1,
+  .call 14,
+  .drop,
+  .localGet 0,
+  .localGet 1,
+  .call 11,
+  .drop,
+  .localGet 0,
+  .localGet 1,
+  .call 15,
+  .drop,
+  .localGet 0,
+  .localGet 1,
+  .call 7,
   .drop,
   .localGet 0,
   .localGet 1,
@@ -148,44 +448,24 @@ def func7 : Wasm.Program :=
   .call 9,
   .drop,
   .localGet 0,
-  .localGet 1,
-  .call 6,
-  .drop,
-  .localGet 0,
-  .localGet 1,
-  .call 10,
-  .drop,
-  .localGet 0,
-  .localGet 1,
-  .call 3,
-  .drop,
-  .localGet 0,
-  .localGet 1,
-  .call 4,
-  .drop,
-  .localGet 0,
-  .localGet 1,
-  .call 5,
-  .drop,
-  .localGet 0,
-  .call 11,
+  .call 16,
   .drop,
   .localGet 0,
   .localGet 2,
-  .call 12,
+  .call 17,
   .drop,
   .localGet 0,
   .localGet 2,
-  .call 13,
+  .call 18,
   .drop,
   .ret
 ]
 
-def func7Def : Wasm.Function :=
-  { params := [.i64, .i64, .i32], locals := [], body := func7, results := [] }
+def func12Def : Wasm.Function :=
+  { params := [.i64, .i64, .i32], locals := [], body := func12, results := [] }
 
 /-- export: sub -/
-def func8 : Wasm.Program :=
+def func13 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -193,11 +473,11 @@ def func8 : Wasm.Program :=
   .ret
 ]
 
-def func8Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func8, results := [.i64] }
+def func13Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func13, results := [.i64] }
 
 /-- export: mul -/
-def func9 : Wasm.Program :=
+def func14 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -205,11 +485,11 @@ def func9 : Wasm.Program :=
   .ret
 ]
 
-def func9Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func9, results := [.i64] }
+def func14Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func14, results := [.i64] }
 
 /-- export: rem -/
-def func10 : Wasm.Program :=
+def func15 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -223,16 +503,16 @@ def func10 : Wasm.Program :=
     .remUI64,
     .ret
   ],
-  .const (1048616 : UInt32),
-  .call 73,
+  .const (1048664 : UInt32),
+  .call 84,
   .unreachable
 ]
 
-def func10Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func10, results := [.i64] }
+def func15Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func15, results := [.i64] }
 
 /-- export: not -/
-def func11 : Wasm.Program :=
+def func16 : Wasm.Program :=
   [
   .localGet 0,
   .constI64 (18446744073709551615 : UInt64),
@@ -240,11 +520,11 @@ def func11 : Wasm.Program :=
   .ret
 ]
 
-def func11Def : Wasm.Function :=
-  { params := [.i64], locals := [], body := func11, results := [.i64] }
+def func16Def : Wasm.Function :=
+  { params := [.i64], locals := [], body := func16, results := [.i64] }
 
 /-- export: shl -/
-def func12 : Wasm.Program :=
+def func17 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -255,11 +535,11 @@ def func12 : Wasm.Program :=
   .ret
 ]
 
-def func12Def : Wasm.Function :=
-  { params := [.i64, .i32], locals := [], body := func12, results := [.i64] }
+def func17Def : Wasm.Function :=
+  { params := [.i64, .i32], locals := [], body := func17, results := [.i64] }
 
 /-- export: shr -/
-def func13 : Wasm.Program :=
+def func18 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -270,11 +550,11 @@ def func13 : Wasm.Program :=
   .ret
 ]
 
-def func13Def : Wasm.Function :=
-  { params := [.i64, .i32], locals := [], body := func13, results := [.i64] }
+def func18Def : Wasm.Function :=
+  { params := [.i64, .i32], locals := [], body := func18, results := [.i64] }
 
 /-- export: eq -/
-def func14 : Wasm.Program :=
+def func19 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -284,11 +564,11 @@ def func14 : Wasm.Program :=
   .ret
 ]
 
-def func14Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func14, results := [.i32] }
+def func19Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func19, results := [.i32] }
 
 /-- export: ge -/
-def func15 : Wasm.Program :=
+def func20 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -298,11 +578,11 @@ def func15 : Wasm.Program :=
   .ret
 ]
 
-def func15Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func15, results := [.i32] }
+def func20Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func20, results := [.i32] }
 
 /-- export: gt -/
-def func16 : Wasm.Program :=
+def func21 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -312,11 +592,11 @@ def func16 : Wasm.Program :=
   .ret
 ]
 
-def func16Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func16, results := [.i32] }
+def func21Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func21, results := [.i32] }
 
 /-- export: le -/
-def func17 : Wasm.Program :=
+def func22 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -326,11 +606,11 @@ def func17 : Wasm.Program :=
   .ret
 ]
 
-def func17Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func17, results := [.i32] }
+def func22Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func22, results := [.i32] }
 
 /-- export: lt -/
-def func18 : Wasm.Program :=
+def func23 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -340,11 +620,35 @@ def func18 : Wasm.Program :=
   .ret
 ]
 
-def func18Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func18, results := [.i32] }
+def func23Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func23, results := [.i32] }
+
+/-- export: max -/
+def func24 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 0,
+  .ret
+]
+
+def func24Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func24, results := [.i64] }
+
+/-- export: min -/
+def func25 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 1,
+  .ret
+]
+
+def func25Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func25, results := [.i64] }
 
 /-- export: ne -/
-def func19 : Wasm.Program :=
+def func26 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -354,63 +658,63 @@ def func19 : Wasm.Program :=
   .ret
 ]
 
-def func19Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func19, results := [.i32] }
+def func26Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func26, results := [.i32] }
 
-def func20 : Wasm.Program :=
+def func27 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 37,
+  .call 44,
   .ret
 ]
 
-def func20Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func20, results := [.i32] }
+def func27Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func27, results := [.i32] }
 
-def func21 : Wasm.Program :=
+def func28 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
-  .call 41,
+  .call 48,
   .ret
 ]
 
-def func21Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func21, results := [] }
+def func28Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func28, results := [] }
 
-def func22 : Wasm.Program :=
+def func29 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
   .localGet 3,
-  .call 43,
+  .call 50,
   .ret
 ]
 
-def func22Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [], body := func22, results := [.i32] }
+def func29Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [], body := func29, results := [.i32] }
 
-def func23 : Wasm.Program :=
+def func30 : Wasm.Program :=
   [
   .ret
 ]
 
-def func23Def : Wasm.Function :=
-  { params := [], locals := [], body := func23, results := [] }
+def func30Def : Wasm.Function :=
+  { params := [], locals := [], body := func30, results := [] }
 
-def func24 : Wasm.Program :=
+def func31 : Wasm.Program :=
   [
-  .call 40,
+  .call 47,
   .unreachable
 ]
 
-def func24Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func24, results := [.i32] }
+def func31Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func31, results := [.i32] }
 
-def func25 : Wasm.Program :=
+def func32 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -429,7 +733,7 @@ def func25 : Wasm.Program :=
     .br_if 0,
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .call 65,
+    .call 72,
     .unreachable
   ],
   .localGet 5,
@@ -469,7 +773,7 @@ def func25 : Wasm.Program :=
   .localGet 2,
   .localGet 3,
   .localGet 4,
-  .call 33,
+  .call 40,
   .block 0 0 [
     .localGet 5,
     .load32 (4 : UInt32),
@@ -480,7 +784,7 @@ def func25 : Wasm.Program :=
     .load32 (8 : UInt32),
     .localGet 5,
     .load32 (12 : UInt32),
-    .call 65,
+    .call 72,
     .unreachable
   ],
   .localGet 5,
@@ -498,10 +802,10 @@ def func25 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func25Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func25, results := [] }
+def func32Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func32, results := [] }
 
-def func26 : Wasm.Program :=
+def func33 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -513,14 +817,14 @@ def func26 : Wasm.Program :=
     .localGet 1,
     .localGet 0,
     .const (1 : UInt32),
-    .call 21
+    .call 28
   ]
 ]
 
-def func26Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func26, results := [] }
+def func33Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func33, results := [] }
 
-def func27 : Wasm.Program :=
+def func34 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -533,14 +837,14 @@ def func27 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 21
+    .call 28
   ]
 ]
 
-def func27Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func27, results := [] }
+def func34Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func34, results := [] }
 
-def func28 : Wasm.Program :=
+def func35 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -554,54 +858,54 @@ def func28 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 21
+    .call 28
   ]
 ]
 
-def func28Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func28, results := [] }
+def func35Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func35, results := [] }
 
-def func29 : Wasm.Program :=
+def func36 : Wasm.Program :=
   [
   .localGet 0,
-  .call 30,
+  .call 37,
   .unreachable
 ]
 
-def func29Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func29, results := [] }
+def func36Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func36, results := [] }
 
-def func30 : Wasm.Program :=
+def func37 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049156 : UInt32),
+  .load32 (1049436 : UInt32),
   .localSet 0,
   .localGet 0,
-  .const (1 : UInt32),
+  .const (2 : UInt32),
   .localGet 0,
   .select,
   .callIndirect 0 0,
   .unreachable
 ]
 
-def func30Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func30, results := [] }
+def func37Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func37, results := [] }
 
-def func31 : Wasm.Program :=
+def func38 : Wasm.Program :=
   [
   .localGet 0,
-  .call 32,
+  .call 39,
   .unreachable
 ]
 
-def func31Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func31, results := [] }
+def func38Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func38, results := [] }
 
-def func32 : Wasm.Program :=
+def func39 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -633,7 +937,7 @@ def func32 : Wasm.Program :=
     .localGet 2,
     .store32 (0 : UInt32),
     .localGet 1,
-    .const (1048656 : UInt32),
+    .const (1048704 : UInt32),
     .localGet 0,
     .load32 (4 : UInt32),
     .localGet 0,
@@ -643,7 +947,7 @@ def func32 : Wasm.Program :=
     .load8U (8 : UInt32),
     .localGet 0,
     .load8U (9 : UInt32),
-    .call 34,
+    .call 41,
     .unreachable
   ],
   .localGet 1,
@@ -653,7 +957,7 @@ def func32 : Wasm.Program :=
   .localGet 0,
   .store32 (12 : UInt32),
   .localGet 1,
-  .const (1048684 : UInt32),
+  .const (1048732 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
   .localGet 0,
@@ -663,14 +967,14 @@ def func32 : Wasm.Program :=
   .load8U (8 : UInt32),
   .localGet 0,
   .load8U (9 : UInt32),
-  .call 34,
+  .call 41,
   .unreachable
 ]
 
-def func32Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32], body := func32, results := [] }
+def func39Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32], body := func39, results := [] }
 
-def func33 : Wasm.Program :=
+def func40 : Wasm.Program :=
   [
   .const (1 : UInt32),
   .localSet 6,
@@ -721,7 +1025,7 @@ def func33 : Wasm.Program :=
             .mul,
             .localGet 4,
             .localGet 3,
-            .call 22,
+            .call 29,
             .localSet 7,
             .br 1
           ],
@@ -732,10 +1036,10 @@ def func33 : Wasm.Program :=
             .localSet 7,
             .br 2
           ],
-          .call 23,
+          .call 30,
           .localGet 3,
           .localGet 4,
-          .call 20,
+          .call 27,
           .localSet 7
         ],
         .localGet 7,
@@ -764,10 +1068,10 @@ def func33 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func33Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func33, results := [] }
+def func40Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func40, results := [] }
 
-def func34 : Wasm.Program :=
+def func41 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -781,13 +1085,13 @@ def func34 : Wasm.Program :=
         .block 0 0 [
           .block 0 0 [
             .const (1 : UInt32),
-            .call 50,
+            .call 57,
             .const (255 : UInt32),
             .and,
             .brTable [4, 1, 0] 1
           ],
           .const (0 : UInt32),
-          .load32 (1049160 : UInt32),
+          .load32 (1049440 : UInt32),
           .localSet 6,
           .localGet 6,
           .const (4294967295 : UInt32),
@@ -797,9 +1101,9 @@ def func34 : Wasm.Program :=
           .localGet 6,
           .const (1 : UInt32),
           .add,
-          .store32 (1049160 : UInt32),
+          .store32 (1049440 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049164 : UInt32),
+          .load32 (1049444 : UInt32),
           .eqz,
           .br_if 1,
           .localGet 5,
@@ -823,12 +1127,12 @@ def func34 : Wasm.Program :=
           .load64 (8 : UInt32),
           .store64 (16 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049164 : UInt32),
+          .load32 (1049444 : UInt32),
           .localGet 5,
           .const (16 : UInt32),
           .add,
           .const (0 : UInt32),
-          .load32 (1049168 : UInt32),
+          .load32 (1049448 : UInt32),
           .load32 (20 : UInt32),
           .callIndirect 0 0,
           .br 2
@@ -842,54 +1146,54 @@ def func34 : Wasm.Program :=
       ],
       .const (2147483648 : UInt32),
       .localGet 5,
-      .call 26
+      .call 33
     ],
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049160 : UInt32),
+    .load32 (1049440 : UInt32),
     .const (4294967295 : UInt32),
     .add,
-    .store32 (1049160 : UInt32),
+    .store32 (1049440 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .store8 (1049152 : UInt32),
+    .store8 (1049432 : UInt32),
     .localGet 3,
     .eqz,
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 36,
+    .call 43,
     .unreachable
   ],
   .unreachable
 ]
 
-def func34Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func34, results := [] }
+def func41Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func41, results := [] }
 
-def func35 : Wasm.Program :=
+def func42 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .const (1 : UInt32),
-  .store8 (1049628 : UInt32)
+  .store8 (1049908 : UInt32)
 ]
 
-def func35Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func35, results := [] }
+def func42Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func42, results := [] }
 
-def func36 : Wasm.Program :=
+def func43 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 24,
+  .call 31,
   .drop,
   .unreachable
 ]
 
-def func36Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func36, results := [] }
+def func43Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func43, results := [] }
 
-def func37 : Wasm.Program :=
+def func44 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -898,17 +1202,17 @@ def func37 : Wasm.Program :=
     .br_if 0,
     .localGet 1,
     .localGet 0,
-    .call 38,
+    .call 45,
     .ret
   ],
   .localGet 0,
-  .call 39
+  .call 46
 ]
 
-def func37Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func37, results := [.i32] }
+def func44Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func44, results := [.i32] }
 
-def func38 : Wasm.Program :=
+def func45 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -942,7 +1246,7 @@ def func38 : Wasm.Program :=
     .add,
     .const (12 : UInt32),
     .add,
-    .call 39,
+    .call 46,
     .localSet 1,
     .localGet 1,
     .eqz,
@@ -1051,7 +1355,7 @@ def func38 : Wasm.Program :=
         .store32 (4 : UInt32),
         .localGet 2,
         .localGet 1,
-        .call 45,
+        .call 52,
         .br 1
       ],
       .localGet 2,
@@ -1119,7 +1423,7 @@ def func38 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 1,
       .localGet 3,
-      .call 45
+      .call 52
     ],
     .localGet 0,
     .const (8 : UInt32),
@@ -1129,10 +1433,10 @@ def func38 : Wasm.Program :=
   .localGet 2
 ]
 
-def func38Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func38, results := [.i32] }
+def func45Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func45, results := [.i32] }
 
-def func39 : Wasm.Program :=
+def func46 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -1166,7 +1470,7 @@ def func39 : Wasm.Program :=
           .and,
           .localSet 3,
           .const (0 : UInt32),
-          .load32 (1049588 : UInt32),
+          .load32 (1049868 : UInt32),
           .localSet 4,
           .localGet 4,
           .eqz,
@@ -1205,7 +1509,7 @@ def func39 : Wasm.Program :=
                 .block 0 0 [
                   .block 0 0 [
                     .const (0 : UInt32),
-                    .load32 (1049584 : UInt32),
+                    .load32 (1049864 : UInt32),
                     .localSet 6,
                     .localGet 6,
                     .const (16 : UInt32),
@@ -1244,12 +1548,12 @@ def func39 : Wasm.Program :=
                     .shl,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049320 : UInt32),
+                    .const (1049600 : UInt32),
                     .add,
                     .localSet 0,
                     .localGet 0,
                     .localGet 3,
-                    .const (1049328 : UInt32),
+                    .const (1049608 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 2,
@@ -1269,13 +1573,13 @@ def func39 : Wasm.Program :=
                   ],
                   .localGet 3,
                   .const (0 : UInt32),
-                  .load32 (1049592 : UInt32),
+                  .load32 (1049872 : UInt32),
                   .leU,
                   .br_if 6,
                   .localGet 0,
                   .br_if 2,
                   .const (0 : UInt32),
-                  .load32 (1049588 : UInt32),
+                  .load32 (1049868 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .eqz,
@@ -1284,7 +1588,7 @@ def func39 : Wasm.Program :=
                   .ctz,
                   .const (2 : UInt32),
                   .shl,
-                  .const (1049176 : UInt32),
+                  .const (1049456 : UInt32),
                   .add,
                   .load32 (0 : UInt32),
                   .localSet 8,
@@ -1401,7 +1705,7 @@ def func39 : Wasm.Program :=
                           .load32 (28 : UInt32),
                           .const (2 : UInt32),
                           .shl,
-                          .const (1049176 : UInt32),
+                          .const (1049456 : UInt32),
                           .add,
                           .localSet 8,
                           .localGet 8,
@@ -1498,7 +1802,7 @@ def func39 : Wasm.Program :=
                 .localGet 7,
                 .rotl,
                 .and,
-                .store32 (1049584 : UInt32)
+                .store32 (1049864 : UInt32)
               ],
               .localGet 2,
               .const (8 : UInt32),
@@ -1543,12 +1847,12 @@ def func39 : Wasm.Program :=
                 .shl,
                 .localSet 2,
                 .localGet 2,
-                .const (1049320 : UInt32),
+                .const (1049600 : UInt32),
                 .add,
                 .localSet 8,
                 .localGet 8,
                 .localGet 2,
-                .const (1049328 : UInt32),
+                .const (1049608 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 0,
@@ -1572,7 +1876,7 @@ def func39 : Wasm.Program :=
               .localGet 9,
               .rotl,
               .and,
-              .store32 (1049584 : UInt32)
+              .store32 (1049864 : UInt32)
             ],
             .localGet 0,
             .localGet 3,
@@ -1599,18 +1903,18 @@ def func39 : Wasm.Program :=
             .store32 (0 : UInt32),
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049592 : UInt32),
+              .load32 (1049872 : UInt32),
               .localSet 2,
               .localGet 2,
               .eqz,
               .br_if 0,
               .const (0 : UInt32),
-              .load32 (1049600 : UInt32),
+              .load32 (1049880 : UInt32),
               .localSet 3,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049584 : UInt32),
+                  .load32 (1049864 : UInt32),
                   .localSet 7,
                   .localGet 7,
                   .const (1 : UInt32),
@@ -1626,11 +1930,11 @@ def func39 : Wasm.Program :=
                   .localGet 7,
                   .localGet 9,
                   .or,
-                  .store32 (1049584 : UInt32),
+                  .store32 (1049864 : UInt32),
                   .localGet 2,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049320 : UInt32),
+                  .const (1049600 : UInt32),
                   .add,
                   .localSet 2,
                   .localGet 2,
@@ -1642,11 +1946,11 @@ def func39 : Wasm.Program :=
                 .and,
                 .localSet 2,
                 .localGet 2,
-                .const (1049320 : UInt32),
+                .const (1049600 : UInt32),
                 .add,
                 .localSet 7,
                 .localGet 2,
-                .const (1049328 : UInt32),
+                .const (1049608 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 2
@@ -1670,21 +1974,21 @@ def func39 : Wasm.Program :=
             .localSet 0,
             .const (0 : UInt32),
             .localGet 6,
-            .store32 (1049600 : UInt32),
+            .store32 (1049880 : UInt32),
             .const (0 : UInt32),
             .localGet 8,
-            .store32 (1049592 : UInt32),
+            .store32 (1049872 : UInt32),
             .br 4
           ],
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049588 : UInt32),
+          .load32 (1049868 : UInt32),
           .const (4294967294 : UInt32),
           .localGet 6,
           .load32 (28 : UInt32),
           .rotl,
           .and,
-          .store32 (1049588 : UInt32)
+          .store32 (1049868 : UInt32)
         ],
         .block 0 0 [
           .block 0 0 [
@@ -1713,18 +2017,18 @@ def func39 : Wasm.Program :=
               .localGet 2,
               .store32 (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049592 : UInt32),
+              .load32 (1049872 : UInt32),
               .localSet 7,
               .localGet 7,
               .eqz,
               .br_if 1,
               .const (0 : UInt32),
-              .load32 (1049600 : UInt32),
+              .load32 (1049880 : UInt32),
               .localSet 0,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049584 : UInt32),
+                  .load32 (1049864 : UInt32),
                   .localSet 9,
                   .localGet 9,
                   .const (1 : UInt32),
@@ -1740,11 +2044,11 @@ def func39 : Wasm.Program :=
                   .localGet 9,
                   .localGet 5,
                   .or,
-                  .store32 (1049584 : UInt32),
+                  .store32 (1049864 : UInt32),
                   .localGet 7,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049320 : UInt32),
+                  .const (1049600 : UInt32),
                   .add,
                   .localSet 7,
                   .localGet 7,
@@ -1756,11 +2060,11 @@ def func39 : Wasm.Program :=
                 .and,
                 .localSet 7,
                 .localGet 7,
-                .const (1049320 : UInt32),
+                .const (1049600 : UInt32),
                 .add,
                 .localSet 9,
                 .localGet 7,
-                .const (1049328 : UInt32),
+                .const (1049608 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 7
@@ -1802,10 +2106,10 @@ def func39 : Wasm.Program :=
           ],
           .const (0 : UInt32),
           .localGet 8,
-          .store32 (1049600 : UInt32),
+          .store32 (1049880 : UInt32),
           .const (0 : UInt32),
           .localGet 2,
-          .store32 (1049592 : UInt32)
+          .store32 (1049872 : UInt32)
         ],
         .localGet 6,
         .const (8 : UInt32),
@@ -1827,7 +2131,7 @@ def func39 : Wasm.Program :=
               .localGet 5,
               .const (2 : UInt32),
               .shl,
-              .const (1049176 : UInt32),
+              .const (1049456 : UInt32),
               .add,
               .load32 (0 : UInt32),
               .localSet 6,
@@ -1947,7 +2251,7 @@ def func39 : Wasm.Program :=
             .ctz,
             .const (2 : UInt32),
             .shl,
-            .const (1049176 : UInt32),
+            .const (1049456 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 0
@@ -2015,7 +2319,7 @@ def func39 : Wasm.Program :=
       .br_if 0,
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049592 : UInt32),
+        .load32 (1049872 : UInt32),
         .localSet 0,
         .localGet 0,
         .localGet 3,
@@ -2122,7 +2426,7 @@ def func39 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049176 : UInt32),
+              .const (1049456 : UInt32),
               .add,
               .localSet 6,
               .localGet 6,
@@ -2189,13 +2493,13 @@ def func39 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049588 : UInt32),
+        .load32 (1049868 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 8,
         .load32 (28 : UInt32),
         .rotl,
         .and,
-        .store32 (1049588 : UInt32)
+        .store32 (1049868 : UInt32)
       ],
       .block 0 0 [
         .block 0 0 [
@@ -2229,13 +2533,13 @@ def func39 : Wasm.Program :=
             .br_if 0,
             .localGet 0,
             .localGet 2,
-            .call 49,
+            .call 56,
             .br 2
           ],
           .block 0 0 [
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049584 : UInt32),
+              .load32 (1049864 : UInt32),
               .localSet 6,
               .localGet 6,
               .const (1 : UInt32),
@@ -2251,11 +2555,11 @@ def func39 : Wasm.Program :=
               .localGet 6,
               .localGet 7,
               .or,
-              .store32 (1049584 : UInt32),
+              .store32 (1049864 : UInt32),
               .localGet 2,
               .const (248 : UInt32),
               .and,
-              .const (1049320 : UInt32),
+              .const (1049600 : UInt32),
               .add,
               .localSet 2,
               .localGet 2,
@@ -2267,11 +2571,11 @@ def func39 : Wasm.Program :=
             .and,
             .localSet 2,
             .localGet 2,
-            .const (1049320 : UInt32),
+            .const (1049600 : UInt32),
             .add,
             .localSet 6,
             .localGet 2,
-            .const (1049328 : UInt32),
+            .const (1049608 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 2
@@ -2324,7 +2628,7 @@ def func39 : Wasm.Program :=
             .block 0 0 [
               .block 0 0 [
                 .const (0 : UInt32),
-                .load32 (1049592 : UInt32),
+                .load32 (1049872 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
@@ -2332,7 +2636,7 @@ def func39 : Wasm.Program :=
                 .br_if 0,
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049596 : UInt32),
+                  .load32 (1049876 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 3,
@@ -2341,13 +2645,13 @@ def func39 : Wasm.Program :=
                   .localGet 1,
                   .const (4 : UInt32),
                   .add,
-                  .const (1049628 : UInt32),
+                  .const (1049908 : UInt32),
                   .localGet 3,
                   .const (65583 : UInt32),
                   .add,
                   .const (4294901760 : UInt32),
                   .and,
-                  .call 64,
+                  .call 71,
                   .block 0 0 [
                     .localGet 1,
                     .load32 (4 : UInt32),
@@ -2363,7 +2667,7 @@ def func39 : Wasm.Program :=
                   .localSet 5,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049608 : UInt32),
+                  .load32 (1049888 : UInt32),
                   .localGet 1,
                   .load32 (8 : UInt32),
                   .localSet 9,
@@ -2371,28 +2675,28 @@ def func39 : Wasm.Program :=
                   .add,
                   .localSet 0,
                   .localGet 0,
-                  .store32 (1049608 : UInt32),
+                  .store32 (1049888 : UInt32),
                   .const (0 : UInt32),
                   .localGet 0,
                   .const (0 : UInt32),
-                  .load32 (1049612 : UInt32),
+                  .load32 (1049892 : UInt32),
                   .localSet 2,
                   .localGet 2,
                   .localGet 0,
                   .localGet 2,
                   .gtU,
                   .select,
-                  .store32 (1049612 : UInt32),
+                  .store32 (1049892 : UInt32),
                   .block 0 0 [
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049604 : UInt32),
+                        .load32 (1049884 : UInt32),
                         .localSet 2,
                         .localGet 2,
                         .eqz,
                         .br_if 0,
-                        .const (1049304 : UInt32),
+                        .const (1049584 : UInt32),
                         .localSet 0,
                         .loop 0 0 [
                           .localGet 6,
@@ -2418,7 +2722,7 @@ def func39 : Wasm.Program :=
                       .block 0 0 [
                         .block 0 0 [
                           .const (0 : UInt32),
-                          .load32 (1049620 : UInt32),
+                          .load32 (1049900 : UInt32),
                           .localSet 0,
                           .localGet 0,
                           .eqz,
@@ -2430,209 +2734,209 @@ def func39 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049620 : UInt32)
+                        .store32 (1049900 : UInt32)
                       ],
                       .const (0 : UInt32),
                       .const (4095 : UInt32),
-                      .store32 (1049624 : UInt32),
+                      .store32 (1049904 : UInt32),
                       .const (0 : UInt32),
                       .localGet 5,
-                      .store32 (1049316 : UInt32),
+                      .store32 (1049596 : UInt32),
                       .const (0 : UInt32),
                       .localGet 9,
-                      .store32 (1049308 : UInt32),
+                      .store32 (1049588 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
-                      .store32 (1049304 : UInt32),
+                      .store32 (1049584 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049320 : UInt32),
-                      .store32 (1049332 : UInt32),
+                      .const (1049600 : UInt32),
+                      .store32 (1049612 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049328 : UInt32),
-                      .store32 (1049340 : UInt32),
+                      .const (1049608 : UInt32),
+                      .store32 (1049620 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049320 : UInt32),
-                      .store32 (1049328 : UInt32),
+                      .const (1049600 : UInt32),
+                      .store32 (1049608 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049336 : UInt32),
-                      .store32 (1049348 : UInt32),
+                      .const (1049616 : UInt32),
+                      .store32 (1049628 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049328 : UInt32),
-                      .store32 (1049336 : UInt32),
+                      .const (1049608 : UInt32),
+                      .store32 (1049616 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049344 : UInt32),
-                      .store32 (1049356 : UInt32),
+                      .const (1049624 : UInt32),
+                      .store32 (1049636 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049336 : UInt32),
-                      .store32 (1049344 : UInt32),
+                      .const (1049616 : UInt32),
+                      .store32 (1049624 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049352 : UInt32),
-                      .store32 (1049364 : UInt32),
+                      .const (1049632 : UInt32),
+                      .store32 (1049644 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049344 : UInt32),
-                      .store32 (1049352 : UInt32),
+                      .const (1049624 : UInt32),
+                      .store32 (1049632 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049360 : UInt32),
-                      .store32 (1049372 : UInt32),
+                      .const (1049640 : UInt32),
+                      .store32 (1049652 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049352 : UInt32),
-                      .store32 (1049360 : UInt32),
+                      .const (1049632 : UInt32),
+                      .store32 (1049640 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049368 : UInt32),
-                      .store32 (1049380 : UInt32),
+                      .const (1049648 : UInt32),
+                      .store32 (1049660 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049360 : UInt32),
-                      .store32 (1049368 : UInt32),
+                      .const (1049640 : UInt32),
+                      .store32 (1049648 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049376 : UInt32),
-                      .store32 (1049388 : UInt32),
+                      .const (1049656 : UInt32),
+                      .store32 (1049668 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049368 : UInt32),
-                      .store32 (1049376 : UInt32),
+                      .const (1049648 : UInt32),
+                      .store32 (1049656 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049384 : UInt32),
-                      .store32 (1049396 : UInt32),
+                      .const (1049664 : UInt32),
+                      .store32 (1049676 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049376 : UInt32),
-                      .store32 (1049384 : UInt32),
+                      .const (1049656 : UInt32),
+                      .store32 (1049664 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049384 : UInt32),
-                      .store32 (1049392 : UInt32),
+                      .const (1049664 : UInt32),
+                      .store32 (1049672 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049392 : UInt32),
-                      .store32 (1049404 : UInt32),
+                      .const (1049672 : UInt32),
+                      .store32 (1049684 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049392 : UInt32),
-                      .store32 (1049400 : UInt32),
+                      .const (1049672 : UInt32),
+                      .store32 (1049680 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049400 : UInt32),
-                      .store32 (1049412 : UInt32),
+                      .const (1049680 : UInt32),
+                      .store32 (1049692 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049400 : UInt32),
-                      .store32 (1049408 : UInt32),
+                      .const (1049680 : UInt32),
+                      .store32 (1049688 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049408 : UInt32),
-                      .store32 (1049420 : UInt32),
+                      .const (1049688 : UInt32),
+                      .store32 (1049700 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049408 : UInt32),
-                      .store32 (1049416 : UInt32),
+                      .const (1049688 : UInt32),
+                      .store32 (1049696 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049416 : UInt32),
-                      .store32 (1049428 : UInt32),
+                      .const (1049696 : UInt32),
+                      .store32 (1049708 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049416 : UInt32),
-                      .store32 (1049424 : UInt32),
+                      .const (1049696 : UInt32),
+                      .store32 (1049704 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049424 : UInt32),
-                      .store32 (1049436 : UInt32),
+                      .const (1049704 : UInt32),
+                      .store32 (1049716 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049424 : UInt32),
-                      .store32 (1049432 : UInt32),
+                      .const (1049704 : UInt32),
+                      .store32 (1049712 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049432 : UInt32),
-                      .store32 (1049444 : UInt32),
+                      .const (1049712 : UInt32),
+                      .store32 (1049724 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049432 : UInt32),
-                      .store32 (1049440 : UInt32),
+                      .const (1049712 : UInt32),
+                      .store32 (1049720 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049440 : UInt32),
-                      .store32 (1049452 : UInt32),
+                      .const (1049720 : UInt32),
+                      .store32 (1049732 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049440 : UInt32),
-                      .store32 (1049448 : UInt32),
+                      .const (1049720 : UInt32),
+                      .store32 (1049728 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049448 : UInt32),
-                      .store32 (1049460 : UInt32),
+                      .const (1049728 : UInt32),
+                      .store32 (1049740 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049456 : UInt32),
-                      .store32 (1049468 : UInt32),
+                      .const (1049736 : UInt32),
+                      .store32 (1049748 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049448 : UInt32),
-                      .store32 (1049456 : UInt32),
+                      .const (1049728 : UInt32),
+                      .store32 (1049736 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049464 : UInt32),
-                      .store32 (1049476 : UInt32),
+                      .const (1049744 : UInt32),
+                      .store32 (1049756 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049456 : UInt32),
-                      .store32 (1049464 : UInt32),
+                      .const (1049736 : UInt32),
+                      .store32 (1049744 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049472 : UInt32),
-                      .store32 (1049484 : UInt32),
+                      .const (1049752 : UInt32),
+                      .store32 (1049764 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049464 : UInt32),
-                      .store32 (1049472 : UInt32),
+                      .const (1049744 : UInt32),
+                      .store32 (1049752 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049480 : UInt32),
-                      .store32 (1049492 : UInt32),
+                      .const (1049760 : UInt32),
+                      .store32 (1049772 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049472 : UInt32),
-                      .store32 (1049480 : UInt32),
+                      .const (1049752 : UInt32),
+                      .store32 (1049760 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049488 : UInt32),
-                      .store32 (1049500 : UInt32),
+                      .const (1049768 : UInt32),
+                      .store32 (1049780 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049480 : UInt32),
-                      .store32 (1049488 : UInt32),
+                      .const (1049760 : UInt32),
+                      .store32 (1049768 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049496 : UInt32),
-                      .store32 (1049508 : UInt32),
+                      .const (1049776 : UInt32),
+                      .store32 (1049788 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049488 : UInt32),
-                      .store32 (1049496 : UInt32),
+                      .const (1049768 : UInt32),
+                      .store32 (1049776 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049504 : UInt32),
-                      .store32 (1049516 : UInt32),
+                      .const (1049784 : UInt32),
+                      .store32 (1049796 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049496 : UInt32),
-                      .store32 (1049504 : UInt32),
+                      .const (1049776 : UInt32),
+                      .store32 (1049784 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049512 : UInt32),
-                      .store32 (1049524 : UInt32),
+                      .const (1049792 : UInt32),
+                      .store32 (1049804 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049504 : UInt32),
-                      .store32 (1049512 : UInt32),
+                      .const (1049784 : UInt32),
+                      .store32 (1049792 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049520 : UInt32),
-                      .store32 (1049532 : UInt32),
+                      .const (1049800 : UInt32),
+                      .store32 (1049812 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049512 : UInt32),
-                      .store32 (1049520 : UInt32),
+                      .const (1049792 : UInt32),
+                      .store32 (1049800 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049528 : UInt32),
-                      .store32 (1049540 : UInt32),
+                      .const (1049808 : UInt32),
+                      .store32 (1049820 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049520 : UInt32),
-                      .store32 (1049528 : UInt32),
+                      .const (1049800 : UInt32),
+                      .store32 (1049808 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049536 : UInt32),
-                      .store32 (1049548 : UInt32),
+                      .const (1049816 : UInt32),
+                      .store32 (1049828 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049528 : UInt32),
-                      .store32 (1049536 : UInt32),
+                      .const (1049808 : UInt32),
+                      .store32 (1049816 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049544 : UInt32),
-                      .store32 (1049556 : UInt32),
+                      .const (1049824 : UInt32),
+                      .store32 (1049836 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049536 : UInt32),
-                      .store32 (1049544 : UInt32),
+                      .const (1049816 : UInt32),
+                      .store32 (1049824 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049552 : UInt32),
-                      .store32 (1049564 : UInt32),
+                      .const (1049832 : UInt32),
+                      .store32 (1049844 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049544 : UInt32),
-                      .store32 (1049552 : UInt32),
+                      .const (1049824 : UInt32),
+                      .store32 (1049832 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049560 : UInt32),
-                      .store32 (1049572 : UInt32),
+                      .const (1049840 : UInt32),
+                      .store32 (1049852 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049552 : UInt32),
-                      .store32 (1049560 : UInt32),
+                      .const (1049832 : UInt32),
+                      .store32 (1049840 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049568 : UInt32),
-                      .store32 (1049580 : UInt32),
+                      .const (1049848 : UInt32),
+                      .store32 (1049860 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049560 : UInt32),
-                      .store32 (1049568 : UInt32),
+                      .const (1049840 : UInt32),
+                      .store32 (1049848 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
                       .const (15 : UInt32),
@@ -2645,10 +2949,10 @@ def func39 : Wasm.Program :=
                       .add,
                       .localSet 2,
                       .localGet 2,
-                      .store32 (1049604 : UInt32),
+                      .store32 (1049884 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049568 : UInt32),
-                      .store32 (1049576 : UInt32),
+                      .const (1049848 : UInt32),
+                      .store32 (1049856 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
                       .localGet 0,
@@ -2663,7 +2967,7 @@ def func39 : Wasm.Program :=
                       .add,
                       .localSet 8,
                       .localGet 8,
-                      .store32 (1049596 : UInt32),
+                      .store32 (1049876 : UInt32),
                       .localGet 2,
                       .localGet 8,
                       .const (1 : UInt32),
@@ -2676,7 +2980,7 @@ def func39 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .const (0 : UInt32),
                       .const (2097152 : UInt32),
-                      .store32 (1049616 : UInt32),
+                      .store32 (1049896 : UInt32),
                       .br 8
                     ],
                     .localGet 2,
@@ -2703,7 +3007,7 @@ def func39 : Wasm.Program :=
                   ],
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049620 : UInt32),
+                  .load32 (1049900 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 6,
@@ -2711,12 +3015,12 @@ def func39 : Wasm.Program :=
                   .localGet 6,
                   .ltU,
                   .select,
-                  .store32 (1049620 : UInt32),
+                  .store32 (1049900 : UInt32),
                   .localGet 6,
                   .localGet 9,
                   .add,
                   .localSet 8,
-                  .const (1049304 : UInt32),
+                  .const (1049584 : UInt32),
                   .localSet 0,
                   .block 0 0 [
                     .block 0 0 [
@@ -2751,7 +3055,7 @@ def func39 : Wasm.Program :=
                       .eq,
                       .br_if 1
                     ],
-                    .const (1049304 : UInt32),
+                    .const (1049584 : UInt32),
                     .localSet 0,
                     .block 0 0 [
                       .loop 0 0 [
@@ -2791,7 +3095,7 @@ def func39 : Wasm.Program :=
                     .add,
                     .localSet 7,
                     .localGet 7,
-                    .store32 (1049604 : UInt32),
+                    .store32 (1049884 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
                     .localGet 0,
@@ -2806,7 +3110,7 @@ def func39 : Wasm.Program :=
                     .add,
                     .localSet 4,
                     .localGet 4,
-                    .store32 (1049596 : UInt32),
+                    .store32 (1049876 : UInt32),
                     .localGet 7,
                     .localGet 4,
                     .const (1 : UInt32),
@@ -2819,7 +3123,7 @@ def func39 : Wasm.Program :=
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
                     .const (2097152 : UInt32),
-                    .store32 (1049616 : UInt32),
+                    .store32 (1049896 : UInt32),
                     .localGet 2,
                     .localGet 8,
                     .const (4294967264 : UInt32),
@@ -2841,13 +3145,13 @@ def func39 : Wasm.Program :=
                     .const (27 : UInt32),
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
-                    .load64 (1049304 : UInt32),
+                    .load64 (1049584 : UInt32),
                     .localSet 10,
                     .localGet 7,
                     .const (16 : UInt32),
                     .add,
                     .const (0 : UInt32),
-                    .load64 (1049312 : UInt32),
+                    .load64 (1049592 : UInt32),
                     .store64 (0 : UInt32),
                     .localGet 7,
                     .const (8 : UInt32),
@@ -2858,16 +3162,16 @@ def func39 : Wasm.Program :=
                     .store64 (0 : UInt32),
                     .const (0 : UInt32),
                     .localGet 5,
-                    .store32 (1049316 : UInt32),
+                    .store32 (1049596 : UInt32),
                     .const (0 : UInt32),
                     .localGet 9,
-                    .store32 (1049308 : UInt32),
+                    .store32 (1049588 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
-                    .store32 (1049304 : UInt32),
+                    .store32 (1049584 : UInt32),
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049312 : UInt32),
+                    .store32 (1049592 : UInt32),
                     .localGet 7,
                     .const (28 : UInt32),
                     .add,
@@ -2914,13 +3218,13 @@ def func39 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 0,
-                      .call 49,
+                      .call 56,
                       .br 8
                     ],
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049584 : UInt32),
+                        .load32 (1049864 : UInt32),
                         .localSet 8,
                         .localGet 8,
                         .const (1 : UInt32),
@@ -2936,11 +3240,11 @@ def func39 : Wasm.Program :=
                         .localGet 8,
                         .localGet 6,
                         .or,
-                        .store32 (1049584 : UInt32),
+                        .store32 (1049864 : UInt32),
                         .localGet 0,
                         .const (248 : UInt32),
                         .and,
-                        .const (1049320 : UInt32),
+                        .const (1049600 : UInt32),
                         .add,
                         .localSet 0,
                         .localGet 0,
@@ -2952,11 +3256,11 @@ def func39 : Wasm.Program :=
                       .and,
                       .localSet 0,
                       .localGet 0,
-                      .const (1049320 : UInt32),
+                      .const (1049600 : UInt32),
                       .add,
                       .localSet 8,
                       .localGet 0,
-                      .const (1049328 : UInt32),
+                      .const (1049608 : UInt32),
                       .add,
                       .load32 (0 : UInt32),
                       .localSet 0
@@ -3015,12 +3319,12 @@ def func39 : Wasm.Program :=
                   .localSet 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049604 : UInt32),
+                  .load32 (1049884 : UInt32),
                   .eq,
                   .br_if 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049600 : UInt32),
+                  .load32 (1049880 : UInt32),
                   .eq,
                   .br_if 4,
                   .block 0 0 [
@@ -3039,7 +3343,7 @@ def func39 : Wasm.Program :=
                     .and,
                     .localSet 6,
                     .localGet 6,
-                    .call 44,
+                    .call 51,
                     .localGet 6,
                     .localGet 3,
                     .add,
@@ -3074,13 +3378,13 @@ def func39 : Wasm.Program :=
                     .br_if 0,
                     .localGet 0,
                     .localGet 3,
-                    .call 49,
+                    .call 56,
                     .br 6
                   ],
                   .block 0 0 [
                     .block 0 0 [
                       .const (0 : UInt32),
-                      .load32 (1049584 : UInt32),
+                      .load32 (1049864 : UInt32),
                       .localSet 2,
                       .localGet 2,
                       .const (1 : UInt32),
@@ -3096,11 +3400,11 @@ def func39 : Wasm.Program :=
                       .localGet 2,
                       .localGet 6,
                       .or,
-                      .store32 (1049584 : UInt32),
+                      .store32 (1049864 : UInt32),
                       .localGet 3,
                       .const (248 : UInt32),
                       .and,
-                      .const (1049320 : UInt32),
+                      .const (1049600 : UInt32),
                       .add,
                       .localSet 3,
                       .localGet 3,
@@ -3112,11 +3416,11 @@ def func39 : Wasm.Program :=
                     .and,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049320 : UInt32),
+                    .const (1049600 : UInt32),
                     .add,
                     .localSet 2,
                     .localGet 3,
-                    .const (1049328 : UInt32),
+                    .const (1049608 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 3
@@ -3141,17 +3445,17 @@ def func39 : Wasm.Program :=
                 .sub,
                 .localSet 2,
                 .localGet 2,
-                .store32 (1049596 : UInt32),
+                .store32 (1049876 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049604 : UInt32),
+                .load32 (1049884 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
                 .add,
                 .localSet 8,
                 .localGet 8,
-                .store32 (1049604 : UInt32),
+                .store32 (1049884 : UInt32),
                 .localGet 8,
                 .localGet 2,
                 .const (1 : UInt32),
@@ -3169,7 +3473,7 @@ def func39 : Wasm.Program :=
                 .br 6
               ],
               .const (0 : UInt32),
-              .load32 (1049600 : UInt32),
+              .load32 (1049880 : UInt32),
               .localSet 2,
               .block 0 0 [
                 .block 0 0 [
@@ -3183,10 +3487,10 @@ def func39 : Wasm.Program :=
                   .br_if 0,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .store32 (1049600 : UInt32),
+                  .store32 (1049880 : UInt32),
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .store32 (1049592 : UInt32),
+                  .store32 (1049872 : UInt32),
                   .localGet 2,
                   .localGet 0,
                   .const (3 : UInt32),
@@ -3206,14 +3510,14 @@ def func39 : Wasm.Program :=
                 ],
                 .const (0 : UInt32),
                 .localGet 8,
-                .store32 (1049592 : UInt32),
+                .store32 (1049872 : UInt32),
                 .const (0 : UInt32),
                 .localGet 2,
                 .localGet 3,
                 .add,
                 .localSet 6,
                 .localGet 6,
-                .store32 (1049600 : UInt32),
+                .store32 (1049880 : UInt32),
                 .localGet 6,
                 .localGet 8,
                 .const (1 : UInt32),
@@ -3243,7 +3547,7 @@ def func39 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049604 : UInt32),
+            .load32 (1049884 : UInt32),
             .localSet 0,
             .localGet 0,
             .const (15 : UInt32),
@@ -3256,13 +3560,13 @@ def func39 : Wasm.Program :=
             .add,
             .localSet 8,
             .localGet 8,
-            .store32 (1049604 : UInt32),
+            .store32 (1049884 : UInt32),
             .const (0 : UInt32),
             .localGet 0,
             .localGet 2,
             .sub,
             .const (0 : UInt32),
-            .load32 (1049596 : UInt32),
+            .load32 (1049876 : UInt32),
             .localGet 9,
             .add,
             .localSet 2,
@@ -3272,7 +3576,7 @@ def func39 : Wasm.Program :=
             .add,
             .localSet 6,
             .localGet 6,
-            .store32 (1049596 : UInt32),
+            .store32 (1049876 : UInt32),
             .localGet 8,
             .localGet 6,
             .const (1 : UInt32),
@@ -3285,20 +3589,20 @@ def func39 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (2097152 : UInt32),
-            .store32 (1049616 : UInt32),
+            .store32 (1049896 : UInt32),
             .br 3
           ],
           .const (0 : UInt32),
           .localGet 0,
-          .store32 (1049604 : UInt32),
+          .store32 (1049884 : UInt32),
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049596 : UInt32),
+          .load32 (1049876 : UInt32),
           .localGet 3,
           .add,
           .localSet 3,
           .localGet 3,
-          .store32 (1049596 : UInt32),
+          .store32 (1049876 : UInt32),
           .localGet 0,
           .localGet 3,
           .const (1 : UInt32),
@@ -3308,15 +3612,15 @@ def func39 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049600 : UInt32),
+        .store32 (1049880 : UInt32),
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049592 : UInt32),
+        .load32 (1049872 : UInt32),
         .localGet 3,
         .add,
         .localSet 3,
         .localGet 3,
-        .store32 (1049592 : UInt32),
+        .store32 (1049872 : UInt32),
         .localGet 0,
         .localGet 3,
         .const (1 : UInt32),
@@ -3337,7 +3641,7 @@ def func39 : Wasm.Program :=
     .const (0 : UInt32),
     .localSet 0,
     .const (0 : UInt32),
-    .load32 (1049596 : UInt32),
+    .load32 (1049876 : UInt32),
     .localSet 2,
     .localGet 2,
     .localGet 3,
@@ -3349,17 +3653,17 @@ def func39 : Wasm.Program :=
     .sub,
     .localSet 2,
     .localGet 2,
-    .store32 (1049596 : UInt32),
+    .store32 (1049876 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049604 : UInt32),
+    .load32 (1049884 : UInt32),
     .localSet 0,
     .localGet 0,
     .localGet 3,
     .add,
     .localSet 8,
     .localGet 8,
-    .store32 (1049604 : UInt32),
+    .store32 (1049884 : UInt32),
     .localGet 8,
     .localGet 2,
     .const (1 : UInt32),
@@ -3382,18 +3686,18 @@ def func39 : Wasm.Program :=
   .localGet 0
 ]
 
-def func39Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func39, results := [.i32] }
+def func46Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func46, results := [.i32] }
 
-def func40 : Wasm.Program :=
+def func47 : Wasm.Program :=
   [
   .unreachable
 ]
 
-def func40Def : Wasm.Function :=
-  { params := [], locals := [], body := func40, results := [] }
+def func47Def : Wasm.Function :=
+  { params := [], locals := [], body := func47, results := [] }
 
-def func41 : Wasm.Program :=
+def func48 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3431,26 +3735,26 @@ def func41 : Wasm.Program :=
         .br_if 2
       ],
       .localGet 0,
-      .call 42,
+      .call 49,
       .ret
     ],
-    .const (1048787 : UInt32),
+    .const (1048835 : UInt32),
     .const (46 : UInt32),
-    .const (1048836 : UInt32),
-    .call 68,
+    .const (1048884 : UInt32),
+    .call 75,
     .unreachable
   ],
-  .const (1048852 : UInt32),
-  .const (46 : UInt32),
   .const (1048900 : UInt32),
-  .call 68,
+  .const (46 : UInt32),
+  .const (1048948 : UInt32),
+  .call 75,
   .unreachable
 ]
 
-def func41Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func41, results := [] }
+def func48Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func48, results := [] }
 
-def func42 : Wasm.Program :=
+def func49 : Wasm.Program :=
   [
   .localGet 0,
   .const (4294967288 : UInt32),
@@ -3494,7 +3798,7 @@ def func42 : Wasm.Program :=
         .localSet 1,
         .localGet 1,
         .const (0 : UInt32),
-        .load32 (1049600 : UInt32),
+        .load32 (1049880 : UInt32),
         .ne,
         .br_if 0,
         .localGet 3,
@@ -3506,7 +3810,7 @@ def func42 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049592 : UInt32),
+        .store32 (1049872 : UInt32),
         .localGet 3,
         .localGet 3,
         .load32 (4 : UInt32),
@@ -3525,7 +3829,7 @@ def func42 : Wasm.Program :=
       ],
       .localGet 1,
       .localGet 2,
-      .call 44
+      .call 51
     ],
     .block 0 0 [
       .block 0 0 [
@@ -3544,12 +3848,12 @@ def func42 : Wasm.Program :=
                     .br_if 0,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049604 : UInt32),
+                    .load32 (1049884 : UInt32),
                     .eq,
                     .br_if 2,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049600 : UInt32),
+                    .load32 (1049880 : UInt32),
                     .eq,
                     .br_if 3,
                     .localGet 3,
@@ -3558,7 +3862,7 @@ def func42 : Wasm.Program :=
                     .and,
                     .localSet 2,
                     .localGet 2,
-                    .call 44,
+                    .call 51,
                     .localGet 1,
                     .localGet 2,
                     .localGet 0,
@@ -3575,12 +3879,12 @@ def func42 : Wasm.Program :=
                     .store32 (0 : UInt32),
                     .localGet 1,
                     .const (0 : UInt32),
-                    .load32 (1049600 : UInt32),
+                    .load32 (1049880 : UInt32),
                     .ne,
                     .br_if 1,
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049592 : UInt32),
+                    .store32 (1049872 : UInt32),
                     .ret
                   ],
                   .localGet 3,
@@ -3605,19 +3909,19 @@ def func42 : Wasm.Program :=
                 .br_if 4,
                 .localGet 1,
                 .localGet 0,
-                .call 49,
+                .call 56,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049624 : UInt32),
+                .load32 (1049904 : UInt32),
                 .const (4294967295 : UInt32),
                 .add,
                 .localSet 1,
                 .localGet 1,
-                .store32 (1049624 : UInt32),
+                .store32 (1049904 : UInt32),
                 .localGet 1,
                 .br_if 6,
                 .const (0 : UInt32),
-                .load32 (1049312 : UInt32),
+                .load32 (1049592 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .br_if 2,
@@ -3627,15 +3931,15 @@ def func42 : Wasm.Program :=
               ],
               .const (0 : UInt32),
               .localGet 1,
-              .store32 (1049604 : UInt32),
+              .store32 (1049884 : UInt32),
               .const (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049596 : UInt32),
+              .load32 (1049876 : UInt32),
               .localGet 0,
               .add,
               .localSet 0,
               .localGet 0,
-              .store32 (1049596 : UInt32),
+              .store32 (1049876 : UInt32),
               .localGet 1,
               .localGet 0,
               .const (1 : UInt32),
@@ -3644,37 +3948,37 @@ def func42 : Wasm.Program :=
               .block 0 0 [
                 .localGet 1,
                 .const (0 : UInt32),
-                .load32 (1049600 : UInt32),
+                .load32 (1049880 : UInt32),
                 .ne,
                 .br_if 0,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049592 : UInt32),
+                .store32 (1049872 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049600 : UInt32)
+                .store32 (1049880 : UInt32)
               ],
               .localGet 0,
               .const (0 : UInt32),
-              .load32 (1049616 : UInt32),
+              .load32 (1049896 : UInt32),
               .localSet 2,
               .localGet 2,
               .leU,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049604 : UInt32),
+              .load32 (1049884 : UInt32),
               .localSet 0,
               .localGet 0,
               .eqz,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049596 : UInt32),
+              .load32 (1049876 : UInt32),
               .localSet 4,
               .localGet 4,
               .const (41 : UInt32),
               .ltU,
               .br_if 4,
-              .const (1049304 : UInt32),
+              .const (1049584 : UInt32),
               .localSet 1,
               .loop 0 0 [
                 .block 0 0 [
@@ -3701,15 +4005,15 @@ def func42 : Wasm.Program :=
             ],
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049600 : UInt32),
+            .store32 (1049880 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049592 : UInt32),
+            .load32 (1049872 : UInt32),
             .localGet 0,
             .add,
             .localSet 0,
             .localGet 0,
-            .store32 (1049592 : UInt32),
+            .store32 (1049872 : UInt32),
             .localGet 1,
             .localGet 0,
             .const (1 : UInt32),
@@ -3745,13 +4049,13 @@ def func42 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049624 : UInt32),
+        .store32 (1049904 : UInt32),
         .ret
       ],
       .block 0 0 [
         .block 0 0 [
           .const (0 : UInt32),
-          .load32 (1049584 : UInt32),
+          .load32 (1049864 : UInt32),
           .localSet 3,
           .localGet 3,
           .const (1 : UInt32),
@@ -3767,11 +4071,11 @@ def func42 : Wasm.Program :=
           .localGet 3,
           .localGet 2,
           .or,
-          .store32 (1049584 : UInt32),
+          .store32 (1049864 : UInt32),
           .localGet 0,
           .const (248 : UInt32),
           .and,
-          .const (1049320 : UInt32),
+          .const (1049600 : UInt32),
           .add,
           .localSet 0,
           .localGet 0,
@@ -3783,11 +4087,11 @@ def func42 : Wasm.Program :=
         .and,
         .localSet 0,
         .localGet 0,
-        .const (1049320 : UInt32),
+        .const (1049600 : UInt32),
         .add,
         .localSet 3,
         .localGet 0,
-        .const (1049328 : UInt32),
+        .const (1049608 : UInt32),
         .add,
         .load32 (0 : UInt32),
         .localSet 0
@@ -3809,7 +4113,7 @@ def func42 : Wasm.Program :=
     .block 0 0 [
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049312 : UInt32),
+        .load32 (1049592 : UInt32),
         .localSet 0,
         .localGet 0,
         .br_if 0,
@@ -3840,21 +4144,21 @@ def func42 : Wasm.Program :=
     ],
     .const (0 : UInt32),
     .localGet 1,
-    .store32 (1049624 : UInt32),
+    .store32 (1049904 : UInt32),
     .localGet 4,
     .localGet 2,
     .leU,
     .br_if 0,
     .const (0 : UInt32),
     .const (4294967295 : UInt32),
-    .store32 (1049616 : UInt32)
+    .store32 (1049896 : UInt32)
   ]
 ]
 
-def func42Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func42, results := [] }
+def func49Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func49, results := [] }
 
-def func43 : Wasm.Program :=
+def func50 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3909,7 +4213,7 @@ def func43 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 3,
-                      .call 38,
+                      .call 45,
                       .localSet 2,
                       .localGet 2,
                       .br_if 1,
@@ -3972,13 +4276,13 @@ def func43 : Wasm.Program :=
                         .br_if 0,
                         .localGet 7,
                         .const (0 : UInt32),
-                        .load32 (1049604 : UInt32),
+                        .load32 (1049884 : UInt32),
                         .eq,
                         .br_if 1,
                         .block 0 0 [
                           .localGet 7,
                           .const (0 : UInt32),
-                          .load32 (1049600 : UInt32),
+                          .load32 (1049880 : UInt32),
                           .eq,
                           .br_if 0,
                           .localGet 7,
@@ -4002,7 +4306,7 @@ def func43 : Wasm.Program :=
                           .br_if 9,
                           .localGet 7,
                           .localGet 9,
-                          .call 44,
+                          .call 51,
                           .block 0 0 [
                             .localGet 5,
                             .localGet 1,
@@ -4043,7 +4347,7 @@ def func43 : Wasm.Program :=
                             .store32 (4 : UInt32),
                             .localGet 1,
                             .localGet 7,
-                            .call 45,
+                            .call 52,
                             .br 9
                           ],
                           .localGet 4,
@@ -4069,7 +4373,7 @@ def func43 : Wasm.Program :=
                           .br 8
                         ],
                         .const (0 : UInt32),
-                        .load32 (1049592 : UInt32),
+                        .load32 (1049872 : UInt32),
                         .localGet 6,
                         .add,
                         .localSet 7,
@@ -4146,10 +4450,10 @@ def func43 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 1,
-                        .store32 (1049600 : UInt32),
+                        .store32 (1049880 : UInt32),
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049592 : UInt32),
+                        .store32 (1049872 : UInt32),
                         .br 7
                       ],
                       .localGet 6,
@@ -4186,11 +4490,11 @@ def func43 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .localGet 1,
                       .localGet 6,
-                      .call 45,
+                      .call 52,
                       .br 6
                     ],
                     .const (0 : UInt32),
-                    .load32 (1049596 : UInt32),
+                    .load32 (1049876 : UInt32),
                     .localGet 6,
                     .add,
                     .localSet 7,
@@ -4243,28 +4547,28 @@ def func43 : Wasm.Program :=
                   .localGet 8,
                   .leU,
                   .br_if 6,
-                  .const (1048852 : UInt32),
-                  .const (46 : UInt32),
                   .const (1048900 : UInt32),
-                  .call 68,
+                  .const (46 : UInt32),
+                  .const (1048948 : UInt32),
+                  .call 75,
                   .unreachable
                 ],
-                .const (1048787 : UInt32),
+                .const (1048835 : UInt32),
                 .const (46 : UInt32),
-                .const (1048836 : UInt32),
-                .call 68,
+                .const (1048884 : UInt32),
+                .call 75,
                 .unreachable
               ],
-              .const (1048852 : UInt32),
-              .const (46 : UInt32),
               .const (1048900 : UInt32),
-              .call 68,
+              .const (46 : UInt32),
+              .const (1048948 : UInt32),
+              .call 75,
               .unreachable
             ],
-            .const (1048787 : UInt32),
+            .const (1048835 : UInt32),
             .const (46 : UInt32),
-            .const (1048836 : UInt32),
-            .call 68,
+            .const (1048884 : UInt32),
+            .call 75,
             .unreachable
           ],
           .localGet 4,
@@ -4291,10 +4595,10 @@ def func43 : Wasm.Program :=
           .store32 (4 : UInt32),
           .const (0 : UInt32),
           .localGet 1,
-          .store32 (1049596 : UInt32),
+          .store32 (1049876 : UInt32),
           .const (0 : UInt32),
           .localGet 5,
-          .store32 (1049604 : UInt32)
+          .store32 (1049884 : UInt32)
         ],
         .localGet 8,
         .eqz,
@@ -4303,7 +4607,7 @@ def func43 : Wasm.Program :=
         .ret
       ],
       .localGet 3,
-      .call 39,
+      .call 46,
       .localSet 1,
       .localGet 1,
       .eqz,
@@ -4342,15 +4646,15 @@ def func43 : Wasm.Program :=
       .localSet 2
     ],
     .localGet 0,
-    .call 42
+    .call 49
   ],
   .localGet 2
 ]
 
-def func43Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func43, results := [.i32] }
+def func50Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func50, results := [.i32] }
 
-def func44 : Wasm.Program :=
+def func51 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (12 : UInt32),
@@ -4452,7 +4756,7 @@ def func44 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049176 : UInt32),
+              .const (1049456 : UInt32),
               .add,
               .localSet 1,
               .localGet 1,
@@ -4504,14 +4808,14 @@ def func44 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049584 : UInt32),
+        .load32 (1049864 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 1,
         .const (3 : UInt32),
         .shrU,
         .rotl,
         .and,
-        .store32 (1049584 : UInt32),
+        .store32 (1049864 : UInt32),
         .ret
       ],
       .localGet 2,
@@ -4549,19 +4853,19 @@ def func44 : Wasm.Program :=
   ],
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049588 : UInt32),
+  .load32 (1049868 : UInt32),
   .const (4294967294 : UInt32),
   .localGet 0,
   .load32 (28 : UInt32),
   .rotl,
   .and,
-  .store32 (1049588 : UInt32)
+  .store32 (1049868 : UInt32)
 ]
 
-def func44Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func44, results := [] }
+def func51Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func51, results := [] }
 
-def func45 : Wasm.Program :=
+def func52 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4595,7 +4899,7 @@ def func45 : Wasm.Program :=
         .localSet 0,
         .localGet 0,
         .const (0 : UInt32),
-        .load32 (1049600 : UInt32),
+        .load32 (1049880 : UInt32),
         .ne,
         .br_if 0,
         .localGet 2,
@@ -4607,7 +4911,7 @@ def func45 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049592 : UInt32),
+        .store32 (1049872 : UInt32),
         .localGet 2,
         .localGet 2,
         .load32 (4 : UInt32),
@@ -4626,7 +4930,7 @@ def func45 : Wasm.Program :=
       ],
       .localGet 0,
       .localGet 3,
-      .call 44
+      .call 51
     ],
     .block 0 0 [
       .block 0 0 [
@@ -4641,12 +4945,12 @@ def func45 : Wasm.Program :=
             .br_if 0,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049604 : UInt32),
+            .load32 (1049884 : UInt32),
             .eq,
             .br_if 2,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049600 : UInt32),
+            .load32 (1049880 : UInt32),
             .eq,
             .br_if 3,
             .localGet 2,
@@ -4655,7 +4959,7 @@ def func45 : Wasm.Program :=
             .and,
             .localSet 3,
             .localGet 3,
-            .call 44,
+            .call 51,
             .localGet 0,
             .localGet 3,
             .localGet 1,
@@ -4672,12 +4976,12 @@ def func45 : Wasm.Program :=
             .store32 (0 : UInt32),
             .localGet 0,
             .const (0 : UInt32),
-            .load32 (1049600 : UInt32),
+            .load32 (1049880 : UInt32),
             .ne,
             .br_if 1,
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049592 : UInt32),
+            .store32 (1049872 : UInt32),
             .ret
           ],
           .localGet 2,
@@ -4703,13 +5007,13 @@ def func45 : Wasm.Program :=
           .br_if 0,
           .localGet 0,
           .localGet 1,
-          .call 49,
+          .call 56,
           .ret
         ],
         .block 0 0 [
           .block 0 0 [
             .const (0 : UInt32),
-            .load32 (1049584 : UInt32),
+            .load32 (1049864 : UInt32),
             .localSet 2,
             .localGet 2,
             .const (1 : UInt32),
@@ -4725,11 +5029,11 @@ def func45 : Wasm.Program :=
             .localGet 2,
             .localGet 3,
             .or,
-            .store32 (1049584 : UInt32),
+            .store32 (1049864 : UInt32),
             .localGet 1,
             .const (248 : UInt32),
             .and,
-            .const (1049320 : UInt32),
+            .const (1049600 : UInt32),
             .add,
             .localSet 1,
             .localGet 1,
@@ -4741,11 +5045,11 @@ def func45 : Wasm.Program :=
           .and,
           .localSet 1,
           .localGet 1,
-          .const (1049320 : UInt32),
+          .const (1049600 : UInt32),
           .add,
           .localSet 2,
           .localGet 1,
-          .const (1049328 : UInt32),
+          .const (1049608 : UInt32),
           .add,
           .load32 (0 : UInt32),
           .localSet 1
@@ -4766,15 +5070,15 @@ def func45 : Wasm.Program :=
       ],
       .const (0 : UInt32),
       .localGet 0,
-      .store32 (1049604 : UInt32),
+      .store32 (1049884 : UInt32),
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .load32 (1049596 : UInt32),
+      .load32 (1049876 : UInt32),
       .localGet 1,
       .add,
       .localSet 1,
       .localGet 1,
-      .store32 (1049596 : UInt32),
+      .store32 (1049876 : UInt32),
       .localGet 0,
       .localGet 1,
       .const (1 : UInt32),
@@ -4782,28 +5086,28 @@ def func45 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 0,
       .const (0 : UInt32),
-      .load32 (1049600 : UInt32),
+      .load32 (1049880 : UInt32),
       .ne,
       .br_if 1,
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .store32 (1049592 : UInt32),
+      .store32 (1049872 : UInt32),
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .store32 (1049600 : UInt32),
+      .store32 (1049880 : UInt32),
       .ret
     ],
     .const (0 : UInt32),
     .localGet 0,
-    .store32 (1049600 : UInt32),
+    .store32 (1049880 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049592 : UInt32),
+    .load32 (1049872 : UInt32),
     .localGet 1,
     .add,
     .localSet 1,
     .localGet 1,
-    .store32 (1049592 : UInt32),
+    .store32 (1049872 : UInt32),
     .localGet 0,
     .localGet 1,
     .const (1 : UInt32),
@@ -4818,10 +5122,10 @@ def func45 : Wasm.Program :=
   ]
 ]
 
-def func45Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func45, results := [] }
+def func52Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func52, results := [] }
 
-def func46 : Wasm.Program :=
+def func53 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4841,25 +5145,25 @@ def func46 : Wasm.Program :=
   .localGet 1,
   .const (4 : UInt32),
   .add,
-  .call 31,
+  .call 38,
   .unreachable
 ]
 
-def func46Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i64], body := func46, results := [] }
+def func53Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i64], body := func53, results := [] }
 
-def func47 : Wasm.Program :=
+def func54 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 48,
+  .call 55,
   .unreachable
 ]
 
-def func47Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func47, results := [] }
+def func54Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func54, results := [] }
 
-def func48 : Wasm.Program :=
+def func55 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4876,14 +5180,14 @@ def func48 : Wasm.Program :=
   .localGet 2,
   .const (8 : UInt32),
   .add,
-  .call 29,
+  .call 36,
   .unreachable
 ]
 
-def func48Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32], body := func48, results := [] }
+def func55Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32], body := func55, results := [] }
 
-def func49 : Wasm.Program :=
+def func56 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -4928,12 +5232,12 @@ def func49 : Wasm.Program :=
   .localGet 2,
   .const (2 : UInt32),
   .shl,
-  .const (1049176 : UInt32),
+  .const (1049456 : UInt32),
   .add,
   .localSet 3,
   .block 0 0 [
     .const (0 : UInt32),
-    .load32 (1049588 : UInt32),
+    .load32 (1049868 : UInt32),
     .const (1 : UInt32),
     .localGet 2,
     .shl,
@@ -4955,10 +5259,10 @@ def func49 : Wasm.Program :=
     .store32 (8 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049588 : UInt32),
+    .load32 (1049868 : UInt32),
     .localGet 4,
     .or,
-    .store32 (1049588 : UInt32),
+    .store32 (1049868 : UInt32),
     .ret
   ],
   .block 0 0 [
@@ -5057,21 +5361,21 @@ def func49 : Wasm.Program :=
   .store32 (8 : UInt32)
 ]
 
-def func49Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func49, results := [] }
+def func56Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func56, results := [] }
 
-def func50 : Wasm.Program :=
+def func57 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 1,
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049172 : UInt32),
+  .load32 (1049452 : UInt32),
   .localSet 2,
   .localGet 2,
   .const (1 : UInt32),
   .add,
-  .store32 (1049172 : UInt32),
+  .store32 (1049452 : UInt32),
   .block 0 0 [
     .localGet 2,
     .const (0 : UInt32),
@@ -5080,57 +5384,57 @@ def func50 : Wasm.Program :=
     .const (1 : UInt32),
     .localSet 1,
     .const (0 : UInt32),
-    .load8U (1049152 : UInt32),
+    .load8U (1049432 : UInt32),
     .br_if 0,
     .const (0 : UInt32),
     .localGet 0,
-    .store8 (1049152 : UInt32),
+    .store8 (1049432 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049148 : UInt32),
+    .load32 (1049428 : UInt32),
     .const (1 : UInt32),
     .add,
-    .store32 (1049148 : UInt32),
+    .store32 (1049428 : UInt32),
     .const (2 : UInt32),
     .localSet 1
   ],
   .localGet 1
 ]
 
-def func50Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32], body := func50, results := [.i32] }
+def func57Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32], body := func57, results := [.i32] }
 
-def func51 : Wasm.Program :=
+def func58 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048736 : UInt32),
+  .load64 (1048784 : UInt32),
   .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048728 : UInt32),
+  .load64 (1048776 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func51Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func51, results := [] }
+def func58Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func58, results := [] }
 
-def func52 : Wasm.Program :=
+def func59 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048720 : UInt32),
+  .load64 (1048768 : UInt32),
   .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048712 : UInt32),
+  .load64 (1048760 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func52Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func52, results := [] }
+def func59Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func59, results := [] }
 
-def func53 : Wasm.Program :=
+def func60 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5143,7 +5447,7 @@ def func53 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 0,
     .load32 (8 : UInt32),
-    .call 71,
+    .call 82,
     .ret
   ],
   .localGet 1,
@@ -5158,26 +5462,26 @@ def func53 : Wasm.Program :=
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 70
+  .call 78
 ]
 
-def func53Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func53, results := [.i32] }
+def func60Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func60, results := [.i32] }
 
-def func54 : Wasm.Program :=
+def func61 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048916 : UInt32),
+  .const (1048964 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func54Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func54, results := [] }
+def func61Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func61, results := [] }
 
-def func55 : Wasm.Program :=
+def func62 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5185,10 +5489,10 @@ def func55 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func55Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func55, results := [] }
+def func62Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func62, results := [] }
 
-def func56 : Wasm.Program :=
+def func63 : Wasm.Program :=
   [
   .localGet 1,
   .load32 (4 : UInt32),
@@ -5196,17 +5500,17 @@ def func56 : Wasm.Program :=
   .localGet 1,
   .load32 (0 : UInt32),
   .localSet 3,
-  .call 23,
+  .call 30,
   .block 0 0 [
     .const (8 : UInt32),
     .const (4 : UInt32),
-    .call 20,
+    .call 27,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (8 : UInt32),
-    .call 66,
+    .call 73,
     .unreachable
   ],
   .localGet 1,
@@ -5216,30 +5520,30 @@ def func56 : Wasm.Program :=
   .localGet 3,
   .store32 (0 : UInt32),
   .localGet 0,
-  .const (1048916 : UInt32),
+  .const (1048964 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func56Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func56, results := [] }
+def func63Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func63, results := [] }
 
-def func57 : Wasm.Program :=
+def func64 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 71
+  .call 82
 ]
 
-def func57Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func57, results := [.i32] }
+def func64Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func64, results := [.i32] }
 
-def func58 : Wasm.Program :=
+def func65 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (8 : UInt32),
@@ -5286,7 +5590,7 @@ def func58 : Wasm.Program :=
     .localGet 3,
     .const (1 : UInt32),
     .const (1 : UInt32),
-    .call 25,
+    .call 32,
     .localGet 0,
     .load32 (8 : UInt32),
     .localSet 4
@@ -5389,10 +5693,10 @@ def func58 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func58Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func58, results := [.i32] }
+def func65Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func65, results := [.i32] }
 
-def func59 : Wasm.Program :=
+def func66 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5412,7 +5716,7 @@ def func59 : Wasm.Program :=
         .localGet 2,
         .const (1 : UInt32),
         .const (1 : UInt32),
-        .call 25,
+        .call 32,
         .localGet 0,
         .load32 (8 : UInt32),
         .localSet 3,
@@ -5441,10 +5745,10 @@ def func59 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func59Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func59, results := [.i32] }
+def func66Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func66, results := [.i32] }
 
-def func60 : Wasm.Program :=
+def func67 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5470,7 +5774,7 @@ def func60 : Wasm.Program :=
     .localGet 2,
     .const (20 : UInt32),
     .add,
-    .const (1048632 : UInt32),
+    .const (1048680 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5478,7 +5782,7 @@ def func60 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 70,
+    .call 78,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5500,7 +5804,7 @@ def func60 : Wasm.Program :=
     .store64 (0 : UInt32)
   ],
   .localGet 0,
-  .const (1048932 : UInt32),
+  .const (1048980 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5511,10 +5815,10 @@ def func60 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func60Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func60, results := [] }
+def func67Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func67, results := [] }
 
-def func61 : Wasm.Program :=
+def func68 : Wasm.Program :=
   [
   .globalGet 0,
   .const (48 : UInt32),
@@ -5540,7 +5844,7 @@ def func61 : Wasm.Program :=
     .localGet 2,
     .const (36 : UInt32),
     .add,
-    .const (1048632 : UInt32),
+    .const (1048680 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5548,7 +5852,7 @@ def func61 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 70,
+    .call 78,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5587,17 +5891,17 @@ def func61 : Wasm.Program :=
   .localGet 2,
   .localGet 4,
   .store64 (8 : UInt32),
-  .call 23,
+  .call 30,
   .block 0 0 [
     .const (12 : UInt32),
     .const (4 : UInt32),
-    .call 20,
+    .call 27,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (12 : UInt32),
-    .call 66,
+    .call 73,
     .unreachable
   ],
   .localGet 1,
@@ -5609,7 +5913,7 @@ def func61 : Wasm.Program :=
   .load64 (8 : UInt32),
   .store64 (0 : UInt32),
   .localGet 0,
-  .const (1048932 : UInt32),
+  .const (1048980 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5620,32 +5924,32 @@ def func61 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func61Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func61, results := [] }
+def func68Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func68, results := [] }
 
-def func62 : Wasm.Program :=
+def func69 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
   .store32 (0 : UInt32)
 ]
 
-def func62Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func62, results := [] }
+def func69Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func69, results := [] }
 
-def func63 : Wasm.Program :=
+def func70 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048632 : UInt32),
+  .const (1048680 : UInt32),
   .localGet 1,
   .localGet 2,
-  .call 70
+  .call 78
 ]
 
-def func63Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func63, results := [.i32] }
+def func70Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func70, results := [.i32] }
 
-def func64 : Wasm.Program :=
+def func71 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5703,10 +6007,10 @@ def func64 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func64Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func64, results := [] }
+def func71Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func71, results := [] }
 
-def func65 : Wasm.Program :=
+def func72 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5714,40 +6018,40 @@ def func65 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 66,
+    .call 73,
     .unreachable
   ],
-  .call 67,
+  .call 74,
   .unreachable
 ]
 
-def func65Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func65, results := [] }
+def func72Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func72, results := [] }
 
-def func66 : Wasm.Program :=
+def func73 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 47,
+  .call 54,
   .unreachable
 ]
 
-def func66Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func66, results := [] }
+def func73Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func73, results := [] }
 
-def func67 : Wasm.Program :=
+def func74 : Wasm.Program :=
   [
-  .const (1049029 : UInt32),
+  .const (1049077 : UInt32),
   .const (35 : UInt32),
-  .const (1049048 : UInt32),
-  .call 69,
+  .const (1049096 : UInt32),
+  .call 76,
   .unreachable
 ]
 
-def func67Def : Wasm.Function :=
-  { params := [], locals := [], body := func67, results := [] }
+def func74Def : Wasm.Function :=
+  { params := [], locals := [], body := func74, results := [] }
 
-def func68 : Wasm.Program :=
+def func75 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5756,14 +6060,14 @@ def func68 : Wasm.Program :=
   .const (1 : UInt32),
   .or,
   .localGet 2,
-  .call 69,
+  .call 76,
   .unreachable
 ]
 
-def func68Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func68, results := [] }
+def func75Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func75, results := [] }
 
-def func69 : Wasm.Program :=
+def func76 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5791,14 +6095,183 @@ def func69 : Wasm.Program :=
   .localGet 3,
   .const (20 : UInt32),
   .add,
-  .call 46,
+  .call 53,
   .unreachable
 ]
 
-def func69Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func69, results := [] }
+def func76Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func76, results := [] }
 
-def func70 : Wasm.Program :=
+def func77 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .const (20 : UInt32),
+  .localSet 3,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 4,
+  .localGet 4,
+  .localSet 5,
+  .block 0 0 [
+    .localGet 4,
+    .constI64 (1000 : UInt64),
+    .ltUI64,
+    .br_if 0,
+    .const (20 : UInt32),
+    .localSet 3,
+    .localGet 4,
+    .localSet 5,
+    .loop 0 0 [
+      .localGet 2,
+      .const (12 : UInt32),
+      .add,
+      .localGet 3,
+      .add,
+      .localSet 0,
+      .localGet 0,
+      .const (4294967292 : UInt32),
+      .add,
+      .localGet 5,
+      .localSet 6,
+      .localGet 6,
+      .localGet 6,
+      .constI64 (10000 : UInt64),
+      .divUI64,
+      .localSet 5,
+      .localGet 5,
+      .constI64 (10000 : UInt64),
+      .mulI64,
+      .subI64,
+      .wrapI64,
+      .localSet 7,
+      .localGet 7,
+      .const (65535 : UInt32),
+      .and,
+      .const (100 : UInt32),
+      .divU,
+      .localSet 8,
+      .localGet 8,
+      .const (1 : UInt32),
+      .shl,
+      .load16U (1049128 : UInt32),
+      .store16 (0 : UInt32),
+      .localGet 0,
+      .const (4294967294 : UInt32),
+      .add,
+      .localGet 7,
+      .localGet 8,
+      .const (100 : UInt32),
+      .mul,
+      .sub,
+      .const (65535 : UInt32),
+      .and,
+      .const (1 : UInt32),
+      .shl,
+      .load16U (1049128 : UInt32),
+      .store16 (0 : UInt32),
+      .localGet 3,
+      .const (4294967292 : UInt32),
+      .add,
+      .localSet 3,
+      .localGet 6,
+      .constI64 (9999999 : UInt64),
+      .gtUI64,
+      .br_if 0
+    ]
+  ],
+  .block 0 0 [
+    .localGet 5,
+    .constI64 (9 : UInt64),
+    .leUI64,
+    .br_if 0,
+    .localGet 2,
+    .const (12 : UInt32),
+    .add,
+    .localGet 3,
+    .const (4294967294 : UInt32),
+    .add,
+    .localSet 3,
+    .localGet 3,
+    .add,
+    .localGet 5,
+    .wrapI64,
+    .localSet 0,
+    .localGet 0,
+    .localGet 0,
+    .const (65535 : UInt32),
+    .and,
+    .const (100 : UInt32),
+    .divU,
+    .localSet 0,
+    .localGet 0,
+    .const (100 : UInt32),
+    .mul,
+    .sub,
+    .const (65535 : UInt32),
+    .and,
+    .const (1 : UInt32),
+    .shl,
+    .load16U (1049128 : UInt32),
+    .store16 (0 : UInt32),
+    .localGet 0,
+    .extendUI32,
+    .localSet 5
+  ],
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 4,
+      .eqzI64,
+      .br_if 0,
+      .localGet 5,
+      .eqzI64,
+      .br_if 1
+    ],
+    .localGet 2,
+    .const (12 : UInt32),
+    .add,
+    .localGet 3,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 3,
+    .localGet 3,
+    .add,
+    .localGet 5,
+    .wrapI64,
+    .const (1 : UInt32),
+    .shl,
+    .load8U (1049129 : UInt32),
+    .store8 (0 : UInt32)
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1 : UInt32),
+  .const (0 : UInt32),
+  .localGet 2,
+  .const (12 : UInt32),
+  .add,
+  .localGet 3,
+  .add,
+  .const (20 : UInt32),
+  .localGet 3,
+  .sub,
+  .call 79,
+  .localSet 3,
+  .localGet 2,
+  .const (32 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 3
+]
+
+def func77Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64, .i64, .i64, .i32, .i32], body := func77, results := [.i32] }
+
+def func78 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -6106,10 +6579,935 @@ def func70 : Wasm.Program :=
   .localGet 5
 ]
 
-def func70Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func70, results := [.i32] }
+def func78Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func78, results := [.i32] }
 
-def func71 : Wasm.Program :=
+def func79 : Wasm.Program :=
+  [
+  .const (43 : UInt32),
+  .const (1114112 : UInt32),
+  .localGet 0,
+  .load32 (8 : UInt32),
+  .localSet 6,
+  .localGet 6,
+  .const (2097152 : UInt32),
+  .and,
+  .localSet 7,
+  .localGet 7,
+  .select,
+  .localSet 8,
+  .localGet 7,
+  .const (21 : UInt32),
+  .shrU,
+  .const (1 : UInt32),
+  .localGet 1,
+  .select,
+  .localGet 5,
+  .add,
+  .localSet 9,
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 6,
+      .const (8388608 : UInt32),
+      .and,
+      .br_if 0,
+      .const (0 : UInt32),
+      .localSet 2,
+      .br 1
+    ],
+    .block 0 0 [
+      .block 0 0 [
+        .localGet 3,
+        .const (16 : UInt32),
+        .ltU,
+        .br_if 0,
+        .localGet 2,
+        .localGet 3,
+        .call 80,
+        .localSet 7,
+        .br 1
+      ],
+      .block 0 0 [
+        .localGet 3,
+        .br_if 0,
+        .const (0 : UInt32),
+        .localSet 7,
+        .br 1
+      ],
+      .localGet 3,
+      .const (3 : UInt32),
+      .and,
+      .localSet 10,
+      .const (0 : UInt32),
+      .localSet 11,
+      .const (0 : UInt32),
+      .localSet 7,
+      .block 0 0 [
+        .localGet 3,
+        .const (4 : UInt32),
+        .ltU,
+        .br_if 0,
+        .localGet 3,
+        .const (12 : UInt32),
+        .and,
+        .localSet 12,
+        .const (0 : UInt32),
+        .localSet 11,
+        .const (0 : UInt32),
+        .localSet 7,
+        .loop 0 0 [
+          .localGet 7,
+          .localGet 2,
+          .localGet 11,
+          .add,
+          .localSet 13,
+          .localGet 13,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (1 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (2 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (3 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localSet 7,
+          .localGet 12,
+          .localGet 11,
+          .const (4 : UInt32),
+          .add,
+          .localSet 11,
+          .localGet 11,
+          .ne,
+          .br_if 0
+        ],
+        .localGet 10,
+        .eqz,
+        .br_if 1
+      ],
+      .localGet 2,
+      .localGet 11,
+      .add,
+      .localSet 13,
+      .loop 0 0 [
+        .localGet 7,
+        .localGet 13,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7,
+        .localGet 13,
+        .const (1 : UInt32),
+        .add,
+        .localSet 13,
+        .localGet 10,
+        .const (4294967295 : UInt32),
+        .add,
+        .localSet 10,
+        .localGet 10,
+        .br_if 0
+      ]
+    ],
+    .localGet 7,
+    .localGet 9,
+    .add,
+    .localSet 9
+  ],
+  .localGet 8,
+  .const (45 : UInt32),
+  .localGet 1,
+  .select,
+  .localSet 12,
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 9,
+      .localGet 0,
+      .load16U (12 : UInt32),
+      .localSet 1,
+      .localGet 1,
+      .geU,
+      .br_if 0,
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 6,
+            .const (16777216 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 1,
+            .localGet 9,
+            .sub,
+            .localSet 8,
+            .const (0 : UInt32),
+            .localSet 7,
+            .const (0 : UInt32),
+            .localSet 1,
+            .block 0 0 [
+              .block 0 0 [
+                .block 0 0 [
+                  .localGet 6,
+                  .const (29 : UInt32),
+                  .shrU,
+                  .const (3 : UInt32),
+                  .and,
+                  .brTable [2, 0, 1, 0] 2
+                ],
+                .localGet 8,
+                .localSet 1,
+                .br 1
+              ],
+              .localGet 8,
+              .const (65534 : UInt32),
+              .and,
+              .const (1 : UInt32),
+              .shrU,
+              .localSet 1
+            ],
+            .localGet 6,
+            .const (2097151 : UInt32),
+            .and,
+            .localSet 9,
+            .localGet 0,
+            .load32 (4 : UInt32),
+            .localSet 11,
+            .localGet 0,
+            .load32 (0 : UInt32),
+            .localSet 10,
+            .loop 0 0 [
+              .localGet 7,
+              .const (65535 : UInt32),
+              .and,
+              .localGet 1,
+              .const (65535 : UInt32),
+              .and,
+              .geU,
+              .br_if 2,
+              .const (1 : UInt32),
+              .localSet 13,
+              .localGet 7,
+              .const (1 : UInt32),
+              .add,
+              .localSet 7,
+              .localGet 10,
+              .localGet 9,
+              .localGet 11,
+              .load32 (16 : UInt32),
+              .callIndirect 2 0,
+              .eqz,
+              .br_if 0,
+              .br 5
+            ]
+          ],
+          .localGet 0,
+          .localGet 0,
+          .load64 (8 : UInt32),
+          .localSet 14,
+          .localGet 14,
+          .wrapI64,
+          .const (2682257408 : UInt32),
+          .and,
+          .const (536870960 : UInt32),
+          .or,
+          .store32 (8 : UInt32),
+          .const (1 : UInt32),
+          .localSet 13,
+          .localGet 0,
+          .load32 (0 : UInt32),
+          .localSet 10,
+          .localGet 10,
+          .localGet 0,
+          .load32 (4 : UInt32),
+          .localSet 11,
+          .localGet 11,
+          .localGet 12,
+          .localGet 2,
+          .localGet 3,
+          .call 81,
+          .br_if 3,
+          .const (0 : UInt32),
+          .localSet 7,
+          .localGet 1,
+          .localGet 9,
+          .sub,
+          .const (65535 : UInt32),
+          .and,
+          .localSet 2,
+          .loop 0 0 [
+            .localGet 7,
+            .const (65535 : UInt32),
+            .and,
+            .localGet 2,
+            .geU,
+            .br_if 2,
+            .const (1 : UInt32),
+            .localSet 13,
+            .localGet 7,
+            .const (1 : UInt32),
+            .add,
+            .localSet 7,
+            .localGet 10,
+            .const (48 : UInt32),
+            .localGet 11,
+            .load32 (16 : UInt32),
+            .callIndirect 2 0,
+            .eqz,
+            .br_if 0,
+            .br 4
+          ]
+        ],
+        .const (1 : UInt32),
+        .localSet 13,
+        .localGet 10,
+        .localGet 11,
+        .localGet 12,
+        .localGet 2,
+        .localGet 3,
+        .call 81,
+        .br_if 2,
+        .localGet 10,
+        .localGet 4,
+        .localGet 5,
+        .localGet 11,
+        .load32 (12 : UInt32),
+        .callIndirect 1 0,
+        .br_if 2,
+        .const (0 : UInt32),
+        .localSet 7,
+        .localGet 8,
+        .localGet 1,
+        .sub,
+        .const (65535 : UInt32),
+        .and,
+        .localSet 0,
+        .loop 0 0 [
+          .localGet 7,
+          .const (65535 : UInt32),
+          .and,
+          .localSet 2,
+          .localGet 2,
+          .localGet 0,
+          .ltU,
+          .localSet 13,
+          .localGet 2,
+          .localGet 0,
+          .geU,
+          .br_if 3,
+          .localGet 7,
+          .const (1 : UInt32),
+          .add,
+          .localSet 7,
+          .localGet 10,
+          .localGet 9,
+          .localGet 11,
+          .load32 (16 : UInt32),
+          .callIndirect 2 0,
+          .eqz,
+          .br_if 0,
+          .br 3
+        ]
+      ],
+      .const (1 : UInt32),
+      .localSet 13,
+      .localGet 10,
+      .localGet 4,
+      .localGet 5,
+      .localGet 11,
+      .load32 (12 : UInt32),
+      .callIndirect 1 0,
+      .br_if 1,
+      .localGet 0,
+      .localGet 14,
+      .store64 (8 : UInt32),
+      .const (0 : UInt32),
+      .ret
+    ],
+    .const (1 : UInt32),
+    .localSet 13,
+    .localGet 0,
+    .load32 (0 : UInt32),
+    .localSet 7,
+    .localGet 7,
+    .localGet 0,
+    .load32 (4 : UInt32),
+    .localSet 10,
+    .localGet 10,
+    .localGet 12,
+    .localGet 2,
+    .localGet 3,
+    .call 81,
+    .br_if 0,
+    .localGet 7,
+    .localGet 4,
+    .localGet 5,
+    .localGet 10,
+    .load32 (12 : UInt32),
+    .callIndirect 1 0,
+    .localSet 13
+  ],
+  .localGet 13
+]
+
+def func79Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func79, results := [.i32] }
+
+def func80 : Wasm.Program :=
+  [
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 1,
+      .localGet 0,
+      .const (3 : UInt32),
+      .add,
+      .const (4294967292 : UInt32),
+      .and,
+      .localSet 2,
+      .localGet 2,
+      .localGet 0,
+      .sub,
+      .localSet 3,
+      .localGet 3,
+      .ltU,
+      .br_if 0,
+      .localGet 1,
+      .localGet 3,
+      .sub,
+      .localSet 4,
+      .localGet 4,
+      .const (2 : UInt32),
+      .shrU,
+      .localSet 5,
+      .localGet 5,
+      .eqz,
+      .br_if 0,
+      .localGet 4,
+      .const (3 : UInt32),
+      .and,
+      .localSet 6,
+      .const (0 : UInt32),
+      .localSet 7,
+      .const (0 : UInt32),
+      .localSet 1,
+      .block 0 0 [
+        .localGet 2,
+        .localGet 0,
+        .eq,
+        .br_if 0,
+        .const (0 : UInt32),
+        .localSet 8,
+        .const (0 : UInt32),
+        .localSet 1,
+        .block 0 0 [
+          .localGet 0,
+          .localGet 2,
+          .sub,
+          .localSet 9,
+          .localGet 9,
+          .const (4294967292 : UInt32),
+          .gtU,
+          .br_if 0,
+          .const (0 : UInt32),
+          .localSet 8,
+          .const (0 : UInt32),
+          .localSet 1,
+          .loop 0 0 [
+            .localGet 1,
+            .localGet 0,
+            .localGet 8,
+            .add,
+            .localSet 2,
+            .localGet 2,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (1 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (2 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (3 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localSet 1,
+            .localGet 8,
+            .const (4 : UInt32),
+            .add,
+            .localSet 8,
+            .localGet 8,
+            .br_if 0
+          ]
+        ],
+        .localGet 0,
+        .localGet 8,
+        .add,
+        .localSet 2,
+        .loop 0 0 [
+          .localGet 1,
+          .localGet 2,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localSet 1,
+          .localGet 2,
+          .const (1 : UInt32),
+          .add,
+          .localSet 2,
+          .localGet 9,
+          .const (1 : UInt32),
+          .add,
+          .localSet 9,
+          .localGet 9,
+          .br_if 0
+        ]
+      ],
+      .localGet 0,
+      .localGet 3,
+      .add,
+      .localSet 9,
+      .block 0 0 [
+        .localGet 6,
+        .eqz,
+        .br_if 0,
+        .localGet 9,
+        .localGet 4,
+        .const (2147483644 : UInt32),
+        .and,
+        .add,
+        .localSet 2,
+        .localGet 2,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .localSet 7,
+        .localGet 6,
+        .const (1 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 7,
+        .localGet 2,
+        .load8S (1 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7,
+        .localGet 6,
+        .const (2 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 7,
+        .localGet 2,
+        .load8S (2 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7
+      ],
+      .localGet 7,
+      .localGet 1,
+      .add,
+      .localSet 8,
+      .loop 0 0 [
+        .localGet 9,
+        .localSet 3,
+        .localGet 5,
+        .eqz,
+        .br_if 2,
+        .localGet 5,
+        .const (192 : UInt32),
+        .localGet 5,
+        .const (192 : UInt32),
+        .ltU,
+        .select,
+        .localSet 7,
+        .localGet 7,
+        .const (3 : UInt32),
+        .and,
+        .localSet 6,
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 7,
+            .const (2 : UInt32),
+            .shl,
+            .localSet 4,
+            .localGet 4,
+            .const (1008 : UInt32),
+            .and,
+            .localSet 1,
+            .localGet 1,
+            .br_if 0,
+            .const (0 : UInt32),
+            .localSet 2,
+            .br 1
+          ],
+          .localGet 3,
+          .localGet 1,
+          .add,
+          .localSet 0,
+          .const (0 : UInt32),
+          .localSet 2,
+          .localGet 3,
+          .localSet 1,
+          .loop 0 0 [
+            .localGet 1,
+            .const (12 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .const (8 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .const (4 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 2,
+            .add,
+            .add,
+            .add,
+            .add,
+            .localSet 2,
+            .localGet 1,
+            .const (16 : UInt32),
+            .add,
+            .localSet 1,
+            .localGet 1,
+            .localGet 0,
+            .ne,
+            .br_if 0
+          ]
+        ],
+        .localGet 5,
+        .localGet 7,
+        .sub,
+        .localSet 5,
+        .localGet 3,
+        .localGet 4,
+        .add,
+        .localSet 9,
+        .localGet 2,
+        .const (8 : UInt32),
+        .shrU,
+        .const (16711935 : UInt32),
+        .and,
+        .localGet 2,
+        .const (16711935 : UInt32),
+        .and,
+        .add,
+        .const (65537 : UInt32),
+        .mul,
+        .const (16 : UInt32),
+        .shrU,
+        .localGet 8,
+        .add,
+        .localSet 8,
+        .localGet 6,
+        .eqz,
+        .br_if 0
+      ],
+      .localGet 3,
+      .localGet 7,
+      .const (252 : UInt32),
+      .and,
+      .const (2 : UInt32),
+      .shl,
+      .add,
+      .localSet 2,
+      .localGet 2,
+      .load32 (0 : UInt32),
+      .localSet 1,
+      .localGet 1,
+      .const (4294967295 : UInt32),
+      .xor,
+      .const (7 : UInt32),
+      .shrU,
+      .localGet 1,
+      .const (6 : UInt32),
+      .shrU,
+      .or,
+      .const (16843009 : UInt32),
+      .and,
+      .localSet 1,
+      .block 0 0 [
+        .localGet 6,
+        .const (1 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 2,
+        .load32 (4 : UInt32),
+        .localSet 9,
+        .localGet 9,
+        .const (4294967295 : UInt32),
+        .xor,
+        .const (7 : UInt32),
+        .shrU,
+        .localGet 9,
+        .const (6 : UInt32),
+        .shrU,
+        .or,
+        .const (16843009 : UInt32),
+        .and,
+        .localGet 1,
+        .add,
+        .localSet 1,
+        .localGet 6,
+        .const (2 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 2,
+        .load32 (8 : UInt32),
+        .localSet 2,
+        .localGet 2,
+        .const (4294967295 : UInt32),
+        .xor,
+        .const (7 : UInt32),
+        .shrU,
+        .localGet 2,
+        .const (6 : UInt32),
+        .shrU,
+        .or,
+        .const (16843009 : UInt32),
+        .and,
+        .localGet 1,
+        .add,
+        .localSet 1
+      ],
+      .localGet 1,
+      .const (8 : UInt32),
+      .shrU,
+      .const (459007 : UInt32),
+      .and,
+      .localGet 1,
+      .const (16711935 : UInt32),
+      .and,
+      .add,
+      .const (65537 : UInt32),
+      .mul,
+      .const (16 : UInt32),
+      .shrU,
+      .localGet 8,
+      .add,
+      .localSet 8,
+      .br 1
+    ],
+    .block 0 0 [
+      .localGet 1,
+      .br_if 0,
+      .const (0 : UInt32),
+      .ret
+    ],
+    .localGet 1,
+    .const (3 : UInt32),
+    .and,
+    .localSet 2,
+    .const (0 : UInt32),
+    .localSet 9,
+    .const (0 : UInt32),
+    .localSet 8,
+    .block 0 0 [
+      .localGet 1,
+      .const (4 : UInt32),
+      .ltU,
+      .br_if 0,
+      .localGet 1,
+      .const (4294967292 : UInt32),
+      .and,
+      .localSet 5,
+      .const (0 : UInt32),
+      .localSet 8,
+      .const (0 : UInt32),
+      .localSet 9,
+      .loop 0 0 [
+        .localGet 8,
+        .localGet 0,
+        .localGet 9,
+        .add,
+        .localSet 1,
+        .localGet 1,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (1 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (2 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (3 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 8,
+        .localGet 5,
+        .localGet 9,
+        .const (4 : UInt32),
+        .add,
+        .localSet 9,
+        .localGet 9,
+        .ne,
+        .br_if 0
+      ],
+      .localGet 2,
+      .eqz,
+      .br_if 1
+    ],
+    .localGet 0,
+    .localGet 9,
+    .add,
+    .localSet 1,
+    .loop 0 0 [
+      .localGet 8,
+      .localGet 1,
+      .load8S (0 : UInt32),
+      .const (4294967231 : UInt32),
+      .gtS,
+      .add,
+      .localSet 8,
+      .localGet 1,
+      .const (1 : UInt32),
+      .add,
+      .localSet 1,
+      .localGet 2,
+      .const (4294967295 : UInt32),
+      .add,
+      .localSet 2,
+      .localGet 2,
+      .br_if 0
+    ]
+  ],
+  .localGet 8
+]
+
+def func80Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func80, results := [.i32] }
+
+def func81 : Wasm.Program :=
+  [
+  .block 0 0 [
+    .localGet 2,
+    .const (1114112 : UInt32),
+    .eq,
+    .br_if 0,
+    .localGet 0,
+    .localGet 2,
+    .localGet 1,
+    .load32 (16 : UInt32),
+    .callIndirect 2 0,
+    .eqz,
+    .br_if 0,
+    .const (1 : UInt32),
+    .ret
+  ],
+  .block 0 0 [
+    .localGet 3,
+    .br_if 0,
+    .const (0 : UInt32),
+    .ret
+  ],
+  .localGet 0,
+  .localGet 3,
+  .localGet 4,
+  .localGet 1,
+  .load32 (12 : UInt32),
+  .callIndirect 1 0
+]
+
+def func81Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [], body := func81, results := [.i32] }
+
+def func82 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -6121,32 +7519,156 @@ def func71 : Wasm.Program :=
   .callIndirect 1 0
 ]
 
-def func71Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func71, results := [.i32] }
+def func82Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func82, results := [.i32] }
 
-def func72 : Wasm.Program :=
+def func83 : Wasm.Program :=
   [
-  .const (1049064 : UInt32),
+  .const (1049328 : UInt32),
   .const (51 : UInt32),
   .localGet 0,
-  .call 69,
+  .call 76,
   .unreachable
 ]
 
-def func72Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func72, results := [] }
+def func83Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func83, results := [] }
 
-def func73 : Wasm.Program :=
+def func84 : Wasm.Program :=
   [
-  .const (1049089 : UInt32),
+  .const (1049353 : UInt32),
   .const (115 : UInt32),
   .localGet 0,
-  .call 69,
+  .call 76,
   .unreachable
 ]
 
-def func73Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func73, results := [] }
+def func84Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func84, results := [] }
+
+def func85 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 3,
+  .const (0 : UInt32),
+  .localSet 0,
+  .loop 0 0 [
+    .localGet 2,
+    .localGet 0,
+    .add,
+    .const (15 : UInt32),
+    .add,
+    .localGet 3,
+    .wrapI64,
+    .const (15 : UInt32),
+    .and,
+    .load8U (1049112 : UInt32),
+    .store8 (0 : UInt32),
+    .localGet 0,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 0,
+    .localGet 3,
+    .constI64 (4 : UInt64),
+    .shrUI64,
+    .localSet 3,
+    .localGet 3,
+    .constI64 (0 : UInt64),
+    .neI64,
+    .br_if 0
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1049410 : UInt32),
+  .const (2 : UInt32),
+  .localGet 2,
+  .localGet 0,
+  .add,
+  .const (16 : UInt32),
+  .add,
+  .const (0 : UInt32),
+  .localGet 0,
+  .sub,
+  .call 79,
+  .localSet 0,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 0
+]
+
+def func85Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i64], body := func85, results := [.i32] }
+
+def func86 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 3,
+  .const (0 : UInt32),
+  .localSet 0,
+  .loop 0 0 [
+    .localGet 2,
+    .localGet 0,
+    .add,
+    .const (15 : UInt32),
+    .add,
+    .localGet 3,
+    .wrapI64,
+    .const (15 : UInt32),
+    .and,
+    .load8U (1049412 : UInt32),
+    .store8 (0 : UInt32),
+    .localGet 0,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 0,
+    .localGet 3,
+    .constI64 (4 : UInt64),
+    .shrUI64,
+    .localSet 3,
+    .localGet 3,
+    .constI64 (0 : UInt64),
+    .neI64,
+    .br_if 0
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1049410 : UInt32),
+  .const (2 : UInt32),
+  .localGet 2,
+  .localGet 0,
+  .add,
+  .const (16 : UInt32),
+  .add,
+  .const (0 : UInt32),
+  .localGet 0,
+  .sub,
+  .call 79,
+  .localSet 0,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 0
+]
+
+def func86Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i64], body := func86, results := [.i32] }
 
 def «module» : Wasm.Module :=
 {
@@ -6225,42 +7747,60 @@ def «module» : Wasm.Module :=
     func70Def,
     func71Def,
     func72Def,
-    func73Def
+    func73Def,
+    func74Def,
+    func75Def,
+    func76Def,
+    func77Def,
+    func78Def,
+    func79Def,
+    func80Def,
+    func81Def,
+    func82Def,
+    func83Def,
+    func84Def,
+    func85Def,
+    func86Def
   ],
   exports := [
-    { name := "abs_diff", funcIdx := 1 },
-    { name := "add", funcIdx := 2 },
-    { name := "bitand", funcIdx := 3 },
-    { name := "bitor", funcIdx := 4 },
-    { name := "bitxor", funcIdx := 5 },
-    { name := "div", funcIdx := 6 },
-    { name := "entrypoint", funcIdx := 7 },
-    { name := "sub", funcIdx := 8 },
-    { name := "mul", funcIdx := 9 },
-    { name := "rem", funcIdx := 10 },
-    { name := "not", funcIdx := 11 },
-    { name := "shl", funcIdx := 12 },
-    { name := "shr", funcIdx := 13 },
-    { name := "eq", funcIdx := 14 },
-    { name := "ge", funcIdx := 15 },
-    { name := "gt", funcIdx := 16 },
-    { name := "le", funcIdx := 17 },
-    { name := "lt", funcIdx := 18 },
-    { name := "ne", funcIdx := 19 }
+    { name := "abs_diff", funcIdx := 5 },
+    { name := "add", funcIdx := 6 },
+    { name := "bitand", funcIdx := 7 },
+    { name := "bitor", funcIdx := 8 },
+    { name := "bitxor", funcIdx := 9 },
+    { name := "clamp", funcIdx := 10 },
+    { name := "div", funcIdx := 11 },
+    { name := "entrypoint", funcIdx := 12 },
+    { name := "sub", funcIdx := 13 },
+    { name := "mul", funcIdx := 14 },
+    { name := "rem", funcIdx := 15 },
+    { name := "not", funcIdx := 16 },
+    { name := "shl", funcIdx := 17 },
+    { name := "shr", funcIdx := 18 },
+    { name := "eq", funcIdx := 19 },
+    { name := "ge", funcIdx := 20 },
+    { name := "gt", funcIdx := 21 },
+    { name := "le", funcIdx := 22 },
+    { name := "lt", funcIdx := 23 },
+    { name := "max", funcIdx := 24 },
+    { name := "min", funcIdx := 25 },
+    { name := "ne", funcIdx := 26 }
   ],
   memory := some { pagesMin := (17 : UInt32), pagesMax := none, data := [
-    { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (33 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (168 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (168 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (116 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
+    { offset := some (1048576 : UInt32), bytes := [(17 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (32 : UInt8), (62 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (46 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (32 : UInt8), (61 : UInt8), (32 : UInt8), (192 : UInt8), (8 : UInt8), (44 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (32 : UInt8), (61 : UInt8), (32 : UInt8), (192 : UInt8), (0 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (110 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (33 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (216 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (216 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (17 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (164 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (48 : UInt8), (49 : UInt8), (50 : UInt8), (51 : UInt8), (52 : UInt8), (53 : UInt8), (54 : UInt8), (55 : UInt8), (56 : UInt8), (57 : UInt8), (97 : UInt8), (98 : UInt8), (99 : UInt8), (100 : UInt8), (101 : UInt8), (102 : UInt8), (48 : UInt8), (48 : UInt8), (48 : UInt8), (49 : UInt8), (48 : UInt8), (50 : UInt8), (48 : UInt8), (51 : UInt8), (48 : UInt8), (52 : UInt8), (48 : UInt8), (53 : UInt8), (48 : UInt8), (54 : UInt8), (48 : UInt8), (55 : UInt8), (48 : UInt8), (56 : UInt8), (48 : UInt8), (57 : UInt8), (49 : UInt8), (48 : UInt8), (49 : UInt8), (49 : UInt8), (49 : UInt8), (50 : UInt8), (49 : UInt8), (51 : UInt8), (49 : UInt8), (52 : UInt8), (49 : UInt8), (53 : UInt8), (49 : UInt8), (54 : UInt8), (49 : UInt8), (55 : UInt8), (49 : UInt8), (56 : UInt8), (49 : UInt8), (57 : UInt8), (50 : UInt8), (48 : UInt8), (50 : UInt8), (49 : UInt8), (50 : UInt8), (50 : UInt8), (50 : UInt8), (51 : UInt8), (50 : UInt8), (52 : UInt8), (50 : UInt8), (53 : UInt8), (50 : UInt8), (54 : UInt8), (50 : UInt8), (55 : UInt8), (50 : UInt8), (56 : UInt8), (50 : UInt8), (57 : UInt8), (51 : UInt8), (48 : UInt8), (51 : UInt8), (49 : UInt8), (51 : UInt8), (50 : UInt8), (51 : UInt8), (51 : UInt8), (51 : UInt8), (52 : UInt8), (51 : UInt8), (53 : UInt8), (51 : UInt8), (54 : UInt8), (51 : UInt8), (55 : UInt8), (51 : UInt8), (56 : UInt8), (51 : UInt8), (57 : UInt8), (52 : UInt8), (48 : UInt8), (52 : UInt8), (49 : UInt8), (52 : UInt8), (50 : UInt8), (52 : UInt8), (51 : UInt8), (52 : UInt8), (52 : UInt8), (52 : UInt8), (53 : UInt8), (52 : UInt8), (54 : UInt8), (52 : UInt8), (55 : UInt8), (52 : UInt8), (56 : UInt8), (52 : UInt8), (57 : UInt8), (53 : UInt8), (48 : UInt8), (53 : UInt8), (49 : UInt8), (53 : UInt8), (50 : UInt8), (53 : UInt8), (51 : UInt8), (53 : UInt8), (52 : UInt8), (53 : UInt8), (53 : UInt8), (53 : UInt8), (54 : UInt8), (53 : UInt8), (55 : UInt8), (53 : UInt8), (56 : UInt8), (53 : UInt8), (57 : UInt8), (54 : UInt8), (48 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (50 : UInt8), (54 : UInt8), (51 : UInt8), (54 : UInt8), (52 : UInt8), (54 : UInt8), (53 : UInt8), (54 : UInt8), (54 : UInt8), (54 : UInt8), (55 : UInt8), (54 : UInt8), (56 : UInt8), (54 : UInt8), (57 : UInt8), (55 : UInt8), (48 : UInt8), (55 : UInt8), (49 : UInt8), (55 : UInt8), (50 : UInt8), (55 : UInt8), (51 : UInt8), (55 : UInt8), (52 : UInt8), (55 : UInt8), (53 : UInt8), (55 : UInt8), (54 : UInt8), (55 : UInt8), (55 : UInt8), (55 : UInt8), (56 : UInt8), (55 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (56 : UInt8), (49 : UInt8), (56 : UInt8), (50 : UInt8), (56 : UInt8), (51 : UInt8), (56 : UInt8), (52 : UInt8), (56 : UInt8), (53 : UInt8), (56 : UInt8), (54 : UInt8), (56 : UInt8), (55 : UInt8), (56 : UInt8), (56 : UInt8), (56 : UInt8), (57 : UInt8), (57 : UInt8), (48 : UInt8), (57 : UInt8), (49 : UInt8), (57 : UInt8), (50 : UInt8), (57 : UInt8), (51 : UInt8), (57 : UInt8), (52 : UInt8), (57 : UInt8), (53 : UInt8), (57 : UInt8), (54 : UInt8), (57 : UInt8), (55 : UInt8), (57 : UInt8), (56 : UInt8), (57 : UInt8), (57 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (48 : UInt8), (120 : UInt8), (48 : UInt8), (49 : UInt8), (50 : UInt8), (51 : UInt8), (52 : UInt8), (53 : UInt8), (54 : UInt8), (55 : UInt8), (56 : UInt8), (57 : UInt8), (65 : UInt8), (66 : UInt8), (67 : UInt8), (68 : UInt8), (69 : UInt8), (70 : UInt8)] }
   ] },
   globals := [
     { init := .i32 (1048576 : UInt32) },
-    { init := .i32 (1049629 : UInt32) },
-    { init := .i32 (1049632 : UInt32) }
+    { init := .i32 (1049909 : UInt32) },
+    { init := .i32 (1049920 : UInt32) }
   ],
   types := [
     { params := [.i32, .i32], results := [] },
     { params := [.i32, .i32, .i32], results := [.i32] },
     { params := [.i32, .i32], results := [.i32] },
     { params := [.i64, .i64], results := [.i64] },
+    { params := [.i64, .i64, .i64, .i32], results := [.i64] },
+    { params := [.i64, .i64, .i64], results := [.i64] },
     { params := [.i64, .i64, .i32], results := [] },
     { params := [.i64], results := [.i64] },
     { params := [.i64, .i32], results := [.i64] },
@@ -6271,13 +7811,15 @@ def «module» : Wasm.Module :=
     { params := [.i32, .i32, .i32, .i32, .i32], results := [] },
     { params := [.i32], results := [] },
     { params := [.i32, .i32, .i32, .i32, .i32, .i32], results := [] },
-    { params := [.i32], results := [.i32] }
+    { params := [.i32], results := [.i32] },
+    { params := [.i32, .i32, .i32, .i32, .i32, .i32], results := [.i32] },
+    { params := [.i32, .i32, .i32, .i32, .i32], results := [.i32] }
   ],
   tables := [
-    { min := 17, max := some 17, elemType := .funcref }
+    { min := 18, max := some 18, elemType := .funcref }
   ],
   elements := [
-    { tableIdx := some 0, offset := some 1, funcs := [some 35, some 27, some 59, some 58, some 63, some 57, some 56, some 54, some 55, some 28, some 53, some 61, some 60, some 62, some 52, some 51] }
+    { tableIdx := some 0, offset := some 1, funcs := [some 3, some 42, some 34, some 66, some 65, some 70, some 64, some 63, some 61, some 62, some 35, some 60, some 68, some 67, some 69, some 59, some 58] }
   ]
 }
 

--- a/programs/lean/Project/RustU64/Program.lean
+++ b/programs/lean/Project/RustU64/Program.lean
@@ -121,7 +121,7 @@ def func6 : Wasm.Program :=
     .ret
   ],
   .const (1048600 : UInt32),
-  .call 66,
+  .call 72,
   .unreachable
 ]
 
@@ -224,7 +224,7 @@ def func10 : Wasm.Program :=
     .ret
   ],
   .const (1048616 : UInt32),
-  .call 67,
+  .call 73,
   .unreachable
 ]
 
@@ -273,60 +273,144 @@ def func13 : Wasm.Program :=
 def func13Def : Wasm.Function :=
   { params := [.i64, .i32], locals := [], body := func13, results := [.i64] }
 
+/-- export: eq -/
 def func14 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 31,
+  .eqI64,
+  .const (1 : UInt32),
+  .and,
   .ret
 ]
 
 def func14Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func14, results := [.i32] }
+  { params := [.i64, .i64], locals := [], body := func14, results := [.i32] }
 
+/-- export: ge -/
 def func15 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .localGet 2,
-  .call 35,
+  .geUI64,
+  .const (1 : UInt32),
+  .and,
   .ret
 ]
 
 def func15Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func15, results := [] }
+  { params := [.i64, .i64], locals := [], body := func15, results := [.i32] }
 
+/-- export: gt -/
 def func16 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .ret
+]
+
+def func16Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func16, results := [.i32] }
+
+/-- export: le -/
+def func17 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .ret
+]
+
+def func17Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func17, results := [.i32] }
+
+/-- export: lt -/
+def func18 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .ret
+]
+
+def func18Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func18, results := [.i32] }
+
+/-- export: ne -/
+def func19 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .neI64,
+  .const (1 : UInt32),
+  .and,
+  .ret
+]
+
+def func19Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func19, results := [.i32] }
+
+def func20 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 37,
+  .ret
+]
+
+def func20Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func20, results := [.i32] }
+
+def func21 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .localGet 2,
+  .call 41,
+  .ret
+]
+
+def func21Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func21, results := [] }
+
+def func22 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
   .localGet 3,
-  .call 37,
+  .call 43,
   .ret
 ]
 
-def func16Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [], body := func16, results := [.i32] }
+def func22Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [], body := func22, results := [.i32] }
 
-def func17 : Wasm.Program :=
+def func23 : Wasm.Program :=
   [
   .ret
 ]
 
-def func17Def : Wasm.Function :=
-  { params := [], locals := [], body := func17, results := [] }
+def func23Def : Wasm.Function :=
+  { params := [], locals := [], body := func23, results := [] }
 
-def func18 : Wasm.Program :=
+def func24 : Wasm.Program :=
   [
-  .call 34,
+  .call 40,
   .unreachable
 ]
 
-def func18Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func18, results := [.i32] }
+def func24Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func24, results := [.i32] }
 
-def func19 : Wasm.Program :=
+def func25 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -345,7 +429,7 @@ def func19 : Wasm.Program :=
     .br_if 0,
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .call 59,
+    .call 65,
     .unreachable
   ],
   .localGet 5,
@@ -385,7 +469,7 @@ def func19 : Wasm.Program :=
   .localGet 2,
   .localGet 3,
   .localGet 4,
-  .call 27,
+  .call 33,
   .block 0 0 [
     .localGet 5,
     .load32 (4 : UInt32),
@@ -396,7 +480,7 @@ def func19 : Wasm.Program :=
     .load32 (8 : UInt32),
     .localGet 5,
     .load32 (12 : UInt32),
-    .call 59,
+    .call 65,
     .unreachable
   ],
   .localGet 5,
@@ -414,10 +498,10 @@ def func19 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func19Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func19, results := [] }
+def func25Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func25, results := [] }
 
-def func20 : Wasm.Program :=
+def func26 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -429,14 +513,14 @@ def func20 : Wasm.Program :=
     .localGet 1,
     .localGet 0,
     .const (1 : UInt32),
-    .call 15
+    .call 21
   ]
 ]
 
-def func20Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func20, results := [] }
+def func26Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func26, results := [] }
 
-def func21 : Wasm.Program :=
+def func27 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -449,14 +533,14 @@ def func21 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 15
+    .call 21
   ]
 ]
 
-def func21Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func21, results := [] }
+def func27Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func27, results := [] }
 
-def func22 : Wasm.Program :=
+def func28 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -470,24 +554,24 @@ def func22 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 15
+    .call 21
   ]
 ]
 
-def func22Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func22, results := [] }
+def func28Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func28, results := [] }
 
-def func23 : Wasm.Program :=
+def func29 : Wasm.Program :=
   [
   .localGet 0,
-  .call 24,
+  .call 30,
   .unreachable
 ]
 
-def func23Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func23, results := [] }
+def func29Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func29, results := [] }
 
-def func24 : Wasm.Program :=
+def func30 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -504,20 +588,20 @@ def func24 : Wasm.Program :=
   .unreachable
 ]
 
-def func24Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func24, results := [] }
+def func30Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func30, results := [] }
 
-def func25 : Wasm.Program :=
+def func31 : Wasm.Program :=
   [
   .localGet 0,
-  .call 26,
+  .call 32,
   .unreachable
 ]
 
-def func25Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func25, results := [] }
+def func31Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func31, results := [] }
 
-def func26 : Wasm.Program :=
+def func32 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -559,7 +643,7 @@ def func26 : Wasm.Program :=
     .load8U (8 : UInt32),
     .localGet 0,
     .load8U (9 : UInt32),
-    .call 28,
+    .call 34,
     .unreachable
   ],
   .localGet 1,
@@ -579,14 +663,14 @@ def func26 : Wasm.Program :=
   .load8U (8 : UInt32),
   .localGet 0,
   .load8U (9 : UInt32),
-  .call 28,
+  .call 34,
   .unreachable
 ]
 
-def func26Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32], body := func26, results := [] }
+def func32Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32], body := func32, results := [] }
 
-def func27 : Wasm.Program :=
+def func33 : Wasm.Program :=
   [
   .const (1 : UInt32),
   .localSet 6,
@@ -637,7 +721,7 @@ def func27 : Wasm.Program :=
             .mul,
             .localGet 4,
             .localGet 3,
-            .call 16,
+            .call 22,
             .localSet 7,
             .br 1
           ],
@@ -648,10 +732,10 @@ def func27 : Wasm.Program :=
             .localSet 7,
             .br 2
           ],
-          .call 17,
+          .call 23,
           .localGet 3,
           .localGet 4,
-          .call 14,
+          .call 20,
           .localSet 7
         ],
         .localGet 7,
@@ -680,10 +764,10 @@ def func27 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func27Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func27, results := [] }
+def func33Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func33, results := [] }
 
-def func28 : Wasm.Program :=
+def func34 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -697,7 +781,7 @@ def func28 : Wasm.Program :=
         .block 0 0 [
           .block 0 0 [
             .const (1 : UInt32),
-            .call 44,
+            .call 50,
             .const (255 : UInt32),
             .and,
             .brTable [4, 1, 0] 1
@@ -758,7 +842,7 @@ def func28 : Wasm.Program :=
       ],
       .const (2147483648 : UInt32),
       .localGet 5,
-      .call 20
+      .call 26
     ],
     .const (0 : UInt32),
     .const (0 : UInt32),
@@ -774,38 +858,38 @@ def func28 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 30,
+    .call 36,
     .unreachable
   ],
   .unreachable
 ]
 
-def func28Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func28, results := [] }
+def func34Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func34, results := [] }
 
-def func29 : Wasm.Program :=
+def func35 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .const (1 : UInt32),
   .store8 (1049628 : UInt32)
 ]
 
-def func29Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func29, results := [] }
+def func35Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func35, results := [] }
 
-def func30 : Wasm.Program :=
+def func36 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 18,
+  .call 24,
   .drop,
   .unreachable
 ]
 
-def func30Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func30, results := [] }
+def func36Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func36, results := [] }
 
-def func31 : Wasm.Program :=
+def func37 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -814,17 +898,17 @@ def func31 : Wasm.Program :=
     .br_if 0,
     .localGet 1,
     .localGet 0,
-    .call 32,
+    .call 38,
     .ret
   ],
   .localGet 0,
-  .call 33
+  .call 39
 ]
 
-def func31Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func31, results := [.i32] }
+def func37Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func37, results := [.i32] }
 
-def func32 : Wasm.Program :=
+def func38 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -858,7 +942,7 @@ def func32 : Wasm.Program :=
     .add,
     .const (12 : UInt32),
     .add,
-    .call 33,
+    .call 39,
     .localSet 1,
     .localGet 1,
     .eqz,
@@ -967,7 +1051,7 @@ def func32 : Wasm.Program :=
         .store32 (4 : UInt32),
         .localGet 2,
         .localGet 1,
-        .call 39,
+        .call 45,
         .br 1
       ],
       .localGet 2,
@@ -1035,7 +1119,7 @@ def func32 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 1,
       .localGet 3,
-      .call 39
+      .call 45
     ],
     .localGet 0,
     .const (8 : UInt32),
@@ -1045,10 +1129,10 @@ def func32 : Wasm.Program :=
   .localGet 2
 ]
 
-def func32Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func32, results := [.i32] }
+def func38Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func38, results := [.i32] }
 
-def func33 : Wasm.Program :=
+def func39 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -2145,7 +2229,7 @@ def func33 : Wasm.Program :=
             .br_if 0,
             .localGet 0,
             .localGet 2,
-            .call 43,
+            .call 49,
             .br 2
           ],
           .block 0 0 [
@@ -2263,7 +2347,7 @@ def func33 : Wasm.Program :=
                   .add,
                   .const (4294901760 : UInt32),
                   .and,
-                  .call 58,
+                  .call 64,
                   .block 0 0 [
                     .localGet 1,
                     .load32 (4 : UInt32),
@@ -2830,7 +2914,7 @@ def func33 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 0,
-                      .call 43,
+                      .call 49,
                       .br 8
                     ],
                     .block 0 0 [
@@ -2955,7 +3039,7 @@ def func33 : Wasm.Program :=
                     .and,
                     .localSet 6,
                     .localGet 6,
-                    .call 38,
+                    .call 44,
                     .localGet 6,
                     .localGet 3,
                     .add,
@@ -2990,7 +3074,7 @@ def func33 : Wasm.Program :=
                     .br_if 0,
                     .localGet 0,
                     .localGet 3,
-                    .call 43,
+                    .call 49,
                     .br 6
                   ],
                   .block 0 0 [
@@ -3298,18 +3382,18 @@ def func33 : Wasm.Program :=
   .localGet 0
 ]
 
-def func33Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func33, results := [.i32] }
+def func39Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func39, results := [.i32] }
 
-def func34 : Wasm.Program :=
+def func40 : Wasm.Program :=
   [
   .unreachable
 ]
 
-def func34Def : Wasm.Function :=
-  { params := [], locals := [], body := func34, results := [] }
+def func40Def : Wasm.Function :=
+  { params := [], locals := [], body := func40, results := [] }
 
-def func35 : Wasm.Program :=
+def func41 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3347,26 +3431,26 @@ def func35 : Wasm.Program :=
         .br_if 2
       ],
       .localGet 0,
-      .call 36,
+      .call 42,
       .ret
     ],
     .const (1048787 : UInt32),
     .const (46 : UInt32),
     .const (1048836 : UInt32),
-    .call 62,
+    .call 68,
     .unreachable
   ],
   .const (1048852 : UInt32),
   .const (46 : UInt32),
   .const (1048900 : UInt32),
-  .call 62,
+  .call 68,
   .unreachable
 ]
 
-def func35Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func35, results := [] }
+def func41Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func41, results := [] }
 
-def func36 : Wasm.Program :=
+def func42 : Wasm.Program :=
   [
   .localGet 0,
   .const (4294967288 : UInt32),
@@ -3441,7 +3525,7 @@ def func36 : Wasm.Program :=
       ],
       .localGet 1,
       .localGet 2,
-      .call 38
+      .call 44
     ],
     .block 0 0 [
       .block 0 0 [
@@ -3474,7 +3558,7 @@ def func36 : Wasm.Program :=
                     .and,
                     .localSet 2,
                     .localGet 2,
-                    .call 38,
+                    .call 44,
                     .localGet 1,
                     .localGet 2,
                     .localGet 0,
@@ -3521,7 +3605,7 @@ def func36 : Wasm.Program :=
                 .br_if 4,
                 .localGet 1,
                 .localGet 0,
-                .call 43,
+                .call 49,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
                 .load32 (1049624 : UInt32),
@@ -3767,10 +3851,10 @@ def func36 : Wasm.Program :=
   ]
 ]
 
-def func36Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func36, results := [] }
+def func42Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func42, results := [] }
 
-def func37 : Wasm.Program :=
+def func43 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3825,7 +3909,7 @@ def func37 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 3,
-                      .call 32,
+                      .call 38,
                       .localSet 2,
                       .localGet 2,
                       .br_if 1,
@@ -3918,7 +4002,7 @@ def func37 : Wasm.Program :=
                           .br_if 9,
                           .localGet 7,
                           .localGet 9,
-                          .call 38,
+                          .call 44,
                           .block 0 0 [
                             .localGet 5,
                             .localGet 1,
@@ -3959,7 +4043,7 @@ def func37 : Wasm.Program :=
                             .store32 (4 : UInt32),
                             .localGet 1,
                             .localGet 7,
-                            .call 39,
+                            .call 45,
                             .br 9
                           ],
                           .localGet 4,
@@ -4102,7 +4186,7 @@ def func37 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .localGet 1,
                       .localGet 6,
-                      .call 39,
+                      .call 45,
                       .br 6
                     ],
                     .const (0 : UInt32),
@@ -4162,25 +4246,25 @@ def func37 : Wasm.Program :=
                   .const (1048852 : UInt32),
                   .const (46 : UInt32),
                   .const (1048900 : UInt32),
-                  .call 62,
+                  .call 68,
                   .unreachable
                 ],
                 .const (1048787 : UInt32),
                 .const (46 : UInt32),
                 .const (1048836 : UInt32),
-                .call 62,
+                .call 68,
                 .unreachable
               ],
               .const (1048852 : UInt32),
               .const (46 : UInt32),
               .const (1048900 : UInt32),
-              .call 62,
+              .call 68,
               .unreachable
             ],
             .const (1048787 : UInt32),
             .const (46 : UInt32),
             .const (1048836 : UInt32),
-            .call 62,
+            .call 68,
             .unreachable
           ],
           .localGet 4,
@@ -4219,7 +4303,7 @@ def func37 : Wasm.Program :=
         .ret
       ],
       .localGet 3,
-      .call 33,
+      .call 39,
       .localSet 1,
       .localGet 1,
       .eqz,
@@ -4258,15 +4342,15 @@ def func37 : Wasm.Program :=
       .localSet 2
     ],
     .localGet 0,
-    .call 36
+    .call 42
   ],
   .localGet 2
 ]
 
-def func37Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func37, results := [.i32] }
+def func43Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func43, results := [.i32] }
 
-def func38 : Wasm.Program :=
+def func44 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (12 : UInt32),
@@ -4474,10 +4558,10 @@ def func38 : Wasm.Program :=
   .store32 (1049588 : UInt32)
 ]
 
-def func38Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func38, results := [] }
+def func44Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func44, results := [] }
 
-def func39 : Wasm.Program :=
+def func45 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4542,7 +4626,7 @@ def func39 : Wasm.Program :=
       ],
       .localGet 0,
       .localGet 3,
-      .call 38
+      .call 44
     ],
     .block 0 0 [
       .block 0 0 [
@@ -4571,7 +4655,7 @@ def func39 : Wasm.Program :=
             .and,
             .localSet 3,
             .localGet 3,
-            .call 38,
+            .call 44,
             .localGet 0,
             .localGet 3,
             .localGet 1,
@@ -4619,7 +4703,7 @@ def func39 : Wasm.Program :=
           .br_if 0,
           .localGet 0,
           .localGet 1,
-          .call 43,
+          .call 49,
           .ret
         ],
         .block 0 0 [
@@ -4734,10 +4818,10 @@ def func39 : Wasm.Program :=
   ]
 ]
 
-def func39Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func39, results := [] }
+def func45Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func45, results := [] }
 
-def func40 : Wasm.Program :=
+def func46 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4757,25 +4841,25 @@ def func40 : Wasm.Program :=
   .localGet 1,
   .const (4 : UInt32),
   .add,
-  .call 25,
+  .call 31,
   .unreachable
 ]
 
-def func40Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i64], body := func40, results := [] }
+def func46Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i64], body := func46, results := [] }
 
-def func41 : Wasm.Program :=
+def func47 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 42,
+  .call 48,
   .unreachable
 ]
 
-def func41Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func41, results := [] }
+def func47Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func47, results := [] }
 
-def func42 : Wasm.Program :=
+def func48 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4792,14 +4876,14 @@ def func42 : Wasm.Program :=
   .localGet 2,
   .const (8 : UInt32),
   .add,
-  .call 23,
+  .call 29,
   .unreachable
 ]
 
-def func42Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32], body := func42, results := [] }
+def func48Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32], body := func48, results := [] }
 
-def func43 : Wasm.Program :=
+def func49 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -4973,10 +5057,10 @@ def func43 : Wasm.Program :=
   .store32 (8 : UInt32)
 ]
 
-def func43Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func43, results := [] }
+def func49Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func49, results := [] }
 
-def func44 : Wasm.Program :=
+def func50 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 1,
@@ -5013,10 +5097,10 @@ def func44 : Wasm.Program :=
   .localGet 1
 ]
 
-def func44Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32], body := func44, results := [.i32] }
+def func50Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32], body := func50, results := [.i32] }
 
-def func45 : Wasm.Program :=
+def func51 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
@@ -5028,10 +5112,10 @@ def func45 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func45Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func45, results := [] }
+def func51Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func51, results := [] }
 
-def func46 : Wasm.Program :=
+def func52 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
@@ -5043,10 +5127,10 @@ def func46 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func46Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func46, results := [] }
+def func52Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func52, results := [] }
 
-def func47 : Wasm.Program :=
+def func53 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5059,7 +5143,7 @@ def func47 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 0,
     .load32 (8 : UInt32),
-    .call 65,
+    .call 71,
     .ret
   ],
   .localGet 1,
@@ -5074,13 +5158,13 @@ def func47 : Wasm.Program :=
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 64
+  .call 70
 ]
 
-def func47Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func47, results := [.i32] }
+def func53Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func53, results := [.i32] }
 
-def func48 : Wasm.Program :=
+def func54 : Wasm.Program :=
   [
   .localGet 0,
   .const (1048916 : UInt32),
@@ -5090,10 +5174,10 @@ def func48 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func48Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func48, results := [] }
+def func54Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func54, results := [] }
 
-def func49 : Wasm.Program :=
+def func55 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5101,10 +5185,10 @@ def func49 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func49Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func49, results := [] }
+def func55Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func55, results := [] }
 
-def func50 : Wasm.Program :=
+def func56 : Wasm.Program :=
   [
   .localGet 1,
   .load32 (4 : UInt32),
@@ -5112,17 +5196,17 @@ def func50 : Wasm.Program :=
   .localGet 1,
   .load32 (0 : UInt32),
   .localSet 3,
-  .call 17,
+  .call 23,
   .block 0 0 [
     .const (8 : UInt32),
     .const (4 : UInt32),
-    .call 14,
+    .call 20,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (8 : UInt32),
-    .call 60,
+    .call 66,
     .unreachable
   ],
   .localGet 1,
@@ -5139,23 +5223,23 @@ def func50 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func50Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func50, results := [] }
+def func56Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func56, results := [] }
 
-def func51 : Wasm.Program :=
+def func57 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 65
+  .call 71
 ]
 
-def func51Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func51, results := [.i32] }
+def func57Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func57, results := [.i32] }
 
-def func52 : Wasm.Program :=
+def func58 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (8 : UInt32),
@@ -5202,7 +5286,7 @@ def func52 : Wasm.Program :=
     .localGet 3,
     .const (1 : UInt32),
     .const (1 : UInt32),
-    .call 19,
+    .call 25,
     .localGet 0,
     .load32 (8 : UInt32),
     .localSet 4
@@ -5305,10 +5389,10 @@ def func52 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func52Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func52, results := [.i32] }
+def func58Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func58, results := [.i32] }
 
-def func53 : Wasm.Program :=
+def func59 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5328,7 +5412,7 @@ def func53 : Wasm.Program :=
         .localGet 2,
         .const (1 : UInt32),
         .const (1 : UInt32),
-        .call 19,
+        .call 25,
         .localGet 0,
         .load32 (8 : UInt32),
         .localSet 3,
@@ -5357,10 +5441,10 @@ def func53 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func53Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func53, results := [.i32] }
+def func59Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func59, results := [.i32] }
 
-def func54 : Wasm.Program :=
+def func60 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5394,7 +5478,7 @@ def func54 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 64,
+    .call 70,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5427,10 +5511,10 @@ def func54 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func54Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func54, results := [] }
+def func60Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func60, results := [] }
 
-def func55 : Wasm.Program :=
+def func61 : Wasm.Program :=
   [
   .globalGet 0,
   .const (48 : UInt32),
@@ -5464,7 +5548,7 @@ def func55 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 64,
+    .call 70,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5503,17 +5587,17 @@ def func55 : Wasm.Program :=
   .localGet 2,
   .localGet 4,
   .store64 (8 : UInt32),
-  .call 17,
+  .call 23,
   .block 0 0 [
     .const (12 : UInt32),
     .const (4 : UInt32),
-    .call 14,
+    .call 20,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (12 : UInt32),
-    .call 60,
+    .call 66,
     .unreachable
   ],
   .localGet 1,
@@ -5536,32 +5620,32 @@ def func55 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func55Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func55, results := [] }
+def func61Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func61, results := [] }
 
-def func56 : Wasm.Program :=
+def func62 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
   .store32 (0 : UInt32)
 ]
 
-def func56Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func56, results := [] }
+def func62Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func62, results := [] }
 
-def func57 : Wasm.Program :=
+def func63 : Wasm.Program :=
   [
   .localGet 0,
   .const (1048632 : UInt32),
   .localGet 1,
   .localGet 2,
-  .call 64
+  .call 70
 ]
 
-def func57Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func57, results := [.i32] }
+def func63Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func63, results := [.i32] }
 
-def func58 : Wasm.Program :=
+def func64 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5619,10 +5703,10 @@ def func58 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func58Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func58, results := [] }
+def func64Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func64, results := [] }
 
-def func59 : Wasm.Program :=
+def func65 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5630,40 +5714,40 @@ def func59 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 60,
+    .call 66,
     .unreachable
   ],
-  .call 61,
+  .call 67,
   .unreachable
 ]
 
-def func59Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func59, results := [] }
+def func65Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func65, results := [] }
 
-def func60 : Wasm.Program :=
+def func66 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 41,
+  .call 47,
   .unreachable
 ]
 
-def func60Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func60, results := [] }
+def func66Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func66, results := [] }
 
-def func61 : Wasm.Program :=
+def func67 : Wasm.Program :=
   [
   .const (1049029 : UInt32),
   .const (35 : UInt32),
   .const (1049048 : UInt32),
-  .call 63,
+  .call 69,
   .unreachable
 ]
 
-def func61Def : Wasm.Function :=
-  { params := [], locals := [], body := func61, results := [] }
+def func67Def : Wasm.Function :=
+  { params := [], locals := [], body := func67, results := [] }
 
-def func62 : Wasm.Program :=
+def func68 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5672,14 +5756,14 @@ def func62 : Wasm.Program :=
   .const (1 : UInt32),
   .or,
   .localGet 2,
-  .call 63,
+  .call 69,
   .unreachable
 ]
 
-def func62Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func62, results := [] }
+def func68Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func68, results := [] }
 
-def func63 : Wasm.Program :=
+def func69 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5707,14 +5791,14 @@ def func63 : Wasm.Program :=
   .localGet 3,
   .const (20 : UInt32),
   .add,
-  .call 40,
+  .call 46,
   .unreachable
 ]
 
-def func63Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func63, results := [] }
+def func69Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func69, results := [] }
 
-def func64 : Wasm.Program :=
+def func70 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -6022,10 +6106,10 @@ def func64 : Wasm.Program :=
   .localGet 5
 ]
 
-def func64Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func64, results := [.i32] }
+def func70Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func70, results := [.i32] }
 
-def func65 : Wasm.Program :=
+def func71 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -6037,32 +6121,32 @@ def func65 : Wasm.Program :=
   .callIndirect 1 0
 ]
 
-def func65Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func65, results := [.i32] }
+def func71Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func71, results := [.i32] }
 
-def func66 : Wasm.Program :=
+def func72 : Wasm.Program :=
   [
   .const (1049064 : UInt32),
   .const (51 : UInt32),
   .localGet 0,
-  .call 63,
+  .call 69,
   .unreachable
 ]
 
-def func66Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func66, results := [] }
+def func72Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func72, results := [] }
 
-def func67 : Wasm.Program :=
+def func73 : Wasm.Program :=
   [
   .const (1049089 : UInt32),
   .const (115 : UInt32),
   .localGet 0,
-  .call 63,
+  .call 69,
   .unreachable
 ]
 
-def func67Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func67, results := [] }
+def func73Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func73, results := [] }
 
 def «module» : Wasm.Module :=
 {
@@ -6135,7 +6219,13 @@ def «module» : Wasm.Module :=
     func64Def,
     func65Def,
     func66Def,
-    func67Def
+    func67Def,
+    func68Def,
+    func69Def,
+    func70Def,
+    func71Def,
+    func72Def,
+    func73Def
   ],
   exports := [
     { name := "abs_diff", funcIdx := 1 },
@@ -6150,7 +6240,13 @@ def «module» : Wasm.Module :=
     { name := "rem", funcIdx := 10 },
     { name := "not", funcIdx := 11 },
     { name := "shl", funcIdx := 12 },
-    { name := "shr", funcIdx := 13 }
+    { name := "shr", funcIdx := 13 },
+    { name := "eq", funcIdx := 14 },
+    { name := "ge", funcIdx := 15 },
+    { name := "gt", funcIdx := 16 },
+    { name := "le", funcIdx := 17 },
+    { name := "lt", funcIdx := 18 },
+    { name := "ne", funcIdx := 19 }
   ],
   memory := some { pagesMin := (17 : UInt32), pagesMax := none, data := [
     { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (23 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (33 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (168 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (168 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (116 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
@@ -6168,6 +6264,7 @@ def «module» : Wasm.Module :=
     { params := [.i64, .i64, .i32], results := [] },
     { params := [.i64], results := [.i64] },
     { params := [.i64, .i32], results := [.i64] },
+    { params := [.i64, .i64], results := [.i32] },
     { params := [.i32, .i32, .i32], results := [] },
     { params := [.i32, .i32, .i32, .i32], results := [.i32] },
     { params := [], results := [] },
@@ -6180,7 +6277,7 @@ def «module» : Wasm.Module :=
     { min := 17, max := some 17, elemType := .funcref }
   ],
   elements := [
-    { tableIdx := some 0, offset := some 1, funcs := [some 29, some 21, some 53, some 52, some 57, some 51, some 50, some 48, some 49, some 22, some 47, some 55, some 54, some 56, some 46, some 45] }
+    { tableIdx := some 0, offset := some 1, funcs := [some 35, some 27, some 59, some 58, some 63, some 57, some 56, some 54, some 55, some 28, some 53, some 61, some 60, some 62, some 52, some 51] }
   ]
 }
 

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -171,4 +171,15 @@ theorem ne_correct : NeSpec := by
   exact (TerminatesWith.of_returns_wp (f := func19Def) (rs := [.i32 (if a ≠ b then 1 else 0)]) rfl rfl
       (neBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::lt"]
+def LtSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 18 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a < b then 1 else 0)])
+@[proves Project.RustU64.Spec.LtSpec]
+theorem lt_correct : LtSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func18Def) (rs := [.i32 (if a < b then 1 else 0)]) rfl rfl
+      (ltBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -193,4 +193,15 @@ theorem le_correct : LeSpec := by
   exact (TerminatesWith.of_returns_wp (f := func17Def) (rs := [.i32 (if a ≤ b then 1 else 0)]) rfl rfl
       (leBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::gt"]
+def GtSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 16 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a > b then 1 else 0)])
+@[proves Project.RustU64.Spec.GtSpec]
+theorem gt_correct : GtSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func16Def) (rs := [.i32 (if a > b then 1 else 0)]) rfl rfl
+      (gtBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -1,4 +1,5 @@
 import Project.RustU64.Program
+import Interpreter.Wasm.Wp.Call
 
 /-!
 # `rust_u64` per-crate specs (abs_diff + operators add .. shr)
@@ -17,7 +18,7 @@ open Wasm Wasm.RustStd Wasm.RustStd.U64
 @[spec_of "rust-internal" "core::num::abs_diff"]
 def AbsDiffSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 0 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 4 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (if a < b then b - a else a - b)])
 
 @[proves Project.RustU64.Spec.AbsDiffSpec]
@@ -31,188 +32,280 @@ theorem abs_diff_correct : AbsDiffSpec := by
 @[spec_of "rust-exported" "rust_u64::add"]
 def AddSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 2 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 6 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a + b)])
 @[proves Project.RustU64.Spec.AddSpec]
 theorem add_correct : AddSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func2Def) (rs := [.i64 (a + b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func6Def) (rs := [.i64 (a + b)]) rfl rfl
       (addBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::sub"]
 def SubSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 8 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 13 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a - b)])
 @[proves Project.RustU64.Spec.SubSpec]
 theorem sub_correct : SubSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func8Def) (rs := [.i64 (a - b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func13Def) (rs := [.i64 (a - b)]) rfl rfl
       (subBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::mul"]
 def MulSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 9 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 14 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a * b)])
 @[proves Project.RustU64.Spec.MulSpec]
 theorem mul_correct : MulSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func9Def) (rs := [.i64 (a * b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func14Def) (rs := [.i64 (a * b)]) rfl rfl
       (mulBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::div"]
 def DivSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64), b ≠ 0 →
-    TerminatesWith env «module» 6 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 11 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a / b)])
 @[proves Project.RustU64.Spec.DivSpec]
 theorem div_correct : DivSpec := by
   intro env a b hb
-  exact (TerminatesWith.of_returns_wp (f := func6Def) (rs := [.i64 (a / b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func11Def) (rs := [.i64 (a / b)]) rfl rfl
       (divBodyWp «module».initialStore a b [] hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::rem"]
 def RemSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64), b ≠ 0 →
-    TerminatesWith env «module» 10 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 15 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a % b)])
 @[proves Project.RustU64.Spec.RemSpec]
 theorem rem_correct : RemSpec := by
   intro env a b hb
-  exact (TerminatesWith.of_returns_wp (f := func10Def) (rs := [.i64 (a % b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func15Def) (rs := [.i64 (a % b)]) rfl rfl
       (remBodyWp «module».initialStore a b [] hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitand"]
 def BitAndSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 3 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 7 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a &&& b)])
 @[proves Project.RustU64.Spec.BitAndSpec]
 theorem bitand_correct : BitAndSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func3Def) (rs := [.i64 (a &&& b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func7Def) (rs := [.i64 (a &&& b)]) rfl rfl
       (bitandBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitor"]
 def BitOrSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 4 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 8 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a ||| b)])
 @[proves Project.RustU64.Spec.BitOrSpec]
 theorem bitor_correct : BitOrSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func4Def) (rs := [.i64 (a ||| b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func8Def) (rs := [.i64 (a ||| b)]) rfl rfl
       (bitorBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitxor"]
 def BitXorSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 5 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 9 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i64 (a ^^^ b)])
 @[proves Project.RustU64.Spec.BitXorSpec]
 theorem bitxor_correct : BitXorSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func5Def) (rs := [.i64 (a ^^^ b)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func9Def) (rs := [.i64 (a ^^^ b)]) rfl rfl
       (bitxorBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::not"]
 def NotSpec : Prop :=
   ∀ (env : HostEnv Unit) (a : UInt64),
-    TerminatesWith env «module» 11 «module».initialStore [.i64 a]
+    TerminatesWith env «module» 16 «module».initialStore [.i64 a]
       (fun _ rs => rs = [.i64 (~~~a)])
 @[proves Project.RustU64.Spec.NotSpec]
 theorem not_correct : NotSpec := by
   intro env a
-  exact (TerminatesWith.of_returns_wp (f := func11Def) (rs := [.i64 (~~~a)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func16Def) (rs := [.i64 (~~~a)]) rfl rfl
       (notBodyWp «module».initialStore a []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::shl"]
 def ShlSpec : Prop :=
   ∀ (env : HostEnv Unit) (a : UInt64) (b : UInt32),
-    TerminatesWith env «module» 12 «module».initialStore [.i32 b, .i64 a]
+    TerminatesWith env «module» 17 «module».initialStore [.i32 b, .i64 a]
       (fun _ rs => rs = [.i64 (a <<< (b.toUInt64 % 64))])
 @[proves Project.RustU64.Spec.ShlSpec]
 theorem shl_correct : ShlSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func12Def) (rs := [.i64 (a <<< (b.toUInt64 % 64))])
+  exact (TerminatesWith.of_returns_wp (f := func17Def) (rs := [.i64 (a <<< (b.toUInt64 % 64))])
       rfl rfl (shlBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::shr"]
 def ShrSpec : Prop :=
   ∀ (env : HostEnv Unit) (a : UInt64) (b : UInt32),
-    TerminatesWith env «module» 13 «module».initialStore [.i32 b, .i64 a]
+    TerminatesWith env «module» 18 «module».initialStore [.i32 b, .i64 a]
       (fun _ rs => rs = [.i64 (a >>> (b.toUInt64 % 64))])
 @[proves Project.RustU64.Spec.ShrSpec]
 theorem shr_correct : ShrSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func13Def) (rs := [.i64 (a >>> (b.toUInt64 % 64))])
+  exact (TerminatesWith.of_returns_wp (f := func18Def) (rs := [.i64 (a >>> (b.toUInt64 % 64))])
       rfl rfl (shrBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::eq"]
 def EqSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 14 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 19 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a = b then 1 else 0)])
 @[proves Project.RustU64.Spec.EqSpec]
 theorem eq_correct : EqSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func14Def) (rs := [.i32 (if a = b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func19Def) (rs := [.i32 (if a = b then 1 else 0)]) rfl rfl
       (eqBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::ne"]
 def NeSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 19 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 26 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a ≠ b then 1 else 0)])
 @[proves Project.RustU64.Spec.NeSpec]
 theorem ne_correct : NeSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func19Def) (rs := [.i32 (if a ≠ b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func26Def) (rs := [.i32 (if a ≠ b then 1 else 0)]) rfl rfl
       (neBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::lt"]
 def LtSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 18 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 23 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a < b then 1 else 0)])
 @[proves Project.RustU64.Spec.LtSpec]
 theorem lt_correct : LtSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func18Def) (rs := [.i32 (if a < b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func23Def) (rs := [.i32 (if a < b then 1 else 0)]) rfl rfl
       (ltBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::le"]
 def LeSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 17 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 22 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a ≤ b then 1 else 0)])
 @[proves Project.RustU64.Spec.LeSpec]
 theorem le_correct : LeSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func17Def) (rs := [.i32 (if a ≤ b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func22Def) (rs := [.i32 (if a ≤ b then 1 else 0)]) rfl rfl
       (leBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::gt"]
 def GtSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 16 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 21 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a > b then 1 else 0)])
 @[proves Project.RustU64.Spec.GtSpec]
 theorem gt_correct : GtSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func16Def) (rs := [.i32 (if a > b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func21Def) (rs := [.i32 (if a > b then 1 else 0)]) rfl rfl
       (gtBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::ge"]
 def GeSpec : Prop :=
   ∀ (env : HostEnv Unit) (a b : UInt64),
-    TerminatesWith env «module» 15 «module».initialStore [.i64 b, .i64 a]
+    TerminatesWith env «module» 20 «module».initialStore [.i64 b, .i64 a]
       (fun _ rs => rs = [.i32 (if a ≥ b then 1 else 0)])
 @[proves Project.RustU64.Spec.GeSpec]
 theorem ge_correct : GeSpec := by
   intro env a b
-  exact (TerminatesWith.of_returns_wp (f := func15Def) (rs := [.i32 (if a ≥ b then 1 else 0)]) rfl rfl
+  exact (TerminatesWith.of_returns_wp (f := func20Def) (rs := [.i32 (if a ≥ b then 1 else 0)]) rfl rfl
       (geBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
+/-- `core::cmp::Ord::max` (inner, `«module» 0`) specialized to a call site, via
+`max_wp`. The exported `rust_u64::max` wrapper reuses this through `wp_call_tw`. -/
+private theorem max_call {env : HostEnv Unit} (st : Store Unit) (a b : UInt64) (rest : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 1048576))
+    (hhi : 1048576 ≤ st.mem.pages * 65536) :
+    TerminatesWith env «module» 0 st (.i64 b :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if b < a then a else b) :: rest
+        ∧ st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := maxFunc)
+    (rs := [.i64 (if b < a then a else b)]) rfl rfl
+    (max_wp st 1048576 a b [] hsp (by decide) hhi) rfl
+
+@[spec_of "rust-exported" "rust_u64::max"]
+def MaxSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 24 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i64 (if b < a then a else b)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64.Spec.MaxSpec]
+theorem max_correct : MaxSpec := by
+  intro env a b
+  apply TerminatesWith.of_wp_entry_for (f := func24Def) rfl
+  unfold func24Def func24
+  wp_run
+  apply wp_call_tw (max_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
+
+/-- `core::cmp::Ord::min` (inner, `«module» 1`) specialized to a call site. -/
+private theorem min_call {env : HostEnv Unit} (st : Store Unit) (a b : UInt64) (rest : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 1048576))
+    (hhi : 1048576 ≤ st.mem.pages * 65536) :
+    TerminatesWith env «module» 1 st (.i64 b :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if b < a then b else a) :: rest
+        ∧ st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := minFunc)
+    (rs := [.i64 (if b < a then b else a)]) rfl rfl
+    (min_wp st 1048576 a b [] hsp (by decide) hhi) rfl
+
+@[spec_of "rust-exported" "rust_u64::min"]
+def MinSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 25 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i64 (if b < a then b else a)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64.Spec.MinSpec]
+theorem min_correct : MinSpec := by
+  intro env a b
+  apply TerminatesWith.of_wp_entry_for (f := func25Def) rfl
+  unfold func25Def func25
+  wp_run
+  apply wp_call_tw (min_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
+
+/-- `core::cmp::Ord::clamp` (inner, `«module» 2`) specialized to a call site (with
+the panic-`Location` pointer arg) under `lo ≤ hi`. -/
+private theorem clamp_call {env : HostEnv Unit} (st : Store Unit) (a lo hi : UInt64) (loc : UInt32)
+    (rest : List Value) (hsp : st.globals.globals[0]? = some (.i32 1048576))
+    (hhi : 1048576 ≤ st.mem.pages * 65536) (hlohi : lo ≤ hi) :
+    TerminatesWith env «module» 2 st (.i32 loc :: .i64 hi :: .i64 lo :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if a < lo then lo else if a > hi then hi else a) :: rest
+        ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := clampFunc 76)
+    (rs := [.i64 (if a < lo then lo else if a > hi then hi else a)]) rfl rfl
+    (clamp_wp st 76 1048576 a lo hi loc [] hsp (by decide) hhi hlohi) rfl
+
+@[spec_of "rust-exported" "rust_u64::clamp"]
+def ClampSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a lo hi : UInt64), lo ≤ hi →
+    TerminatesWith env «module» 10 «module».initialStore [.i64 hi, .i64 lo, .i64 a]
+      (fun _ rs => rs = [.i64 (if a < lo then lo else if a > hi then hi else a)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64.Spec.ClampSpec]
+theorem clamp_correct : ClampSpec := by
+  intro env a lo hi hlohi
+  apply TerminatesWith.of_wp_entry_for (f := func10Def) rfl
+  unfold func10Def func10
+  wp_run
+  apply wp_call_tw (clamp_call «module».initialStore a lo hi 1048632 [] rfl (by decide) hlohi)
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
 
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -149,4 +149,15 @@ theorem shr_correct : ShrSpec := by
   exact (TerminatesWith.of_returns_wp (f := func13Def) (rs := [.i64 (a >>> (b.toUInt64 % 64))])
       rfl rfl (shrBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::eq"]
+def EqSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 14 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a = b then 1 else 0)])
+@[proves Project.RustU64.Spec.EqSpec]
+theorem eq_correct : EqSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func14Def) (rs := [.i32 (if a = b then 1 else 0)]) rfl rfl
+      (eqBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -160,4 +160,15 @@ theorem eq_correct : EqSpec := by
   exact (TerminatesWith.of_returns_wp (f := func14Def) (rs := [.i32 (if a = b then 1 else 0)]) rfl rfl
       (eqBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::ne"]
+def NeSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 19 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a ≠ b then 1 else 0)])
+@[proves Project.RustU64.Spec.NeSpec]
+theorem ne_correct : NeSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func19Def) (rs := [.i32 (if a ≠ b then 1 else 0)]) rfl rfl
+      (neBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -204,4 +204,15 @@ theorem gt_correct : GtSpec := by
   exact (TerminatesWith.of_returns_wp (f := func16Def) (rs := [.i32 (if a > b then 1 else 0)]) rfl rfl
       (gtBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::ge"]
+def GeSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 15 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a ≥ b then 1 else 0)])
+@[proves Project.RustU64.Spec.GeSpec]
+theorem ge_correct : GeSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func15Def) (rs := [.i32 (if a ≥ b then 1 else 0)]) rfl rfl
+      (geBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -182,4 +182,15 @@ theorem lt_correct : LtSpec := by
   exact (TerminatesWith.of_returns_wp (f := func18Def) (rs := [.i32 (if a < b then 1 else 0)]) rfl rfl
       (ltBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
 
+@[spec_of "rust-exported" "rust_u64::le"]
+def LeSpec : Prop :=
+  ∀ (env : HostEnv Unit) (a b : UInt64),
+    TerminatesWith env «module» 17 «module».initialStore [.i64 b, .i64 a]
+      (fun _ rs => rs = [.i32 (if a ≤ b then 1 else 0)])
+@[proves Project.RustU64.Spec.LeSpec]
+theorem le_correct : LeSpec := by
+  intro env a b
+  exact (TerminatesWith.of_returns_wp (f := func17Def) (rs := [.i32 (if a ≤ b then 1 else 0)]) rfl rfl
+      (leBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64Tests/Program.lean
+++ b/programs/lean/Project/RustU64Tests/Program.lean
@@ -84,7 +84,7 @@ def func4 : Wasm.Program :=
     .ret
   ],
   .const (1048608 : UInt32),
-  .call 74,
+  .call 86,
   .unreachable
 ]
 
@@ -109,15 +109,210 @@ def func5 : Wasm.Program :=
     .ret
   ],
   .const (1048624 : UInt32),
-  .call 74,
+  .call 86,
   .unreachable
 ]
 
 def func5Def : Wasm.Function :=
   { params := [.i64, .i64, .i64], locals := [], body := func5, results := [.i64] }
 
-/-- export: mul_chain -/
+/-- export: eq_two -/
 def func6 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .eqI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .eqI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func6Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func6, results := [.i64] }
+
+/-- export: eq_u64 -/
+def func7 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .eqI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func7Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func7, results := [.i64] }
+
+/-- export: ge_two -/
+def func8 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .geUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .geUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func8Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func8, results := [.i64] }
+
+/-- export: ge_u64 -/
+def func9 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .geUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func9Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func9, results := [.i64] }
+
+/-- export: gt_two -/
+def func10 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func10Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func10, results := [.i64] }
+
+/-- export: gt_u64 -/
+def func11 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func11Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func11, results := [.i64] }
+
+/-- export: le_two -/
+def func12 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func12Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func12, results := [.i64] }
+
+/-- export: le_u64 -/
+def func13 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func13Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func13, results := [.i64] }
+
+/-- export: lt_two -/
+def func14 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func14Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func14, results := [.i64] }
+
+/-- export: lt_u64 -/
+def func15 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func15Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func15, results := [.i64] }
+
+/-- export: mul_chain -/
+def func16 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -127,11 +322,11 @@ def func6 : Wasm.Program :=
   .ret
 ]
 
-def func6Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func6, results := [.i64] }
+def func16Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func16, results := [.i64] }
 
 /-- export: mul_then_add -/
-def func7 : Wasm.Program :=
+def func17 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -141,11 +336,50 @@ def func7 : Wasm.Program :=
   .ret
 ]
 
-def func7Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func7, results := [.i64] }
+def func17Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func17, results := [.i64] }
+
+/-- export: ne_two -/
+def func18 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .neI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .neI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func18Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func18, results := [.i64] }
+
+/-- export: ne_u64 -/
+def func19 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .neI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func19Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func19, results := [.i64] }
 
 /-- export: not_then_xor -/
-def func8 : Wasm.Program :=
+def func20 : Wasm.Program :=
   [
   .localGet 0,
   .constI64 (18446744073709551615 : UInt64),
@@ -155,11 +389,11 @@ def func8 : Wasm.Program :=
   .ret
 ]
 
-def func8Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func8, results := [.i64] }
+def func20Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func20, results := [.i64] }
 
 /-- export: not_twice -/
-def func9 : Wasm.Program :=
+def func21 : Wasm.Program :=
   [
   .localGet 0,
   .constI64 (18446744073709551615 : UInt64),
@@ -169,11 +403,11 @@ def func9 : Wasm.Program :=
   .ret
 ]
 
-def func9Def : Wasm.Function :=
-  { params := [.i64], locals := [], body := func9, results := [.i64] }
+def func21Def : Wasm.Function :=
+  { params := [.i64], locals := [], body := func21, results := [.i64] }
 
 /-- export: or_chain -/
-def func10 : Wasm.Program :=
+def func22 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -183,11 +417,11 @@ def func10 : Wasm.Program :=
   .ret
 ]
 
-def func10Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func10, results := [.i64] }
+def func22Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func22, results := [.i64] }
 
 /-- export: or_then_xor -/
-def func11 : Wasm.Program :=
+def func23 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -197,11 +431,11 @@ def func11 : Wasm.Program :=
   .ret
 ]
 
-def func11Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func11, results := [.i64] }
+def func23Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func23, results := [.i64] }
 
 /-- export: rem_then_add -/
-def func12 : Wasm.Program :=
+def func24 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -218,15 +452,15 @@ def func12 : Wasm.Program :=
     .ret
   ],
   .const (1048640 : UInt32),
-  .call 75,
+  .call 87,
   .unreachable
 ]
 
-def func12Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func12, results := [.i64] }
+def func24Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func24, results := [.i64] }
 
 /-- export: rem_then_mul -/
-def func13 : Wasm.Program :=
+def func25 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -243,15 +477,15 @@ def func13 : Wasm.Program :=
     .ret
   ],
   .const (1048656 : UInt32),
-  .call 75,
+  .call 87,
   .unreachable
 ]
 
-def func13Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func13, results := [.i64] }
+def func25Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func25, results := [.i64] }
 
 /-- export: shl_then_add -/
-def func14 : Wasm.Program :=
+def func26 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -264,11 +498,11 @@ def func14 : Wasm.Program :=
   .ret
 ]
 
-def func14Def : Wasm.Function :=
-  { params := [.i64, .i32, .i64], locals := [], body := func14, results := [.i64] }
+def func26Def : Wasm.Function :=
+  { params := [.i64, .i32, .i64], locals := [], body := func26, results := [.i64] }
 
 /-- export: shl_twice -/
-def func15 : Wasm.Program :=
+def func27 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -284,11 +518,11 @@ def func15 : Wasm.Program :=
   .ret
 ]
 
-def func15Def : Wasm.Function :=
-  { params := [.i64, .i32, .i32], locals := [], body := func15, results := [.i64] }
+def func27Def : Wasm.Function :=
+  { params := [.i64, .i32, .i32], locals := [], body := func27, results := [.i64] }
 
 /-- export: shr_then_sub -/
-def func16 : Wasm.Program :=
+def func28 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -301,11 +535,11 @@ def func16 : Wasm.Program :=
   .ret
 ]
 
-def func16Def : Wasm.Function :=
-  { params := [.i64, .i32, .i64], locals := [], body := func16, results := [.i64] }
+def func28Def : Wasm.Function :=
+  { params := [.i64, .i32, .i64], locals := [], body := func28, results := [.i64] }
 
 /-- export: shr_twice -/
-def func17 : Wasm.Program :=
+def func29 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -321,11 +555,11 @@ def func17 : Wasm.Program :=
   .ret
 ]
 
-def func17Def : Wasm.Function :=
-  { params := [.i64, .i32, .i32], locals := [], body := func17, results := [.i64] }
+def func29Def : Wasm.Function :=
+  { params := [.i64, .i32, .i32], locals := [], body := func29, results := [.i64] }
 
 /-- export: sub_chain -/
-def func18 : Wasm.Program :=
+def func30 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -335,11 +569,11 @@ def func18 : Wasm.Program :=
   .ret
 ]
 
-def func18Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func18, results := [.i64] }
+def func30Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func30, results := [.i64] }
 
 /-- export: sub_then_add -/
-def func19 : Wasm.Program :=
+def func31 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -349,11 +583,11 @@ def func19 : Wasm.Program :=
   .ret
 ]
 
-def func19Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func19, results := [.i64] }
+def func31Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func31, results := [.i64] }
 
 /-- export: xor_chain -/
-def func20 : Wasm.Program :=
+def func32 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -363,11 +597,11 @@ def func20 : Wasm.Program :=
   .ret
 ]
 
-def func20Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func20, results := [.i64] }
+def func32Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func32, results := [.i64] }
 
 /-- export: xor_then_and -/
-def func21 : Wasm.Program :=
+def func33 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -377,63 +611,63 @@ def func21 : Wasm.Program :=
   .ret
 ]
 
-def func21Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func21, results := [.i64] }
+def func33Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func33, results := [.i64] }
 
-def func22 : Wasm.Program :=
+def func34 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 39,
+  .call 51,
   .ret
 ]
 
-def func22Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func22, results := [.i32] }
+def func34Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func34, results := [.i32] }
 
-def func23 : Wasm.Program :=
+def func35 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
-  .call 43,
+  .call 55,
   .ret
 ]
 
-def func23Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func23, results := [] }
+def func35Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func35, results := [] }
 
-def func24 : Wasm.Program :=
+def func36 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
   .localGet 3,
-  .call 45,
+  .call 57,
   .ret
 ]
 
-def func24Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [], body := func24, results := [.i32] }
+def func36Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [], body := func36, results := [.i32] }
 
-def func25 : Wasm.Program :=
+def func37 : Wasm.Program :=
   [
   .ret
 ]
 
-def func25Def : Wasm.Function :=
-  { params := [], locals := [], body := func25, results := [] }
+def func37Def : Wasm.Function :=
+  { params := [], locals := [], body := func37, results := [] }
 
-def func26 : Wasm.Program :=
+def func38 : Wasm.Program :=
   [
-  .call 42,
+  .call 54,
   .unreachable
 ]
 
-def func26Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func26, results := [.i32] }
+def func38Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func38, results := [.i32] }
 
-def func27 : Wasm.Program :=
+def func39 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -452,7 +686,7 @@ def func27 : Wasm.Program :=
     .br_if 0,
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .call 67,
+    .call 79,
     .unreachable
   ],
   .localGet 5,
@@ -492,7 +726,7 @@ def func27 : Wasm.Program :=
   .localGet 2,
   .localGet 3,
   .localGet 4,
-  .call 35,
+  .call 47,
   .block 0 0 [
     .localGet 5,
     .load32 (4 : UInt32),
@@ -503,7 +737,7 @@ def func27 : Wasm.Program :=
     .load32 (8 : UInt32),
     .localGet 5,
     .load32 (12 : UInt32),
-    .call 67,
+    .call 79,
     .unreachable
   ],
   .localGet 5,
@@ -521,10 +755,10 @@ def func27 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func27Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func27, results := [] }
+def func39Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func39, results := [] }
 
-def func28 : Wasm.Program :=
+def func40 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -536,14 +770,14 @@ def func28 : Wasm.Program :=
     .localGet 1,
     .localGet 0,
     .const (1 : UInt32),
-    .call 23
+    .call 35
   ]
 ]
 
-def func28Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func28, results := [] }
+def func40Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func40, results := [] }
 
-def func29 : Wasm.Program :=
+def func41 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -556,14 +790,14 @@ def func29 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 23
+    .call 35
   ]
 ]
 
-def func29Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func29, results := [] }
+def func41Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func41, results := [] }
 
-def func30 : Wasm.Program :=
+def func42 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -577,24 +811,24 @@ def func30 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 23
+    .call 35
   ]
 ]
 
-def func30Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func30, results := [] }
+def func42Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func42, results := [] }
 
-def func31 : Wasm.Program :=
+def func43 : Wasm.Program :=
   [
   .localGet 0,
-  .call 32,
+  .call 44,
   .unreachable
 ]
 
-def func31Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func31, results := [] }
+def func43Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func43, results := [] }
 
-def func32 : Wasm.Program :=
+def func44 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -611,20 +845,20 @@ def func32 : Wasm.Program :=
   .unreachable
 ]
 
-def func32Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func32, results := [] }
+def func44Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func44, results := [] }
 
-def func33 : Wasm.Program :=
+def func45 : Wasm.Program :=
   [
   .localGet 0,
-  .call 34,
+  .call 46,
   .unreachable
 ]
 
-def func33Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func33, results := [] }
+def func45Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func45, results := [] }
 
-def func34 : Wasm.Program :=
+def func46 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -666,7 +900,7 @@ def func34 : Wasm.Program :=
     .load8U (8 : UInt32),
     .localGet 0,
     .load8U (9 : UInt32),
-    .call 36,
+    .call 48,
     .unreachable
   ],
   .localGet 1,
@@ -686,14 +920,14 @@ def func34 : Wasm.Program :=
   .load8U (8 : UInt32),
   .localGet 0,
   .load8U (9 : UInt32),
-  .call 36,
+  .call 48,
   .unreachable
 ]
 
-def func34Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32], body := func34, results := [] }
+def func46Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32], body := func46, results := [] }
 
-def func35 : Wasm.Program :=
+def func47 : Wasm.Program :=
   [
   .const (1 : UInt32),
   .localSet 6,
@@ -744,7 +978,7 @@ def func35 : Wasm.Program :=
             .mul,
             .localGet 4,
             .localGet 3,
-            .call 24,
+            .call 36,
             .localSet 7,
             .br 1
           ],
@@ -755,10 +989,10 @@ def func35 : Wasm.Program :=
             .localSet 7,
             .br 2
           ],
-          .call 25,
+          .call 37,
           .localGet 3,
           .localGet 4,
-          .call 22,
+          .call 34,
           .localSet 7
         ],
         .localGet 7,
@@ -787,10 +1021,10 @@ def func35 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func35Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func35, results := [] }
+def func47Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func47, results := [] }
 
-def func36 : Wasm.Program :=
+def func48 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -804,7 +1038,7 @@ def func36 : Wasm.Program :=
         .block 0 0 [
           .block 0 0 [
             .const (1 : UInt32),
-            .call 52,
+            .call 64,
             .const (255 : UInt32),
             .and,
             .brTable [4, 1, 0] 1
@@ -865,7 +1099,7 @@ def func36 : Wasm.Program :=
       ],
       .const (2147483648 : UInt32),
       .localGet 5,
-      .call 28
+      .call 40
     ],
     .const (0 : UInt32),
     .const (0 : UInt32),
@@ -881,38 +1115,38 @@ def func36 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 38,
+    .call 50,
     .unreachable
   ],
   .unreachable
 ]
 
-def func36Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func36, results := [] }
+def func48Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func48, results := [] }
 
-def func37 : Wasm.Program :=
+def func49 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .const (1 : UInt32),
   .store8 (1049668 : UInt32)
 ]
 
-def func37Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func37, results := [] }
+def func49Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func49, results := [] }
 
-def func38 : Wasm.Program :=
+def func50 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 26,
+  .call 38,
   .drop,
   .unreachable
 ]
 
-def func38Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func38, results := [] }
+def func50Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func50, results := [] }
 
-def func39 : Wasm.Program :=
+def func51 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -921,17 +1155,17 @@ def func39 : Wasm.Program :=
     .br_if 0,
     .localGet 1,
     .localGet 0,
-    .call 40,
+    .call 52,
     .ret
   ],
   .localGet 0,
-  .call 41
+  .call 53
 ]
 
-def func39Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func39, results := [.i32] }
+def func51Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func51, results := [.i32] }
 
-def func40 : Wasm.Program :=
+def func52 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -965,7 +1199,7 @@ def func40 : Wasm.Program :=
     .add,
     .const (12 : UInt32),
     .add,
-    .call 41,
+    .call 53,
     .localSet 1,
     .localGet 1,
     .eqz,
@@ -1074,7 +1308,7 @@ def func40 : Wasm.Program :=
         .store32 (4 : UInt32),
         .localGet 2,
         .localGet 1,
-        .call 47,
+        .call 59,
         .br 1
       ],
       .localGet 2,
@@ -1142,7 +1376,7 @@ def func40 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 1,
       .localGet 3,
-      .call 47
+      .call 59
     ],
     .localGet 0,
     .const (8 : UInt32),
@@ -1152,10 +1386,10 @@ def func40 : Wasm.Program :=
   .localGet 2
 ]
 
-def func40Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func40, results := [.i32] }
+def func52Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func52, results := [.i32] }
 
-def func41 : Wasm.Program :=
+def func53 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -2252,7 +2486,7 @@ def func41 : Wasm.Program :=
             .br_if 0,
             .localGet 0,
             .localGet 2,
-            .call 51,
+            .call 63,
             .br 2
           ],
           .block 0 0 [
@@ -2370,7 +2604,7 @@ def func41 : Wasm.Program :=
                   .add,
                   .const (4294901760 : UInt32),
                   .and,
-                  .call 66,
+                  .call 78,
                   .block 0 0 [
                     .localGet 1,
                     .load32 (4 : UInt32),
@@ -2937,7 +3171,7 @@ def func41 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 0,
-                      .call 51,
+                      .call 63,
                       .br 8
                     ],
                     .block 0 0 [
@@ -3062,7 +3296,7 @@ def func41 : Wasm.Program :=
                     .and,
                     .localSet 6,
                     .localGet 6,
-                    .call 46,
+                    .call 58,
                     .localGet 6,
                     .localGet 3,
                     .add,
@@ -3097,7 +3331,7 @@ def func41 : Wasm.Program :=
                     .br_if 0,
                     .localGet 0,
                     .localGet 3,
-                    .call 51,
+                    .call 63,
                     .br 6
                   ],
                   .block 0 0 [
@@ -3405,18 +3639,18 @@ def func41 : Wasm.Program :=
   .localGet 0
 ]
 
-def func41Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func41, results := [.i32] }
+def func53Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func53, results := [.i32] }
 
-def func42 : Wasm.Program :=
+def func54 : Wasm.Program :=
   [
   .unreachable
 ]
 
-def func42Def : Wasm.Function :=
-  { params := [], locals := [], body := func42, results := [] }
+def func54Def : Wasm.Function :=
+  { params := [], locals := [], body := func54, results := [] }
 
-def func43 : Wasm.Program :=
+def func55 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3454,26 +3688,26 @@ def func43 : Wasm.Program :=
         .br_if 2
       ],
       .localGet 0,
-      .call 44,
+      .call 56,
       .ret
     ],
     .const (1048827 : UInt32),
     .const (46 : UInt32),
     .const (1048876 : UInt32),
-    .call 70,
+    .call 82,
     .unreachable
   ],
   .const (1048892 : UInt32),
   .const (46 : UInt32),
   .const (1048940 : UInt32),
-  .call 70,
+  .call 82,
   .unreachable
 ]
 
-def func43Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func43, results := [] }
+def func55Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func55, results := [] }
 
-def func44 : Wasm.Program :=
+def func56 : Wasm.Program :=
   [
   .localGet 0,
   .const (4294967288 : UInt32),
@@ -3548,7 +3782,7 @@ def func44 : Wasm.Program :=
       ],
       .localGet 1,
       .localGet 2,
-      .call 46
+      .call 58
     ],
     .block 0 0 [
       .block 0 0 [
@@ -3581,7 +3815,7 @@ def func44 : Wasm.Program :=
                     .and,
                     .localSet 2,
                     .localGet 2,
-                    .call 46,
+                    .call 58,
                     .localGet 1,
                     .localGet 2,
                     .localGet 0,
@@ -3628,7 +3862,7 @@ def func44 : Wasm.Program :=
                 .br_if 4,
                 .localGet 1,
                 .localGet 0,
-                .call 51,
+                .call 63,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
                 .load32 (1049664 : UInt32),
@@ -3874,10 +4108,10 @@ def func44 : Wasm.Program :=
   ]
 ]
 
-def func44Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func44, results := [] }
+def func56Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func56, results := [] }
 
-def func45 : Wasm.Program :=
+def func57 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3932,7 +4166,7 @@ def func45 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 3,
-                      .call 40,
+                      .call 52,
                       .localSet 2,
                       .localGet 2,
                       .br_if 1,
@@ -4025,7 +4259,7 @@ def func45 : Wasm.Program :=
                           .br_if 9,
                           .localGet 7,
                           .localGet 9,
-                          .call 46,
+                          .call 58,
                           .block 0 0 [
                             .localGet 5,
                             .localGet 1,
@@ -4066,7 +4300,7 @@ def func45 : Wasm.Program :=
                             .store32 (4 : UInt32),
                             .localGet 1,
                             .localGet 7,
-                            .call 47,
+                            .call 59,
                             .br 9
                           ],
                           .localGet 4,
@@ -4209,7 +4443,7 @@ def func45 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .localGet 1,
                       .localGet 6,
-                      .call 47,
+                      .call 59,
                       .br 6
                     ],
                     .const (0 : UInt32),
@@ -4269,25 +4503,25 @@ def func45 : Wasm.Program :=
                   .const (1048892 : UInt32),
                   .const (46 : UInt32),
                   .const (1048940 : UInt32),
-                  .call 70,
+                  .call 82,
                   .unreachable
                 ],
                 .const (1048827 : UInt32),
                 .const (46 : UInt32),
                 .const (1048876 : UInt32),
-                .call 70,
+                .call 82,
                 .unreachable
               ],
               .const (1048892 : UInt32),
               .const (46 : UInt32),
               .const (1048940 : UInt32),
-              .call 70,
+              .call 82,
               .unreachable
             ],
             .const (1048827 : UInt32),
             .const (46 : UInt32),
             .const (1048876 : UInt32),
-            .call 70,
+            .call 82,
             .unreachable
           ],
           .localGet 4,
@@ -4326,7 +4560,7 @@ def func45 : Wasm.Program :=
         .ret
       ],
       .localGet 3,
-      .call 41,
+      .call 53,
       .localSet 1,
       .localGet 1,
       .eqz,
@@ -4365,15 +4599,15 @@ def func45 : Wasm.Program :=
       .localSet 2
     ],
     .localGet 0,
-    .call 44
+    .call 56
   ],
   .localGet 2
 ]
 
-def func45Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func45, results := [.i32] }
+def func57Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func57, results := [.i32] }
 
-def func46 : Wasm.Program :=
+def func58 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (12 : UInt32),
@@ -4581,10 +4815,10 @@ def func46 : Wasm.Program :=
   .store32 (1049628 : UInt32)
 ]
 
-def func46Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func46, results := [] }
+def func58Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func58, results := [] }
 
-def func47 : Wasm.Program :=
+def func59 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4649,7 +4883,7 @@ def func47 : Wasm.Program :=
       ],
       .localGet 0,
       .localGet 3,
-      .call 46
+      .call 58
     ],
     .block 0 0 [
       .block 0 0 [
@@ -4678,7 +4912,7 @@ def func47 : Wasm.Program :=
             .and,
             .localSet 3,
             .localGet 3,
-            .call 46,
+            .call 58,
             .localGet 0,
             .localGet 3,
             .localGet 1,
@@ -4726,7 +4960,7 @@ def func47 : Wasm.Program :=
           .br_if 0,
           .localGet 0,
           .localGet 1,
-          .call 51,
+          .call 63,
           .ret
         ],
         .block 0 0 [
@@ -4841,10 +5075,10 @@ def func47 : Wasm.Program :=
   ]
 ]
 
-def func47Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func47, results := [] }
+def func59Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func59, results := [] }
 
-def func48 : Wasm.Program :=
+def func60 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4864,25 +5098,25 @@ def func48 : Wasm.Program :=
   .localGet 1,
   .const (4 : UInt32),
   .add,
-  .call 33,
+  .call 45,
   .unreachable
 ]
 
-def func48Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i64], body := func48, results := [] }
+def func60Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i64], body := func60, results := [] }
 
-def func49 : Wasm.Program :=
+def func61 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 50,
+  .call 62,
   .unreachable
 ]
 
-def func49Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func49, results := [] }
+def func61Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func61, results := [] }
 
-def func50 : Wasm.Program :=
+def func62 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -4899,14 +5133,14 @@ def func50 : Wasm.Program :=
   .localGet 2,
   .const (8 : UInt32),
   .add,
-  .call 31,
+  .call 43,
   .unreachable
 ]
 
-def func50Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32], body := func50, results := [] }
+def func62Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32], body := func62, results := [] }
 
-def func51 : Wasm.Program :=
+def func63 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -5080,10 +5314,10 @@ def func51 : Wasm.Program :=
   .store32 (8 : UInt32)
 ]
 
-def func51Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func51, results := [] }
+def func63Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func63, results := [] }
 
-def func52 : Wasm.Program :=
+def func64 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 1,
@@ -5120,10 +5354,10 @@ def func52 : Wasm.Program :=
   .localGet 1
 ]
 
-def func52Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32], body := func52, results := [.i32] }
+def func64Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32], body := func64, results := [.i32] }
 
-def func53 : Wasm.Program :=
+def func65 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
@@ -5135,10 +5369,10 @@ def func53 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func53Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func53, results := [] }
+def func65Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func65, results := [] }
 
-def func54 : Wasm.Program :=
+def func66 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
@@ -5150,10 +5384,10 @@ def func54 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func54Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func54, results := [] }
+def func66Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func66, results := [] }
 
-def func55 : Wasm.Program :=
+def func67 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5166,7 +5400,7 @@ def func55 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 0,
     .load32 (8 : UInt32),
-    .call 73,
+    .call 85,
     .ret
   ],
   .localGet 1,
@@ -5181,13 +5415,13 @@ def func55 : Wasm.Program :=
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 72
+  .call 84
 ]
 
-def func55Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func55, results := [.i32] }
+def func67Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func67, results := [.i32] }
 
-def func56 : Wasm.Program :=
+def func68 : Wasm.Program :=
   [
   .localGet 0,
   .const (1048956 : UInt32),
@@ -5197,10 +5431,10 @@ def func56 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func56Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func56, results := [] }
+def func68Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func68, results := [] }
 
-def func57 : Wasm.Program :=
+def func69 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5208,10 +5442,10 @@ def func57 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func57Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func57, results := [] }
+def func69Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func69, results := [] }
 
-def func58 : Wasm.Program :=
+def func70 : Wasm.Program :=
   [
   .localGet 1,
   .load32 (4 : UInt32),
@@ -5219,17 +5453,17 @@ def func58 : Wasm.Program :=
   .localGet 1,
   .load32 (0 : UInt32),
   .localSet 3,
-  .call 25,
+  .call 37,
   .block 0 0 [
     .const (8 : UInt32),
     .const (4 : UInt32),
-    .call 22,
+    .call 34,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (8 : UInt32),
-    .call 68,
+    .call 80,
     .unreachable
   ],
   .localGet 1,
@@ -5246,23 +5480,23 @@ def func58 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func58Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func58, results := [] }
+def func70Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func70, results := [] }
 
-def func59 : Wasm.Program :=
+def func71 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 73
+  .call 85
 ]
 
-def func59Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func59, results := [.i32] }
+def func71Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func71, results := [.i32] }
 
-def func60 : Wasm.Program :=
+def func72 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (8 : UInt32),
@@ -5309,7 +5543,7 @@ def func60 : Wasm.Program :=
     .localGet 3,
     .const (1 : UInt32),
     .const (1 : UInt32),
-    .call 27,
+    .call 39,
     .localGet 0,
     .load32 (8 : UInt32),
     .localSet 4
@@ -5412,10 +5646,10 @@ def func60 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func60Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func60, results := [.i32] }
+def func72Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func72, results := [.i32] }
 
-def func61 : Wasm.Program :=
+def func73 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5435,7 +5669,7 @@ def func61 : Wasm.Program :=
         .localGet 2,
         .const (1 : UInt32),
         .const (1 : UInt32),
-        .call 27,
+        .call 39,
         .localGet 0,
         .load32 (8 : UInt32),
         .localSet 3,
@@ -5464,10 +5698,10 @@ def func61 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func61Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func61, results := [.i32] }
+def func73Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func73, results := [.i32] }
 
-def func62 : Wasm.Program :=
+def func74 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5501,7 +5735,7 @@ def func62 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 72,
+    .call 84,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5534,10 +5768,10 @@ def func62 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func62Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func62, results := [] }
+def func74Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func74, results := [] }
 
-def func63 : Wasm.Program :=
+def func75 : Wasm.Program :=
   [
   .globalGet 0,
   .const (48 : UInt32),
@@ -5571,7 +5805,7 @@ def func63 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 72,
+    .call 84,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5610,17 +5844,17 @@ def func63 : Wasm.Program :=
   .localGet 2,
   .localGet 4,
   .store64 (8 : UInt32),
-  .call 25,
+  .call 37,
   .block 0 0 [
     .const (12 : UInt32),
     .const (4 : UInt32),
-    .call 22,
+    .call 34,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (12 : UInt32),
-    .call 68,
+    .call 80,
     .unreachable
   ],
   .localGet 1,
@@ -5643,32 +5877,32 @@ def func63 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func63Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func63, results := [] }
+def func75Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func75, results := [] }
 
-def func64 : Wasm.Program :=
+def func76 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
   .store32 (0 : UInt32)
 ]
 
-def func64Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func64, results := [] }
+def func76Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func76, results := [] }
 
-def func65 : Wasm.Program :=
+def func77 : Wasm.Program :=
   [
   .localGet 0,
   .const (1048672 : UInt32),
   .localGet 1,
   .localGet 2,
-  .call 72
+  .call 84
 ]
 
-def func65Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func65, results := [.i32] }
+def func77Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func77, results := [.i32] }
 
-def func66 : Wasm.Program :=
+def func78 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5726,10 +5960,10 @@ def func66 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func66Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func66, results := [] }
+def func78Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func78, results := [] }
 
-def func67 : Wasm.Program :=
+def func79 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5737,40 +5971,40 @@ def func67 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 68,
+    .call 80,
     .unreachable
   ],
-  .call 69,
+  .call 81,
   .unreachable
 ]
 
-def func67Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func67, results := [] }
+def func79Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func79, results := [] }
 
-def func68 : Wasm.Program :=
+def func80 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 49,
+  .call 61,
   .unreachable
 ]
 
-def func68Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func68, results := [] }
+def func80Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func80, results := [] }
 
-def func69 : Wasm.Program :=
+def func81 : Wasm.Program :=
   [
   .const (1049069 : UInt32),
   .const (35 : UInt32),
   .const (1049088 : UInt32),
-  .call 71,
+  .call 83,
   .unreachable
 ]
 
-def func69Def : Wasm.Function :=
-  { params := [], locals := [], body := func69, results := [] }
+def func81Def : Wasm.Function :=
+  { params := [], locals := [], body := func81, results := [] }
 
-def func70 : Wasm.Program :=
+def func82 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5779,14 +6013,14 @@ def func70 : Wasm.Program :=
   .const (1 : UInt32),
   .or,
   .localGet 2,
-  .call 71,
+  .call 83,
   .unreachable
 ]
 
-def func70Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func70, results := [] }
+def func82Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func82, results := [] }
 
-def func71 : Wasm.Program :=
+def func83 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5814,14 +6048,14 @@ def func71 : Wasm.Program :=
   .localGet 3,
   .const (20 : UInt32),
   .add,
-  .call 48,
+  .call 60,
   .unreachable
 ]
 
-def func71Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func71, results := [] }
+def func83Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func83, results := [] }
 
-def func72 : Wasm.Program :=
+def func84 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -6129,10 +6363,10 @@ def func72 : Wasm.Program :=
   .localGet 5
 ]
 
-def func72Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func72, results := [.i32] }
+def func84Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func84, results := [.i32] }
 
-def func73 : Wasm.Program :=
+def func85 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -6144,32 +6378,32 @@ def func73 : Wasm.Program :=
   .callIndirect 1 0
 ]
 
-def func73Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func73, results := [.i32] }
+def func85Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func85, results := [.i32] }
 
-def func74 : Wasm.Program :=
+def func86 : Wasm.Program :=
   [
   .const (1049104 : UInt32),
   .const (51 : UInt32),
   .localGet 0,
-  .call 71,
+  .call 83,
   .unreachable
 ]
 
-def func74Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func74, results := [] }
+def func86Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func86, results := [] }
 
-def func75 : Wasm.Program :=
+def func87 : Wasm.Program :=
   [
   .const (1049129 : UInt32),
   .const (115 : UInt32),
   .localGet 0,
-  .call 71,
+  .call 83,
   .unreachable
 ]
 
-def func75Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func75, results := [] }
+def func87Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func87, results := [] }
 
 def «module» : Wasm.Module :=
 {
@@ -6250,7 +6484,19 @@ def «module» : Wasm.Module :=
     func72Def,
     func73Def,
     func74Def,
-    func75Def
+    func75Def,
+    func76Def,
+    func77Def,
+    func78Def,
+    func79Def,
+    func80Def,
+    func81Def,
+    func82Def,
+    func83Def,
+    func84Def,
+    func85Def,
+    func86Def,
+    func87Def
   ],
   exports := [
     { name := "add_chain", funcIdx := 0 },
@@ -6259,22 +6505,34 @@ def «module» : Wasm.Module :=
     { name := "and_then_or", funcIdx := 3 },
     { name := "div_then_add", funcIdx := 4 },
     { name := "div_then_mul", funcIdx := 5 },
-    { name := "mul_chain", funcIdx := 6 },
-    { name := "mul_then_add", funcIdx := 7 },
-    { name := "not_then_xor", funcIdx := 8 },
-    { name := "not_twice", funcIdx := 9 },
-    { name := "or_chain", funcIdx := 10 },
-    { name := "or_then_xor", funcIdx := 11 },
-    { name := "rem_then_add", funcIdx := 12 },
-    { name := "rem_then_mul", funcIdx := 13 },
-    { name := "shl_then_add", funcIdx := 14 },
-    { name := "shl_twice", funcIdx := 15 },
-    { name := "shr_then_sub", funcIdx := 16 },
-    { name := "shr_twice", funcIdx := 17 },
-    { name := "sub_chain", funcIdx := 18 },
-    { name := "sub_then_add", funcIdx := 19 },
-    { name := "xor_chain", funcIdx := 20 },
-    { name := "xor_then_and", funcIdx := 21 }
+    { name := "eq_two", funcIdx := 6 },
+    { name := "eq_u64", funcIdx := 7 },
+    { name := "ge_two", funcIdx := 8 },
+    { name := "ge_u64", funcIdx := 9 },
+    { name := "gt_two", funcIdx := 10 },
+    { name := "gt_u64", funcIdx := 11 },
+    { name := "le_two", funcIdx := 12 },
+    { name := "le_u64", funcIdx := 13 },
+    { name := "lt_two", funcIdx := 14 },
+    { name := "lt_u64", funcIdx := 15 },
+    { name := "mul_chain", funcIdx := 16 },
+    { name := "mul_then_add", funcIdx := 17 },
+    { name := "ne_two", funcIdx := 18 },
+    { name := "ne_u64", funcIdx := 19 },
+    { name := "not_then_xor", funcIdx := 20 },
+    { name := "not_twice", funcIdx := 21 },
+    { name := "or_chain", funcIdx := 22 },
+    { name := "or_then_xor", funcIdx := 23 },
+    { name := "rem_then_add", funcIdx := 24 },
+    { name := "rem_then_mul", funcIdx := 25 },
+    { name := "shl_then_add", funcIdx := 26 },
+    { name := "shl_twice", funcIdx := 27 },
+    { name := "shr_then_sub", funcIdx := 28 },
+    { name := "shr_twice", funcIdx := 29 },
+    { name := "sub_chain", funcIdx := 30 },
+    { name := "sub_then_add", funcIdx := 31 },
+    { name := "xor_chain", funcIdx := 32 },
+    { name := "xor_then_and", funcIdx := 33 }
   ],
   memory := some { pagesMin := (17 : UInt32), pagesMax := none, data := [
     { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (95 : UInt8), (116 : UInt8), (101 : UInt8), (115 : UInt8), (116 : UInt8), (115 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (48 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (51 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (52 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (208 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (208 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (156 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
@@ -6289,6 +6547,7 @@ def «module» : Wasm.Module :=
     { params := [.i32, .i32, .i32], results := [.i32] },
     { params := [.i32, .i32], results := [.i32] },
     { params := [.i64, .i64, .i64], results := [.i64] },
+    { params := [.i64, .i64, .i64, .i64], results := [.i64] },
     { params := [.i64, .i64], results := [.i64] },
     { params := [.i64], results := [.i64] },
     { params := [.i64, .i32, .i64], results := [.i64] },
@@ -6305,7 +6564,7 @@ def «module» : Wasm.Module :=
     { min := 17, max := some 17, elemType := .funcref }
   ],
   elements := [
-    { tableIdx := some 0, offset := some 1, funcs := [some 37, some 29, some 61, some 60, some 65, some 59, some 58, some 56, some 57, some 30, some 55, some 63, some 62, some 64, some 54, some 53] }
+    { tableIdx := some 0, offset := some 1, funcs := [some 49, some 41, some 73, some 72, some 77, some 71, some 70, some 68, some 69, some 42, some 67, some 75, some 74, some 76, some 66, some 65] }
   ]
 }
 

--- a/programs/lean/Project/RustU64Tests/Program.lean
+++ b/programs/lean/Project/RustU64Tests/Program.lean
@@ -10,8 +10,274 @@ namespace Project.RustU64Tests
 
 open Wasm
 
-/-- export: add_chain -/
 def func0 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .localGet 0,
+  .store64 (8 : UInt32),
+  .localGet 2,
+  .localGet 1,
+  .store64 (16 : UInt32),
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .ltUI64,
+      .const (1 : UInt32),
+      .and,
+      .br_if 0,
+      .localGet 2,
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .store64 (24 : UInt32),
+      .br 1
+    ],
+    .localGet 2,
+    .localGet 2,
+    .load64 (8 : UInt32),
+    .store64 (24 : UInt32)
+  ],
+  .localGet 2,
+  .load64 (24 : UInt32),
+  .ret
+]
+
+def func0Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [.i32], body := func0, results := [.i64] }
+
+def func1 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .localGet 0,
+  .store64 (8 : UInt32),
+  .localGet 2,
+  .localGet 1,
+  .store64 (16 : UInt32),
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 2,
+      .load64 (16 : UInt32),
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .ltUI64,
+      .const (1 : UInt32),
+      .and,
+      .br_if 0,
+      .localGet 2,
+      .localGet 2,
+      .load64 (8 : UInt32),
+      .store64 (24 : UInt32),
+      .br 1
+    ],
+    .localGet 2,
+    .localGet 2,
+    .load64 (16 : UInt32),
+    .store64 (24 : UInt32)
+  ],
+  .localGet 2,
+  .load64 (24 : UInt32),
+  .ret
+]
+
+def func1Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [.i32], body := func1, results := [.i64] }
+
+def func2 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (80 : UInt32),
+  .sub,
+  .localSet 4,
+  .localGet 4,
+  .globalSet 0,
+  .block 0 0 [
+    .localGet 1,
+    .localGet 2,
+    .leUI64,
+    .const (1 : UInt32),
+    .and,
+    .br_if 0,
+    .localGet 4,
+    .localGet 1,
+    .store64 (16 : UInt32),
+    .localGet 4,
+    .localGet 2,
+    .store64 (24 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .const (16 : UInt32),
+    .add,
+    .store32 (64 : UInt32),
+    .localGet 4,
+    .const (1 : UInt32),
+    .store32 (68 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .load64 (64 : UInt32),
+    .store64 (48 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .const (24 : UInt32),
+    .add,
+    .store32 (72 : UInt32),
+    .localGet 4,
+    .const (1 : UInt32),
+    .store32 (76 : UInt32),
+    .localGet 4,
+    .localGet 4,
+    .load64 (72 : UInt32),
+    .store64 (56 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .localGet 4,
+    .load64 (48 : UInt32),
+    .store64 (0 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .const (8 : UInt32),
+    .add,
+    .localGet 4,
+    .load64 (56 : UInt32),
+    .store64 (0 : UInt32),
+    .const (1048576 : UInt32),
+    .localGet 4,
+    .const (32 : UInt32),
+    .add,
+    .localGet 3,
+    .call 93,
+    .unreachable
+  ],
+  .block 0 0 [
+    .block 0 0 [
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 0,
+            .localGet 1,
+            .ltUI64,
+            .const (1 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 0,
+            .localGet 2,
+            .gtUI64,
+            .const (1 : UInt32),
+            .and,
+            .br_if 2,
+            .br 1
+          ],
+          .localGet 4,
+          .localGet 1,
+          .store64 (8 : UInt32),
+          .br 3
+        ],
+        .localGet 4,
+        .localGet 0,
+        .store64 (8 : UInt32),
+        .br 1
+      ],
+      .localGet 4,
+      .localGet 2,
+      .store64 (8 : UInt32)
+    ]
+  ],
+  .localGet 4,
+  .load64 (8 : UInt32),
+  .localSet 5,
+  .localGet 4,
+  .const (80 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 5,
+  .ret
+]
+
+def func2Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i32], locals := [.i32, .i64], body := func2, results := [.i64] }
+
+def func3 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .block 0 0 [
+    .block 0 0 [
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 1,
+            .load32 (8 : UInt32),
+            .const (33554432 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 1,
+            .load32 (8 : UInt32),
+            .const (67108864 : UInt32),
+            .and,
+            .eqz,
+            .br_if 1,
+            .br 2
+          ],
+          .localGet 2,
+          .localGet 0,
+          .localGet 1,
+          .call 102,
+          .const (1 : UInt32),
+          .and,
+          .store8 (15 : UInt32),
+          .br 3
+        ],
+        .localGet 2,
+        .localGet 0,
+        .localGet 1,
+        .call 94,
+        .const (1 : UInt32),
+        .and,
+        .store8 (15 : UInt32),
+        .br 1
+      ],
+      .localGet 2,
+      .localGet 0,
+      .localGet 1,
+      .call 103,
+      .const (1 : UInt32),
+      .and,
+      .store8 (15 : UInt32)
+    ]
+  ],
+  .localGet 2,
+  .load8U (15 : UInt32),
+  .const (1 : UInt32),
+  .and,
+  .localSet 3,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 3,
+  .ret
+]
+
+def func3Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func3, results := [.i32] }
+
+/-- export: add_chain -/
+def func4 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -21,11 +287,11 @@ def func0 : Wasm.Program :=
   .ret
 ]
 
-def func0Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func0, results := [.i64] }
+def func4Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func4, results := [.i64] }
 
 /-- export: add_then_mul -/
-def func1 : Wasm.Program :=
+def func5 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -35,11 +301,11 @@ def func1 : Wasm.Program :=
   .ret
 ]
 
-def func1Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func1, results := [.i64] }
+def func5Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func5, results := [.i64] }
 
 /-- export: and_chain -/
-def func2 : Wasm.Program :=
+def func6 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -49,11 +315,11 @@ def func2 : Wasm.Program :=
   .ret
 ]
 
-def func2Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func2, results := [.i64] }
+def func6Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func6, results := [.i64] }
 
 /-- export: and_then_or -/
-def func3 : Wasm.Program :=
+def func7 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -63,11 +329,43 @@ def func3 : Wasm.Program :=
   .ret
 ]
 
-def func3Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func3, results := [.i64] }
+def func7Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func7, results := [.i64] }
+
+/-- export: clamp_add -/
+def func8 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .localGet 2,
+  .const (1048636 : UInt32),
+  .call 2,
+  .localGet 3,
+  .addI64,
+  .ret
+]
+
+def func8Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func8, results := [.i64] }
+
+/-- export: clamp_mul -/
+def func9 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .localGet 2,
+  .const (1048652 : UInt32),
+  .call 2,
+  .localGet 3,
+  .mulI64,
+  .ret
+]
+
+def func9Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func9, results := [.i64] }
 
 /-- export: div_then_add -/
-def func4 : Wasm.Program :=
+def func10 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -83,16 +381,16 @@ def func4 : Wasm.Program :=
     .addI64,
     .ret
   ],
-  .const (1048608 : UInt32),
-  .call 86,
+  .const (1048668 : UInt32),
+  .call 100,
   .unreachable
 ]
 
-def func4Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func4, results := [.i64] }
+def func10Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func10, results := [.i64] }
 
 /-- export: div_then_mul -/
-def func5 : Wasm.Program :=
+def func11 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -108,143 +406,26 @@ def func5 : Wasm.Program :=
     .mulI64,
     .ret
   ],
-  .const (1048624 : UInt32),
-  .call 86,
+  .const (1048684 : UInt32),
+  .call 100,
   .unreachable
-]
-
-def func5Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func5, results := [.i64] }
-
-/-- export: eq_two -/
-def func6 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .eqI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .localGet 3,
-  .eqI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .addI64,
-  .ret
-]
-
-def func6Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64, .i64], locals := [], body := func6, results := [.i64] }
-
-/-- export: eq_u64 -/
-def func7 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .eqI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .addI64,
-  .ret
-]
-
-def func7Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func7, results := [.i64] }
-
-/-- export: ge_two -/
-def func8 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .geUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .localGet 3,
-  .geUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .addI64,
-  .ret
-]
-
-def func8Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64, .i64], locals := [], body := func8, results := [.i64] }
-
-/-- export: ge_u64 -/
-def func9 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .geUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .addI64,
-  .ret
-]
-
-def func9Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func9, results := [.i64] }
-
-/-- export: gt_two -/
-def func10 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .gtUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .localGet 3,
-  .gtUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .addI64,
-  .ret
-]
-
-def func10Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64, .i64], locals := [], body := func10, results := [.i64] }
-
-/-- export: gt_u64 -/
-def func11 : Wasm.Program :=
-  [
-  .localGet 0,
-  .localGet 1,
-  .gtUI64,
-  .const (1 : UInt32),
-  .and,
-  .extendUI32,
-  .localGet 2,
-  .addI64,
-  .ret
 ]
 
 def func11Def : Wasm.Function :=
   { params := [.i64, .i64, .i64], locals := [], body := func11, results := [.i64] }
 
-/-- export: le_two -/
+/-- export: eq_two -/
 def func12 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .leUI64,
+  .eqI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
   .localGet 2,
   .localGet 3,
-  .leUI64,
+  .eqI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
@@ -255,12 +436,12 @@ def func12 : Wasm.Program :=
 def func12Def : Wasm.Function :=
   { params := [.i64, .i64, .i64, .i64], locals := [], body := func12, results := [.i64] }
 
-/-- export: le_u64 -/
+/-- export: eq_u64 -/
 def func13 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .leUI64,
+  .eqI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
@@ -272,18 +453,18 @@ def func13 : Wasm.Program :=
 def func13Def : Wasm.Function :=
   { params := [.i64, .i64, .i64], locals := [], body := func13, results := [.i64] }
 
-/-- export: lt_two -/
+/-- export: ge_two -/
 def func14 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .ltUI64,
+  .geUI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
   .localGet 2,
   .localGet 3,
-  .ltUI64,
+  .geUI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
@@ -294,12 +475,12 @@ def func14 : Wasm.Program :=
 def func14Def : Wasm.Function :=
   { params := [.i64, .i64, .i64, .i64], locals := [], body := func14, results := [.i64] }
 
-/-- export: lt_u64 -/
+/-- export: ge_u64 -/
 def func15 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .ltUI64,
+  .geUI64,
   .const (1 : UInt32),
   .and,
   .extendUI32,
@@ -311,8 +492,181 @@ def func15 : Wasm.Program :=
 def func15Def : Wasm.Function :=
   { params := [.i64, .i64, .i64], locals := [], body := func15, results := [.i64] }
 
-/-- export: mul_chain -/
+/-- export: gt_two -/
 def func16 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func16Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func16, results := [.i64] }
+
+/-- export: gt_u64 -/
+def func17 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .gtUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func17Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func17, results := [.i64] }
+
+/-- export: le_two -/
+def func18 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func18Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func18, results := [.i64] }
+
+/-- export: le_u64 -/
+def func19 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .leUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func19Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func19, results := [.i64] }
+
+/-- export: lt_two -/
+def func20 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .localGet 3,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .addI64,
+  .ret
+]
+
+def func20Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func20, results := [.i64] }
+
+/-- export: lt_u64 -/
+def func21 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .ltUI64,
+  .const (1 : UInt32),
+  .and,
+  .extendUI32,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func21Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func21, results := [.i64] }
+
+/-- export: max_add -/
+def func22 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 0,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func22Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func22, results := [.i64] }
+
+/-- export: max_chain -/
+def func23 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 0,
+  .localGet 2,
+  .call 0,
+  .ret
+]
+
+def func23Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func23, results := [.i64] }
+
+/-- export: min_add -/
+def func24 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 1,
+  .localGet 2,
+  .addI64,
+  .ret
+]
+
+def func24Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func24, results := [.i64] }
+
+/-- export: min_chain -/
+def func25 : Wasm.Program :=
+  [
+  .localGet 0,
+  .localGet 1,
+  .call 1,
+  .localGet 2,
+  .call 1,
+  .ret
+]
+
+def func25Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func25, results := [.i64] }
+
+/-- export: mul_chain -/
+def func26 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -322,11 +676,11 @@ def func16 : Wasm.Program :=
   .ret
 ]
 
-def func16Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func16, results := [.i64] }
+def func26Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func26, results := [.i64] }
 
 /-- export: mul_then_add -/
-def func17 : Wasm.Program :=
+def func27 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -336,11 +690,11 @@ def func17 : Wasm.Program :=
   .ret
 ]
 
-def func17Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func17, results := [.i64] }
+def func27Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func27, results := [.i64] }
 
 /-- export: ne_two -/
-def func18 : Wasm.Program :=
+def func28 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -358,11 +712,11 @@ def func18 : Wasm.Program :=
   .ret
 ]
 
-def func18Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64, .i64], locals := [], body := func18, results := [.i64] }
+def func28Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64, .i64], locals := [], body := func28, results := [.i64] }
 
 /-- export: ne_u64 -/
-def func19 : Wasm.Program :=
+def func29 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -375,11 +729,11 @@ def func19 : Wasm.Program :=
   .ret
 ]
 
-def func19Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func19, results := [.i64] }
+def func29Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func29, results := [.i64] }
 
 /-- export: not_then_xor -/
-def func20 : Wasm.Program :=
+def func30 : Wasm.Program :=
   [
   .localGet 0,
   .constI64 (18446744073709551615 : UInt64),
@@ -389,11 +743,11 @@ def func20 : Wasm.Program :=
   .ret
 ]
 
-def func20Def : Wasm.Function :=
-  { params := [.i64, .i64], locals := [], body := func20, results := [.i64] }
+def func30Def : Wasm.Function :=
+  { params := [.i64, .i64], locals := [], body := func30, results := [.i64] }
 
 /-- export: not_twice -/
-def func21 : Wasm.Program :=
+def func31 : Wasm.Program :=
   [
   .localGet 0,
   .constI64 (18446744073709551615 : UInt64),
@@ -403,11 +757,11 @@ def func21 : Wasm.Program :=
   .ret
 ]
 
-def func21Def : Wasm.Function :=
-  { params := [.i64], locals := [], body := func21, results := [.i64] }
+def func31Def : Wasm.Function :=
+  { params := [.i64], locals := [], body := func31, results := [.i64] }
 
 /-- export: or_chain -/
-def func22 : Wasm.Program :=
+def func32 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -417,11 +771,11 @@ def func22 : Wasm.Program :=
   .ret
 ]
 
-def func22Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func22, results := [.i64] }
+def func32Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func32, results := [.i64] }
 
 /-- export: or_then_xor -/
-def func23 : Wasm.Program :=
+def func33 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -431,11 +785,11 @@ def func23 : Wasm.Program :=
   .ret
 ]
 
-def func23Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func23, results := [.i64] }
+def func33Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func33, results := [.i64] }
 
 /-- export: rem_then_add -/
-def func24 : Wasm.Program :=
+def func34 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -451,16 +805,16 @@ def func24 : Wasm.Program :=
     .addI64,
     .ret
   ],
-  .const (1048640 : UInt32),
-  .call 87,
+  .const (1048700 : UInt32),
+  .call 101,
   .unreachable
 ]
 
-def func24Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func24, results := [.i64] }
+def func34Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func34, results := [.i64] }
 
 /-- export: rem_then_mul -/
-def func25 : Wasm.Program :=
+def func35 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -476,16 +830,16 @@ def func25 : Wasm.Program :=
     .mulI64,
     .ret
   ],
-  .const (1048656 : UInt32),
-  .call 87,
+  .const (1048716 : UInt32),
+  .call 101,
   .unreachable
 ]
 
-def func25Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func25, results := [.i64] }
+def func35Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func35, results := [.i64] }
 
 /-- export: shl_then_add -/
-def func26 : Wasm.Program :=
+def func36 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -498,11 +852,11 @@ def func26 : Wasm.Program :=
   .ret
 ]
 
-def func26Def : Wasm.Function :=
-  { params := [.i64, .i32, .i64], locals := [], body := func26, results := [.i64] }
+def func36Def : Wasm.Function :=
+  { params := [.i64, .i32, .i64], locals := [], body := func36, results := [.i64] }
 
 /-- export: shl_twice -/
-def func27 : Wasm.Program :=
+def func37 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -518,11 +872,11 @@ def func27 : Wasm.Program :=
   .ret
 ]
 
-def func27Def : Wasm.Function :=
-  { params := [.i64, .i32, .i32], locals := [], body := func27, results := [.i64] }
+def func37Def : Wasm.Function :=
+  { params := [.i64, .i32, .i32], locals := [], body := func37, results := [.i64] }
 
 /-- export: shr_then_sub -/
-def func28 : Wasm.Program :=
+def func38 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -535,11 +889,11 @@ def func28 : Wasm.Program :=
   .ret
 ]
 
-def func28Def : Wasm.Function :=
-  { params := [.i64, .i32, .i64], locals := [], body := func28, results := [.i64] }
+def func38Def : Wasm.Function :=
+  { params := [.i64, .i32, .i64], locals := [], body := func38, results := [.i64] }
 
 /-- export: shr_twice -/
-def func29 : Wasm.Program :=
+def func39 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -555,11 +909,11 @@ def func29 : Wasm.Program :=
   .ret
 ]
 
-def func29Def : Wasm.Function :=
-  { params := [.i64, .i32, .i32], locals := [], body := func29, results := [.i64] }
+def func39Def : Wasm.Function :=
+  { params := [.i64, .i32, .i32], locals := [], body := func39, results := [.i64] }
 
 /-- export: sub_chain -/
-def func30 : Wasm.Program :=
+def func40 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -569,11 +923,11 @@ def func30 : Wasm.Program :=
   .ret
 ]
 
-def func30Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func30, results := [.i64] }
+def func40Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func40, results := [.i64] }
 
 /-- export: sub_then_add -/
-def func31 : Wasm.Program :=
+def func41 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -583,11 +937,11 @@ def func31 : Wasm.Program :=
   .ret
 ]
 
-def func31Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func31, results := [.i64] }
+def func41Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func41, results := [.i64] }
 
 /-- export: xor_chain -/
-def func32 : Wasm.Program :=
+def func42 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -597,11 +951,11 @@ def func32 : Wasm.Program :=
   .ret
 ]
 
-def func32Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func32, results := [.i64] }
+def func42Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func42, results := [.i64] }
 
 /-- export: xor_then_and -/
-def func33 : Wasm.Program :=
+def func43 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -611,63 +965,63 @@ def func33 : Wasm.Program :=
   .ret
 ]
 
-def func33Def : Wasm.Function :=
-  { params := [.i64, .i64, .i64], locals := [], body := func33, results := [.i64] }
+def func43Def : Wasm.Function :=
+  { params := [.i64, .i64, .i64], locals := [], body := func43, results := [.i64] }
 
-def func34 : Wasm.Program :=
+def func44 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 51,
+  .call 61,
   .ret
 ]
 
-def func34Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func34, results := [.i32] }
+def func44Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func44, results := [.i32] }
 
-def func35 : Wasm.Program :=
+def func45 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
-  .call 55,
+  .call 65,
   .ret
 ]
 
-def func35Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func35, results := [] }
+def func45Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func45, results := [] }
 
-def func36 : Wasm.Program :=
+def func46 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
   .localGet 2,
   .localGet 3,
-  .call 57,
+  .call 67,
   .ret
 ]
 
-def func36Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [], body := func36, results := [.i32] }
+def func46Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [], body := func46, results := [.i32] }
 
-def func37 : Wasm.Program :=
+def func47 : Wasm.Program :=
   [
   .ret
 ]
 
-def func37Def : Wasm.Function :=
-  { params := [], locals := [], body := func37, results := [] }
+def func47Def : Wasm.Function :=
+  { params := [], locals := [], body := func47, results := [] }
 
-def func38 : Wasm.Program :=
+def func48 : Wasm.Program :=
   [
-  .call 54,
+  .call 64,
   .unreachable
 ]
 
-def func38Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func38, results := [.i32] }
+def func48Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func48, results := [.i32] }
 
-def func39 : Wasm.Program :=
+def func49 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -686,7 +1040,7 @@ def func39 : Wasm.Program :=
     .br_if 0,
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .call 79,
+    .call 89,
     .unreachable
   ],
   .localGet 5,
@@ -726,7 +1080,7 @@ def func39 : Wasm.Program :=
   .localGet 2,
   .localGet 3,
   .localGet 4,
-  .call 47,
+  .call 57,
   .block 0 0 [
     .localGet 5,
     .load32 (4 : UInt32),
@@ -737,7 +1091,7 @@ def func39 : Wasm.Program :=
     .load32 (8 : UInt32),
     .localGet 5,
     .load32 (12 : UInt32),
-    .call 79,
+    .call 89,
     .unreachable
   ],
   .localGet 5,
@@ -755,10 +1109,10 @@ def func39 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func39Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func39, results := [] }
+def func49Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32], body := func49, results := [] }
 
-def func40 : Wasm.Program :=
+def func50 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -770,14 +1124,14 @@ def func40 : Wasm.Program :=
     .localGet 1,
     .localGet 0,
     .const (1 : UInt32),
-    .call 35
+    .call 45
   ]
 ]
 
-def func40Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func40, results := [] }
+def func50Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func50, results := [] }
 
-def func41 : Wasm.Program :=
+def func51 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -790,14 +1144,14 @@ def func41 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 35
+    .call 45
   ]
 ]
 
-def func41Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func41, results := [] }
+def func51Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func51, results := [] }
 
-def func42 : Wasm.Program :=
+def func52 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -811,54 +1165,54 @@ def func42 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 1,
     .const (1 : UInt32),
-    .call 35
+    .call 45
   ]
 ]
 
-def func42Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32], body := func42, results := [] }
+def func52Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32], body := func52, results := [] }
 
-def func43 : Wasm.Program :=
+def func53 : Wasm.Program :=
   [
   .localGet 0,
-  .call 44,
+  .call 54,
   .unreachable
 ]
 
-def func43Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func43, results := [] }
+def func53Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func53, results := [] }
 
-def func44 : Wasm.Program :=
+def func54 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049196 : UInt32),
+  .load32 (1049488 : UInt32),
   .localSet 0,
   .localGet 0,
-  .const (1 : UInt32),
+  .const (2 : UInt32),
   .localGet 0,
   .select,
   .callIndirect 0 0,
   .unreachable
 ]
 
-def func44Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func44, results := [] }
+def func54Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func54, results := [] }
 
-def func45 : Wasm.Program :=
+def func55 : Wasm.Program :=
   [
   .localGet 0,
-  .call 46,
+  .call 56,
   .unreachable
 ]
 
-def func45Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func45, results := [] }
+def func55Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func55, results := [] }
 
-def func46 : Wasm.Program :=
+def func56 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -890,7 +1244,7 @@ def func46 : Wasm.Program :=
     .localGet 2,
     .store32 (0 : UInt32),
     .localGet 1,
-    .const (1048696 : UInt32),
+    .const (1048756 : UInt32),
     .localGet 0,
     .load32 (4 : UInt32),
     .localGet 0,
@@ -900,7 +1254,7 @@ def func46 : Wasm.Program :=
     .load8U (8 : UInt32),
     .localGet 0,
     .load8U (9 : UInt32),
-    .call 48,
+    .call 58,
     .unreachable
   ],
   .localGet 1,
@@ -910,7 +1264,7 @@ def func46 : Wasm.Program :=
   .localGet 0,
   .store32 (12 : UInt32),
   .localGet 1,
-  .const (1048724 : UInt32),
+  .const (1048784 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
   .localGet 0,
@@ -920,14 +1274,14 @@ def func46 : Wasm.Program :=
   .load8U (8 : UInt32),
   .localGet 0,
   .load8U (9 : UInt32),
-  .call 48,
+  .call 58,
   .unreachable
 ]
 
-def func46Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32], body := func46, results := [] }
+def func56Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32], body := func56, results := [] }
 
-def func47 : Wasm.Program :=
+def func57 : Wasm.Program :=
   [
   .const (1 : UInt32),
   .localSet 6,
@@ -978,7 +1332,7 @@ def func47 : Wasm.Program :=
             .mul,
             .localGet 4,
             .localGet 3,
-            .call 36,
+            .call 46,
             .localSet 7,
             .br 1
           ],
@@ -989,10 +1343,10 @@ def func47 : Wasm.Program :=
             .localSet 7,
             .br 2
           ],
-          .call 37,
+          .call 47,
           .localGet 3,
           .localGet 4,
-          .call 34,
+          .call 44,
           .localSet 7
         ],
         .localGet 7,
@@ -1021,10 +1375,10 @@ def func47 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func47Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func47, results := [] }
+def func57Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i64], body := func57, results := [] }
 
-def func48 : Wasm.Program :=
+def func58 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -1038,13 +1392,13 @@ def func48 : Wasm.Program :=
         .block 0 0 [
           .block 0 0 [
             .const (1 : UInt32),
-            .call 64,
+            .call 74,
             .const (255 : UInt32),
             .and,
             .brTable [4, 1, 0] 1
           ],
           .const (0 : UInt32),
-          .load32 (1049200 : UInt32),
+          .load32 (1049492 : UInt32),
           .localSet 6,
           .localGet 6,
           .const (4294967295 : UInt32),
@@ -1054,9 +1408,9 @@ def func48 : Wasm.Program :=
           .localGet 6,
           .const (1 : UInt32),
           .add,
-          .store32 (1049200 : UInt32),
+          .store32 (1049492 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049204 : UInt32),
+          .load32 (1049496 : UInt32),
           .eqz,
           .br_if 1,
           .localGet 5,
@@ -1080,12 +1434,12 @@ def func48 : Wasm.Program :=
           .load64 (8 : UInt32),
           .store64 (16 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049204 : UInt32),
+          .load32 (1049496 : UInt32),
           .localGet 5,
           .const (16 : UInt32),
           .add,
           .const (0 : UInt32),
-          .load32 (1049208 : UInt32),
+          .load32 (1049500 : UInt32),
           .load32 (20 : UInt32),
           .callIndirect 0 0,
           .br 2
@@ -1099,54 +1453,54 @@ def func48 : Wasm.Program :=
       ],
       .const (2147483648 : UInt32),
       .localGet 5,
-      .call 40
+      .call 50
     ],
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049200 : UInt32),
+    .load32 (1049492 : UInt32),
     .const (4294967295 : UInt32),
     .add,
-    .store32 (1049200 : UInt32),
+    .store32 (1049492 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .store8 (1049192 : UInt32),
+    .store8 (1049484 : UInt32),
     .localGet 3,
     .eqz,
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 50,
+    .call 60,
     .unreachable
   ],
   .unreachable
 ]
 
-def func48Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func48, results := [] }
+def func58Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32], body := func58, results := [] }
 
-def func49 : Wasm.Program :=
+def func59 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .const (1 : UInt32),
-  .store8 (1049668 : UInt32)
+  .store8 (1049960 : UInt32)
 ]
 
-def func49Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func49, results := [] }
+def func59Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func59, results := [] }
 
-def func50 : Wasm.Program :=
+def func60 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
-  .call 38,
+  .call 48,
   .drop,
   .unreachable
 ]
 
-def func50Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func50, results := [] }
+def func60Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func60, results := [] }
 
-def func51 : Wasm.Program :=
+def func61 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 1,
@@ -1155,17 +1509,17 @@ def func51 : Wasm.Program :=
     .br_if 0,
     .localGet 1,
     .localGet 0,
-    .call 52,
+    .call 62,
     .ret
   ],
   .localGet 0,
-  .call 53
+  .call 63
 ]
 
-def func51Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func51, results := [.i32] }
+def func61Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func61, results := [.i32] }
 
-def func52 : Wasm.Program :=
+def func62 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -1199,7 +1553,7 @@ def func52 : Wasm.Program :=
     .add,
     .const (12 : UInt32),
     .add,
-    .call 53,
+    .call 63,
     .localSet 1,
     .localGet 1,
     .eqz,
@@ -1308,7 +1662,7 @@ def func52 : Wasm.Program :=
         .store32 (4 : UInt32),
         .localGet 2,
         .localGet 1,
-        .call 59,
+        .call 69,
         .br 1
       ],
       .localGet 2,
@@ -1376,7 +1730,7 @@ def func52 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 1,
       .localGet 3,
-      .call 59
+      .call 69
     ],
     .localGet 0,
     .const (8 : UInt32),
@@ -1386,10 +1740,10 @@ def func52 : Wasm.Program :=
   .localGet 2
 ]
 
-def func52Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func52, results := [.i32] }
+def func62Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32], body := func62, results := [.i32] }
 
-def func53 : Wasm.Program :=
+def func63 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -1423,7 +1777,7 @@ def func53 : Wasm.Program :=
           .and,
           .localSet 3,
           .const (0 : UInt32),
-          .load32 (1049628 : UInt32),
+          .load32 (1049920 : UInt32),
           .localSet 4,
           .localGet 4,
           .eqz,
@@ -1462,7 +1816,7 @@ def func53 : Wasm.Program :=
                 .block 0 0 [
                   .block 0 0 [
                     .const (0 : UInt32),
-                    .load32 (1049624 : UInt32),
+                    .load32 (1049916 : UInt32),
                     .localSet 6,
                     .localGet 6,
                     .const (16 : UInt32),
@@ -1501,12 +1855,12 @@ def func53 : Wasm.Program :=
                     .shl,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049360 : UInt32),
+                    .const (1049652 : UInt32),
                     .add,
                     .localSet 0,
                     .localGet 0,
                     .localGet 3,
-                    .const (1049368 : UInt32),
+                    .const (1049660 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 2,
@@ -1526,13 +1880,13 @@ def func53 : Wasm.Program :=
                   ],
                   .localGet 3,
                   .const (0 : UInt32),
-                  .load32 (1049632 : UInt32),
+                  .load32 (1049924 : UInt32),
                   .leU,
                   .br_if 6,
                   .localGet 0,
                   .br_if 2,
                   .const (0 : UInt32),
-                  .load32 (1049628 : UInt32),
+                  .load32 (1049920 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .eqz,
@@ -1541,7 +1895,7 @@ def func53 : Wasm.Program :=
                   .ctz,
                   .const (2 : UInt32),
                   .shl,
-                  .const (1049216 : UInt32),
+                  .const (1049508 : UInt32),
                   .add,
                   .load32 (0 : UInt32),
                   .localSet 8,
@@ -1658,7 +2012,7 @@ def func53 : Wasm.Program :=
                           .load32 (28 : UInt32),
                           .const (2 : UInt32),
                           .shl,
-                          .const (1049216 : UInt32),
+                          .const (1049508 : UInt32),
                           .add,
                           .localSet 8,
                           .localGet 8,
@@ -1755,7 +2109,7 @@ def func53 : Wasm.Program :=
                 .localGet 7,
                 .rotl,
                 .and,
-                .store32 (1049624 : UInt32)
+                .store32 (1049916 : UInt32)
               ],
               .localGet 2,
               .const (8 : UInt32),
@@ -1800,12 +2154,12 @@ def func53 : Wasm.Program :=
                 .shl,
                 .localSet 2,
                 .localGet 2,
-                .const (1049360 : UInt32),
+                .const (1049652 : UInt32),
                 .add,
                 .localSet 8,
                 .localGet 8,
                 .localGet 2,
-                .const (1049368 : UInt32),
+                .const (1049660 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 0,
@@ -1829,7 +2183,7 @@ def func53 : Wasm.Program :=
               .localGet 9,
               .rotl,
               .and,
-              .store32 (1049624 : UInt32)
+              .store32 (1049916 : UInt32)
             ],
             .localGet 0,
             .localGet 3,
@@ -1856,18 +2210,18 @@ def func53 : Wasm.Program :=
             .store32 (0 : UInt32),
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049632 : UInt32),
+              .load32 (1049924 : UInt32),
               .localSet 2,
               .localGet 2,
               .eqz,
               .br_if 0,
               .const (0 : UInt32),
-              .load32 (1049640 : UInt32),
+              .load32 (1049932 : UInt32),
               .localSet 3,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049624 : UInt32),
+                  .load32 (1049916 : UInt32),
                   .localSet 7,
                   .localGet 7,
                   .const (1 : UInt32),
@@ -1883,11 +2237,11 @@ def func53 : Wasm.Program :=
                   .localGet 7,
                   .localGet 9,
                   .or,
-                  .store32 (1049624 : UInt32),
+                  .store32 (1049916 : UInt32),
                   .localGet 2,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049360 : UInt32),
+                  .const (1049652 : UInt32),
                   .add,
                   .localSet 2,
                   .localGet 2,
@@ -1899,11 +2253,11 @@ def func53 : Wasm.Program :=
                 .and,
                 .localSet 2,
                 .localGet 2,
-                .const (1049360 : UInt32),
+                .const (1049652 : UInt32),
                 .add,
                 .localSet 7,
                 .localGet 2,
-                .const (1049368 : UInt32),
+                .const (1049660 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 2
@@ -1927,21 +2281,21 @@ def func53 : Wasm.Program :=
             .localSet 0,
             .const (0 : UInt32),
             .localGet 6,
-            .store32 (1049640 : UInt32),
+            .store32 (1049932 : UInt32),
             .const (0 : UInt32),
             .localGet 8,
-            .store32 (1049632 : UInt32),
+            .store32 (1049924 : UInt32),
             .br 4
           ],
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049628 : UInt32),
+          .load32 (1049920 : UInt32),
           .const (4294967294 : UInt32),
           .localGet 6,
           .load32 (28 : UInt32),
           .rotl,
           .and,
-          .store32 (1049628 : UInt32)
+          .store32 (1049920 : UInt32)
         ],
         .block 0 0 [
           .block 0 0 [
@@ -1970,18 +2324,18 @@ def func53 : Wasm.Program :=
               .localGet 2,
               .store32 (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049632 : UInt32),
+              .load32 (1049924 : UInt32),
               .localSet 7,
               .localGet 7,
               .eqz,
               .br_if 1,
               .const (0 : UInt32),
-              .load32 (1049640 : UInt32),
+              .load32 (1049932 : UInt32),
               .localSet 0,
               .block 0 0 [
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049624 : UInt32),
+                  .load32 (1049916 : UInt32),
                   .localSet 9,
                   .localGet 9,
                   .const (1 : UInt32),
@@ -1997,11 +2351,11 @@ def func53 : Wasm.Program :=
                   .localGet 9,
                   .localGet 5,
                   .or,
-                  .store32 (1049624 : UInt32),
+                  .store32 (1049916 : UInt32),
                   .localGet 7,
                   .const (4294967288 : UInt32),
                   .and,
-                  .const (1049360 : UInt32),
+                  .const (1049652 : UInt32),
                   .add,
                   .localSet 7,
                   .localGet 7,
@@ -2013,11 +2367,11 @@ def func53 : Wasm.Program :=
                 .and,
                 .localSet 7,
                 .localGet 7,
-                .const (1049360 : UInt32),
+                .const (1049652 : UInt32),
                 .add,
                 .localSet 9,
                 .localGet 7,
-                .const (1049368 : UInt32),
+                .const (1049660 : UInt32),
                 .add,
                 .load32 (0 : UInt32),
                 .localSet 7
@@ -2059,10 +2413,10 @@ def func53 : Wasm.Program :=
           ],
           .const (0 : UInt32),
           .localGet 8,
-          .store32 (1049640 : UInt32),
+          .store32 (1049932 : UInt32),
           .const (0 : UInt32),
           .localGet 2,
-          .store32 (1049632 : UInt32)
+          .store32 (1049924 : UInt32)
         ],
         .localGet 6,
         .const (8 : UInt32),
@@ -2084,7 +2438,7 @@ def func53 : Wasm.Program :=
               .localGet 5,
               .const (2 : UInt32),
               .shl,
-              .const (1049216 : UInt32),
+              .const (1049508 : UInt32),
               .add,
               .load32 (0 : UInt32),
               .localSet 6,
@@ -2204,7 +2558,7 @@ def func53 : Wasm.Program :=
             .ctz,
             .const (2 : UInt32),
             .shl,
-            .const (1049216 : UInt32),
+            .const (1049508 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 0
@@ -2272,7 +2626,7 @@ def func53 : Wasm.Program :=
       .br_if 0,
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049632 : UInt32),
+        .load32 (1049924 : UInt32),
         .localSet 0,
         .localGet 0,
         .localGet 3,
@@ -2379,7 +2733,7 @@ def func53 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049216 : UInt32),
+              .const (1049508 : UInt32),
               .add,
               .localSet 6,
               .localGet 6,
@@ -2446,13 +2800,13 @@ def func53 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049628 : UInt32),
+        .load32 (1049920 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 8,
         .load32 (28 : UInt32),
         .rotl,
         .and,
-        .store32 (1049628 : UInt32)
+        .store32 (1049920 : UInt32)
       ],
       .block 0 0 [
         .block 0 0 [
@@ -2486,13 +2840,13 @@ def func53 : Wasm.Program :=
             .br_if 0,
             .localGet 0,
             .localGet 2,
-            .call 63,
+            .call 73,
             .br 2
           ],
           .block 0 0 [
             .block 0 0 [
               .const (0 : UInt32),
-              .load32 (1049624 : UInt32),
+              .load32 (1049916 : UInt32),
               .localSet 6,
               .localGet 6,
               .const (1 : UInt32),
@@ -2508,11 +2862,11 @@ def func53 : Wasm.Program :=
               .localGet 6,
               .localGet 7,
               .or,
-              .store32 (1049624 : UInt32),
+              .store32 (1049916 : UInt32),
               .localGet 2,
               .const (248 : UInt32),
               .and,
-              .const (1049360 : UInt32),
+              .const (1049652 : UInt32),
               .add,
               .localSet 2,
               .localGet 2,
@@ -2524,11 +2878,11 @@ def func53 : Wasm.Program :=
             .and,
             .localSet 2,
             .localGet 2,
-            .const (1049360 : UInt32),
+            .const (1049652 : UInt32),
             .add,
             .localSet 6,
             .localGet 2,
-            .const (1049368 : UInt32),
+            .const (1049660 : UInt32),
             .add,
             .load32 (0 : UInt32),
             .localSet 2
@@ -2581,7 +2935,7 @@ def func53 : Wasm.Program :=
             .block 0 0 [
               .block 0 0 [
                 .const (0 : UInt32),
-                .load32 (1049632 : UInt32),
+                .load32 (1049924 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
@@ -2589,7 +2943,7 @@ def func53 : Wasm.Program :=
                 .br_if 0,
                 .block 0 0 [
                   .const (0 : UInt32),
-                  .load32 (1049636 : UInt32),
+                  .load32 (1049928 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 3,
@@ -2598,13 +2952,13 @@ def func53 : Wasm.Program :=
                   .localGet 1,
                   .const (4 : UInt32),
                   .add,
-                  .const (1049668 : UInt32),
+                  .const (1049960 : UInt32),
                   .localGet 3,
                   .const (65583 : UInt32),
                   .add,
                   .const (4294901760 : UInt32),
                   .and,
-                  .call 78,
+                  .call 88,
                   .block 0 0 [
                     .localGet 1,
                     .load32 (4 : UInt32),
@@ -2620,7 +2974,7 @@ def func53 : Wasm.Program :=
                   .localSet 5,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049648 : UInt32),
+                  .load32 (1049940 : UInt32),
                   .localGet 1,
                   .load32 (8 : UInt32),
                   .localSet 9,
@@ -2628,28 +2982,28 @@ def func53 : Wasm.Program :=
                   .add,
                   .localSet 0,
                   .localGet 0,
-                  .store32 (1049648 : UInt32),
+                  .store32 (1049940 : UInt32),
                   .const (0 : UInt32),
                   .localGet 0,
                   .const (0 : UInt32),
-                  .load32 (1049652 : UInt32),
+                  .load32 (1049944 : UInt32),
                   .localSet 2,
                   .localGet 2,
                   .localGet 0,
                   .localGet 2,
                   .gtU,
                   .select,
-                  .store32 (1049652 : UInt32),
+                  .store32 (1049944 : UInt32),
                   .block 0 0 [
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049644 : UInt32),
+                        .load32 (1049936 : UInt32),
                         .localSet 2,
                         .localGet 2,
                         .eqz,
                         .br_if 0,
-                        .const (1049344 : UInt32),
+                        .const (1049636 : UInt32),
                         .localSet 0,
                         .loop 0 0 [
                           .localGet 6,
@@ -2675,7 +3029,7 @@ def func53 : Wasm.Program :=
                       .block 0 0 [
                         .block 0 0 [
                           .const (0 : UInt32),
-                          .load32 (1049660 : UInt32),
+                          .load32 (1049952 : UInt32),
                           .localSet 0,
                           .localGet 0,
                           .eqz,
@@ -2687,209 +3041,209 @@ def func53 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049660 : UInt32)
+                        .store32 (1049952 : UInt32)
                       ],
                       .const (0 : UInt32),
                       .const (4095 : UInt32),
-                      .store32 (1049664 : UInt32),
+                      .store32 (1049956 : UInt32),
                       .const (0 : UInt32),
                       .localGet 5,
-                      .store32 (1049356 : UInt32),
+                      .store32 (1049648 : UInt32),
                       .const (0 : UInt32),
                       .localGet 9,
-                      .store32 (1049348 : UInt32),
+                      .store32 (1049640 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
-                      .store32 (1049344 : UInt32),
+                      .store32 (1049636 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049360 : UInt32),
-                      .store32 (1049372 : UInt32),
+                      .const (1049652 : UInt32),
+                      .store32 (1049664 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049368 : UInt32),
-                      .store32 (1049380 : UInt32),
+                      .const (1049660 : UInt32),
+                      .store32 (1049672 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049360 : UInt32),
-                      .store32 (1049368 : UInt32),
+                      .const (1049652 : UInt32),
+                      .store32 (1049660 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049376 : UInt32),
-                      .store32 (1049388 : UInt32),
+                      .const (1049668 : UInt32),
+                      .store32 (1049680 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049368 : UInt32),
-                      .store32 (1049376 : UInt32),
+                      .const (1049660 : UInt32),
+                      .store32 (1049668 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049384 : UInt32),
-                      .store32 (1049396 : UInt32),
+                      .const (1049676 : UInt32),
+                      .store32 (1049688 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049376 : UInt32),
-                      .store32 (1049384 : UInt32),
+                      .const (1049668 : UInt32),
+                      .store32 (1049676 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049392 : UInt32),
-                      .store32 (1049404 : UInt32),
+                      .const (1049684 : UInt32),
+                      .store32 (1049696 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049384 : UInt32),
-                      .store32 (1049392 : UInt32),
+                      .const (1049676 : UInt32),
+                      .store32 (1049684 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049400 : UInt32),
-                      .store32 (1049412 : UInt32),
+                      .const (1049692 : UInt32),
+                      .store32 (1049704 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049392 : UInt32),
-                      .store32 (1049400 : UInt32),
+                      .const (1049684 : UInt32),
+                      .store32 (1049692 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049408 : UInt32),
-                      .store32 (1049420 : UInt32),
+                      .const (1049700 : UInt32),
+                      .store32 (1049712 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049400 : UInt32),
-                      .store32 (1049408 : UInt32),
+                      .const (1049692 : UInt32),
+                      .store32 (1049700 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049416 : UInt32),
-                      .store32 (1049428 : UInt32),
+                      .const (1049708 : UInt32),
+                      .store32 (1049720 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049408 : UInt32),
-                      .store32 (1049416 : UInt32),
+                      .const (1049700 : UInt32),
+                      .store32 (1049708 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049424 : UInt32),
-                      .store32 (1049436 : UInt32),
+                      .const (1049716 : UInt32),
+                      .store32 (1049728 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049416 : UInt32),
-                      .store32 (1049424 : UInt32),
+                      .const (1049708 : UInt32),
+                      .store32 (1049716 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049424 : UInt32),
-                      .store32 (1049432 : UInt32),
+                      .const (1049716 : UInt32),
+                      .store32 (1049724 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049432 : UInt32),
-                      .store32 (1049444 : UInt32),
+                      .const (1049724 : UInt32),
+                      .store32 (1049736 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049432 : UInt32),
-                      .store32 (1049440 : UInt32),
+                      .const (1049724 : UInt32),
+                      .store32 (1049732 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049440 : UInt32),
-                      .store32 (1049452 : UInt32),
+                      .const (1049732 : UInt32),
+                      .store32 (1049744 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049440 : UInt32),
-                      .store32 (1049448 : UInt32),
+                      .const (1049732 : UInt32),
+                      .store32 (1049740 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049448 : UInt32),
-                      .store32 (1049460 : UInt32),
+                      .const (1049740 : UInt32),
+                      .store32 (1049752 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049448 : UInt32),
-                      .store32 (1049456 : UInt32),
+                      .const (1049740 : UInt32),
+                      .store32 (1049748 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049456 : UInt32),
-                      .store32 (1049468 : UInt32),
+                      .const (1049748 : UInt32),
+                      .store32 (1049760 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049456 : UInt32),
-                      .store32 (1049464 : UInt32),
+                      .const (1049748 : UInt32),
+                      .store32 (1049756 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049464 : UInt32),
-                      .store32 (1049476 : UInt32),
+                      .const (1049756 : UInt32),
+                      .store32 (1049768 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049464 : UInt32),
-                      .store32 (1049472 : UInt32),
+                      .const (1049756 : UInt32),
+                      .store32 (1049764 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049472 : UInt32),
-                      .store32 (1049484 : UInt32),
+                      .const (1049764 : UInt32),
+                      .store32 (1049776 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049472 : UInt32),
-                      .store32 (1049480 : UInt32),
+                      .const (1049764 : UInt32),
+                      .store32 (1049772 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049480 : UInt32),
-                      .store32 (1049492 : UInt32),
+                      .const (1049772 : UInt32),
+                      .store32 (1049784 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049480 : UInt32),
-                      .store32 (1049488 : UInt32),
+                      .const (1049772 : UInt32),
+                      .store32 (1049780 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049488 : UInt32),
-                      .store32 (1049500 : UInt32),
+                      .const (1049780 : UInt32),
+                      .store32 (1049792 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049496 : UInt32),
-                      .store32 (1049508 : UInt32),
+                      .const (1049788 : UInt32),
+                      .store32 (1049800 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049488 : UInt32),
-                      .store32 (1049496 : UInt32),
+                      .const (1049780 : UInt32),
+                      .store32 (1049788 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049504 : UInt32),
-                      .store32 (1049516 : UInt32),
+                      .const (1049796 : UInt32),
+                      .store32 (1049808 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049496 : UInt32),
-                      .store32 (1049504 : UInt32),
+                      .const (1049788 : UInt32),
+                      .store32 (1049796 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049512 : UInt32),
-                      .store32 (1049524 : UInt32),
+                      .const (1049804 : UInt32),
+                      .store32 (1049816 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049504 : UInt32),
-                      .store32 (1049512 : UInt32),
+                      .const (1049796 : UInt32),
+                      .store32 (1049804 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049520 : UInt32),
-                      .store32 (1049532 : UInt32),
+                      .const (1049812 : UInt32),
+                      .store32 (1049824 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049512 : UInt32),
-                      .store32 (1049520 : UInt32),
+                      .const (1049804 : UInt32),
+                      .store32 (1049812 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049528 : UInt32),
-                      .store32 (1049540 : UInt32),
+                      .const (1049820 : UInt32),
+                      .store32 (1049832 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049520 : UInt32),
-                      .store32 (1049528 : UInt32),
+                      .const (1049812 : UInt32),
+                      .store32 (1049820 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049536 : UInt32),
-                      .store32 (1049548 : UInt32),
+                      .const (1049828 : UInt32),
+                      .store32 (1049840 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049528 : UInt32),
-                      .store32 (1049536 : UInt32),
+                      .const (1049820 : UInt32),
+                      .store32 (1049828 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049544 : UInt32),
-                      .store32 (1049556 : UInt32),
+                      .const (1049836 : UInt32),
+                      .store32 (1049848 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049536 : UInt32),
-                      .store32 (1049544 : UInt32),
+                      .const (1049828 : UInt32),
+                      .store32 (1049836 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049552 : UInt32),
-                      .store32 (1049564 : UInt32),
+                      .const (1049844 : UInt32),
+                      .store32 (1049856 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049544 : UInt32),
-                      .store32 (1049552 : UInt32),
+                      .const (1049836 : UInt32),
+                      .store32 (1049844 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049560 : UInt32),
-                      .store32 (1049572 : UInt32),
+                      .const (1049852 : UInt32),
+                      .store32 (1049864 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049552 : UInt32),
-                      .store32 (1049560 : UInt32),
+                      .const (1049844 : UInt32),
+                      .store32 (1049852 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049568 : UInt32),
-                      .store32 (1049580 : UInt32),
+                      .const (1049860 : UInt32),
+                      .store32 (1049872 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049560 : UInt32),
-                      .store32 (1049568 : UInt32),
+                      .const (1049852 : UInt32),
+                      .store32 (1049860 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049576 : UInt32),
-                      .store32 (1049588 : UInt32),
+                      .const (1049868 : UInt32),
+                      .store32 (1049880 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049568 : UInt32),
-                      .store32 (1049576 : UInt32),
+                      .const (1049860 : UInt32),
+                      .store32 (1049868 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049584 : UInt32),
-                      .store32 (1049596 : UInt32),
+                      .const (1049876 : UInt32),
+                      .store32 (1049888 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049576 : UInt32),
-                      .store32 (1049584 : UInt32),
+                      .const (1049868 : UInt32),
+                      .store32 (1049876 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049592 : UInt32),
-                      .store32 (1049604 : UInt32),
+                      .const (1049884 : UInt32),
+                      .store32 (1049896 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049584 : UInt32),
-                      .store32 (1049592 : UInt32),
+                      .const (1049876 : UInt32),
+                      .store32 (1049884 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049600 : UInt32),
-                      .store32 (1049612 : UInt32),
+                      .const (1049892 : UInt32),
+                      .store32 (1049904 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049592 : UInt32),
-                      .store32 (1049600 : UInt32),
+                      .const (1049884 : UInt32),
+                      .store32 (1049892 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049608 : UInt32),
-                      .store32 (1049620 : UInt32),
+                      .const (1049900 : UInt32),
+                      .store32 (1049912 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049600 : UInt32),
-                      .store32 (1049608 : UInt32),
+                      .const (1049892 : UInt32),
+                      .store32 (1049900 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
                       .const (15 : UInt32),
@@ -2902,10 +3256,10 @@ def func53 : Wasm.Program :=
                       .add,
                       .localSet 2,
                       .localGet 2,
-                      .store32 (1049644 : UInt32),
+                      .store32 (1049936 : UInt32),
                       .const (0 : UInt32),
-                      .const (1049608 : UInt32),
-                      .store32 (1049616 : UInt32),
+                      .const (1049900 : UInt32),
+                      .store32 (1049908 : UInt32),
                       .const (0 : UInt32),
                       .localGet 6,
                       .localGet 0,
@@ -2920,7 +3274,7 @@ def func53 : Wasm.Program :=
                       .add,
                       .localSet 8,
                       .localGet 8,
-                      .store32 (1049636 : UInt32),
+                      .store32 (1049928 : UInt32),
                       .localGet 2,
                       .localGet 8,
                       .const (1 : UInt32),
@@ -2933,7 +3287,7 @@ def func53 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .const (0 : UInt32),
                       .const (2097152 : UInt32),
-                      .store32 (1049656 : UInt32),
+                      .store32 (1049948 : UInt32),
                       .br 8
                     ],
                     .localGet 2,
@@ -2960,7 +3314,7 @@ def func53 : Wasm.Program :=
                   ],
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .load32 (1049660 : UInt32),
+                  .load32 (1049952 : UInt32),
                   .localSet 0,
                   .localGet 0,
                   .localGet 6,
@@ -2968,12 +3322,12 @@ def func53 : Wasm.Program :=
                   .localGet 6,
                   .ltU,
                   .select,
-                  .store32 (1049660 : UInt32),
+                  .store32 (1049952 : UInt32),
                   .localGet 6,
                   .localGet 9,
                   .add,
                   .localSet 8,
-                  .const (1049344 : UInt32),
+                  .const (1049636 : UInt32),
                   .localSet 0,
                   .block 0 0 [
                     .block 0 0 [
@@ -3008,7 +3362,7 @@ def func53 : Wasm.Program :=
                       .eq,
                       .br_if 1
                     ],
-                    .const (1049344 : UInt32),
+                    .const (1049636 : UInt32),
                     .localSet 0,
                     .block 0 0 [
                       .loop 0 0 [
@@ -3048,7 +3402,7 @@ def func53 : Wasm.Program :=
                     .add,
                     .localSet 7,
                     .localGet 7,
-                    .store32 (1049644 : UInt32),
+                    .store32 (1049936 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
                     .localGet 0,
@@ -3063,7 +3417,7 @@ def func53 : Wasm.Program :=
                     .add,
                     .localSet 4,
                     .localGet 4,
-                    .store32 (1049636 : UInt32),
+                    .store32 (1049928 : UInt32),
                     .localGet 7,
                     .localGet 4,
                     .const (1 : UInt32),
@@ -3076,7 +3430,7 @@ def func53 : Wasm.Program :=
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
                     .const (2097152 : UInt32),
-                    .store32 (1049656 : UInt32),
+                    .store32 (1049948 : UInt32),
                     .localGet 2,
                     .localGet 8,
                     .const (4294967264 : UInt32),
@@ -3098,13 +3452,13 @@ def func53 : Wasm.Program :=
                     .const (27 : UInt32),
                     .store32 (4 : UInt32),
                     .const (0 : UInt32),
-                    .load64 (1049344 : UInt32),
+                    .load64 (1049636 : UInt32),
                     .localSet 10,
                     .localGet 7,
                     .const (16 : UInt32),
                     .add,
                     .const (0 : UInt32),
-                    .load64 (1049352 : UInt32),
+                    .load64 (1049644 : UInt32),
                     .store64 (0 : UInt32),
                     .localGet 7,
                     .const (8 : UInt32),
@@ -3115,16 +3469,16 @@ def func53 : Wasm.Program :=
                     .store64 (0 : UInt32),
                     .const (0 : UInt32),
                     .localGet 5,
-                    .store32 (1049356 : UInt32),
+                    .store32 (1049648 : UInt32),
                     .const (0 : UInt32),
                     .localGet 9,
-                    .store32 (1049348 : UInt32),
+                    .store32 (1049640 : UInt32),
                     .const (0 : UInt32),
                     .localGet 6,
-                    .store32 (1049344 : UInt32),
+                    .store32 (1049636 : UInt32),
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049352 : UInt32),
+                    .store32 (1049644 : UInt32),
                     .localGet 7,
                     .const (28 : UInt32),
                     .add,
@@ -3171,13 +3525,13 @@ def func53 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 0,
-                      .call 63,
+                      .call 73,
                       .br 8
                     ],
                     .block 0 0 [
                       .block 0 0 [
                         .const (0 : UInt32),
-                        .load32 (1049624 : UInt32),
+                        .load32 (1049916 : UInt32),
                         .localSet 8,
                         .localGet 8,
                         .const (1 : UInt32),
@@ -3193,11 +3547,11 @@ def func53 : Wasm.Program :=
                         .localGet 8,
                         .localGet 6,
                         .or,
-                        .store32 (1049624 : UInt32),
+                        .store32 (1049916 : UInt32),
                         .localGet 0,
                         .const (248 : UInt32),
                         .and,
-                        .const (1049360 : UInt32),
+                        .const (1049652 : UInt32),
                         .add,
                         .localSet 0,
                         .localGet 0,
@@ -3209,11 +3563,11 @@ def func53 : Wasm.Program :=
                       .and,
                       .localSet 0,
                       .localGet 0,
-                      .const (1049360 : UInt32),
+                      .const (1049652 : UInt32),
                       .add,
                       .localSet 8,
                       .localGet 0,
-                      .const (1049368 : UInt32),
+                      .const (1049660 : UInt32),
                       .add,
                       .load32 (0 : UInt32),
                       .localSet 0
@@ -3272,12 +3626,12 @@ def func53 : Wasm.Program :=
                   .localSet 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049644 : UInt32),
+                  .load32 (1049936 : UInt32),
                   .eq,
                   .br_if 3,
                   .localGet 2,
                   .const (0 : UInt32),
-                  .load32 (1049640 : UInt32),
+                  .load32 (1049932 : UInt32),
                   .eq,
                   .br_if 4,
                   .block 0 0 [
@@ -3296,7 +3650,7 @@ def func53 : Wasm.Program :=
                     .and,
                     .localSet 6,
                     .localGet 6,
-                    .call 58,
+                    .call 68,
                     .localGet 6,
                     .localGet 3,
                     .add,
@@ -3331,13 +3685,13 @@ def func53 : Wasm.Program :=
                     .br_if 0,
                     .localGet 0,
                     .localGet 3,
-                    .call 63,
+                    .call 73,
                     .br 6
                   ],
                   .block 0 0 [
                     .block 0 0 [
                       .const (0 : UInt32),
-                      .load32 (1049624 : UInt32),
+                      .load32 (1049916 : UInt32),
                       .localSet 2,
                       .localGet 2,
                       .const (1 : UInt32),
@@ -3353,11 +3707,11 @@ def func53 : Wasm.Program :=
                       .localGet 2,
                       .localGet 6,
                       .or,
-                      .store32 (1049624 : UInt32),
+                      .store32 (1049916 : UInt32),
                       .localGet 3,
                       .const (248 : UInt32),
                       .and,
-                      .const (1049360 : UInt32),
+                      .const (1049652 : UInt32),
                       .add,
                       .localSet 3,
                       .localGet 3,
@@ -3369,11 +3723,11 @@ def func53 : Wasm.Program :=
                     .and,
                     .localSet 3,
                     .localGet 3,
-                    .const (1049360 : UInt32),
+                    .const (1049652 : UInt32),
                     .add,
                     .localSet 2,
                     .localGet 3,
-                    .const (1049368 : UInt32),
+                    .const (1049660 : UInt32),
                     .add,
                     .load32 (0 : UInt32),
                     .localSet 3
@@ -3398,17 +3752,17 @@ def func53 : Wasm.Program :=
                 .sub,
                 .localSet 2,
                 .localGet 2,
-                .store32 (1049636 : UInt32),
+                .store32 (1049928 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049644 : UInt32),
+                .load32 (1049936 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .localGet 3,
                 .add,
                 .localSet 8,
                 .localGet 8,
-                .store32 (1049644 : UInt32),
+                .store32 (1049936 : UInt32),
                 .localGet 8,
                 .localGet 2,
                 .const (1 : UInt32),
@@ -3426,7 +3780,7 @@ def func53 : Wasm.Program :=
                 .br 6
               ],
               .const (0 : UInt32),
-              .load32 (1049640 : UInt32),
+              .load32 (1049932 : UInt32),
               .localSet 2,
               .block 0 0 [
                 .block 0 0 [
@@ -3440,10 +3794,10 @@ def func53 : Wasm.Program :=
                   .br_if 0,
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .store32 (1049640 : UInt32),
+                  .store32 (1049932 : UInt32),
                   .const (0 : UInt32),
                   .const (0 : UInt32),
-                  .store32 (1049632 : UInt32),
+                  .store32 (1049924 : UInt32),
                   .localGet 2,
                   .localGet 0,
                   .const (3 : UInt32),
@@ -3463,14 +3817,14 @@ def func53 : Wasm.Program :=
                 ],
                 .const (0 : UInt32),
                 .localGet 8,
-                .store32 (1049632 : UInt32),
+                .store32 (1049924 : UInt32),
                 .const (0 : UInt32),
                 .localGet 2,
                 .localGet 3,
                 .add,
                 .localSet 6,
                 .localGet 6,
-                .store32 (1049640 : UInt32),
+                .store32 (1049932 : UInt32),
                 .localGet 6,
                 .localGet 8,
                 .const (1 : UInt32),
@@ -3500,7 +3854,7 @@ def func53 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049644 : UInt32),
+            .load32 (1049936 : UInt32),
             .localSet 0,
             .localGet 0,
             .const (15 : UInt32),
@@ -3513,13 +3867,13 @@ def func53 : Wasm.Program :=
             .add,
             .localSet 8,
             .localGet 8,
-            .store32 (1049644 : UInt32),
+            .store32 (1049936 : UInt32),
             .const (0 : UInt32),
             .localGet 0,
             .localGet 2,
             .sub,
             .const (0 : UInt32),
-            .load32 (1049636 : UInt32),
+            .load32 (1049928 : UInt32),
             .localGet 9,
             .add,
             .localSet 2,
@@ -3529,7 +3883,7 @@ def func53 : Wasm.Program :=
             .add,
             .localSet 6,
             .localGet 6,
-            .store32 (1049636 : UInt32),
+            .store32 (1049928 : UInt32),
             .localGet 8,
             .localGet 6,
             .const (1 : UInt32),
@@ -3542,20 +3896,20 @@ def func53 : Wasm.Program :=
             .store32 (4 : UInt32),
             .const (0 : UInt32),
             .const (2097152 : UInt32),
-            .store32 (1049656 : UInt32),
+            .store32 (1049948 : UInt32),
             .br 3
           ],
           .const (0 : UInt32),
           .localGet 0,
-          .store32 (1049644 : UInt32),
+          .store32 (1049936 : UInt32),
           .const (0 : UInt32),
           .const (0 : UInt32),
-          .load32 (1049636 : UInt32),
+          .load32 (1049928 : UInt32),
           .localGet 3,
           .add,
           .localSet 3,
           .localGet 3,
-          .store32 (1049636 : UInt32),
+          .store32 (1049928 : UInt32),
           .localGet 0,
           .localGet 3,
           .const (1 : UInt32),
@@ -3565,15 +3919,15 @@ def func53 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049640 : UInt32),
+        .store32 (1049932 : UInt32),
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049632 : UInt32),
+        .load32 (1049924 : UInt32),
         .localGet 3,
         .add,
         .localSet 3,
         .localGet 3,
-        .store32 (1049632 : UInt32),
+        .store32 (1049924 : UInt32),
         .localGet 0,
         .localGet 3,
         .const (1 : UInt32),
@@ -3594,7 +3948,7 @@ def func53 : Wasm.Program :=
     .const (0 : UInt32),
     .localSet 0,
     .const (0 : UInt32),
-    .load32 (1049636 : UInt32),
+    .load32 (1049928 : UInt32),
     .localSet 2,
     .localGet 2,
     .localGet 3,
@@ -3606,17 +3960,17 @@ def func53 : Wasm.Program :=
     .sub,
     .localSet 2,
     .localGet 2,
-    .store32 (1049636 : UInt32),
+    .store32 (1049928 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049644 : UInt32),
+    .load32 (1049936 : UInt32),
     .localSet 0,
     .localGet 0,
     .localGet 3,
     .add,
     .localSet 8,
     .localGet 8,
-    .store32 (1049644 : UInt32),
+    .store32 (1049936 : UInt32),
     .localGet 8,
     .localGet 2,
     .const (1 : UInt32),
@@ -3639,18 +3993,18 @@ def func53 : Wasm.Program :=
   .localGet 0
 ]
 
-def func53Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func53, results := [.i32] }
+def func63Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func63, results := [.i32] }
 
-def func54 : Wasm.Program :=
+def func64 : Wasm.Program :=
   [
   .unreachable
 ]
 
-def func54Def : Wasm.Function :=
-  { params := [], locals := [], body := func54, results := [] }
+def func64Def : Wasm.Function :=
+  { params := [], locals := [], body := func64, results := [] }
 
-def func55 : Wasm.Program :=
+def func65 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -3688,26 +4042,26 @@ def func55 : Wasm.Program :=
         .br_if 2
       ],
       .localGet 0,
-      .call 56,
+      .call 66,
       .ret
     ],
-    .const (1048827 : UInt32),
+    .const (1048887 : UInt32),
     .const (46 : UInt32),
-    .const (1048876 : UInt32),
-    .call 82,
+    .const (1048936 : UInt32),
+    .call 92,
     .unreachable
   ],
-  .const (1048892 : UInt32),
+  .const (1048952 : UInt32),
   .const (46 : UInt32),
-  .const (1048940 : UInt32),
-  .call 82,
+  .const (1049000 : UInt32),
+  .call 92,
   .unreachable
 ]
 
-def func55Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func55, results := [] }
+def func65Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func65, results := [] }
 
-def func56 : Wasm.Program :=
+def func66 : Wasm.Program :=
   [
   .localGet 0,
   .const (4294967288 : UInt32),
@@ -3751,7 +4105,7 @@ def func56 : Wasm.Program :=
         .localSet 1,
         .localGet 1,
         .const (0 : UInt32),
-        .load32 (1049640 : UInt32),
+        .load32 (1049932 : UInt32),
         .ne,
         .br_if 0,
         .localGet 3,
@@ -3763,7 +4117,7 @@ def func56 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 0,
-        .store32 (1049632 : UInt32),
+        .store32 (1049924 : UInt32),
         .localGet 3,
         .localGet 3,
         .load32 (4 : UInt32),
@@ -3782,7 +4136,7 @@ def func56 : Wasm.Program :=
       ],
       .localGet 1,
       .localGet 2,
-      .call 58
+      .call 68
     ],
     .block 0 0 [
       .block 0 0 [
@@ -3801,12 +4155,12 @@ def func56 : Wasm.Program :=
                     .br_if 0,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049644 : UInt32),
+                    .load32 (1049936 : UInt32),
                     .eq,
                     .br_if 2,
                     .localGet 3,
                     .const (0 : UInt32),
-                    .load32 (1049640 : UInt32),
+                    .load32 (1049932 : UInt32),
                     .eq,
                     .br_if 3,
                     .localGet 3,
@@ -3815,7 +4169,7 @@ def func56 : Wasm.Program :=
                     .and,
                     .localSet 2,
                     .localGet 2,
-                    .call 58,
+                    .call 68,
                     .localGet 1,
                     .localGet 2,
                     .localGet 0,
@@ -3832,12 +4186,12 @@ def func56 : Wasm.Program :=
                     .store32 (0 : UInt32),
                     .localGet 1,
                     .const (0 : UInt32),
-                    .load32 (1049640 : UInt32),
+                    .load32 (1049932 : UInt32),
                     .ne,
                     .br_if 1,
                     .const (0 : UInt32),
                     .localGet 0,
-                    .store32 (1049632 : UInt32),
+                    .store32 (1049924 : UInt32),
                     .ret
                   ],
                   .localGet 3,
@@ -3862,19 +4216,19 @@ def func56 : Wasm.Program :=
                 .br_if 4,
                 .localGet 1,
                 .localGet 0,
-                .call 63,
+                .call 73,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .load32 (1049664 : UInt32),
+                .load32 (1049956 : UInt32),
                 .const (4294967295 : UInt32),
                 .add,
                 .localSet 1,
                 .localGet 1,
-                .store32 (1049664 : UInt32),
+                .store32 (1049956 : UInt32),
                 .localGet 1,
                 .br_if 6,
                 .const (0 : UInt32),
-                .load32 (1049352 : UInt32),
+                .load32 (1049644 : UInt32),
                 .localSet 0,
                 .localGet 0,
                 .br_if 2,
@@ -3884,15 +4238,15 @@ def func56 : Wasm.Program :=
               ],
               .const (0 : UInt32),
               .localGet 1,
-              .store32 (1049644 : UInt32),
+              .store32 (1049936 : UInt32),
               .const (0 : UInt32),
               .const (0 : UInt32),
-              .load32 (1049636 : UInt32),
+              .load32 (1049928 : UInt32),
               .localGet 0,
               .add,
               .localSet 0,
               .localGet 0,
-              .store32 (1049636 : UInt32),
+              .store32 (1049928 : UInt32),
               .localGet 1,
               .localGet 0,
               .const (1 : UInt32),
@@ -3901,37 +4255,37 @@ def func56 : Wasm.Program :=
               .block 0 0 [
                 .localGet 1,
                 .const (0 : UInt32),
-                .load32 (1049640 : UInt32),
+                .load32 (1049932 : UInt32),
                 .ne,
                 .br_if 0,
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049632 : UInt32),
+                .store32 (1049924 : UInt32),
                 .const (0 : UInt32),
                 .const (0 : UInt32),
-                .store32 (1049640 : UInt32)
+                .store32 (1049932 : UInt32)
               ],
               .localGet 0,
               .const (0 : UInt32),
-              .load32 (1049656 : UInt32),
+              .load32 (1049948 : UInt32),
               .localSet 2,
               .localGet 2,
               .leU,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049644 : UInt32),
+              .load32 (1049936 : UInt32),
               .localSet 0,
               .localGet 0,
               .eqz,
               .br_if 5,
               .const (0 : UInt32),
-              .load32 (1049636 : UInt32),
+              .load32 (1049928 : UInt32),
               .localSet 4,
               .localGet 4,
               .const (41 : UInt32),
               .ltU,
               .br_if 4,
-              .const (1049344 : UInt32),
+              .const (1049636 : UInt32),
               .localSet 1,
               .loop 0 0 [
                 .block 0 0 [
@@ -3958,15 +4312,15 @@ def func56 : Wasm.Program :=
             ],
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049640 : UInt32),
+            .store32 (1049932 : UInt32),
             .const (0 : UInt32),
             .const (0 : UInt32),
-            .load32 (1049632 : UInt32),
+            .load32 (1049924 : UInt32),
             .localGet 0,
             .add,
             .localSet 0,
             .localGet 0,
-            .store32 (1049632 : UInt32),
+            .store32 (1049924 : UInt32),
             .localGet 1,
             .localGet 0,
             .const (1 : UInt32),
@@ -4002,13 +4356,13 @@ def func56 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049664 : UInt32),
+        .store32 (1049956 : UInt32),
         .ret
       ],
       .block 0 0 [
         .block 0 0 [
           .const (0 : UInt32),
-          .load32 (1049624 : UInt32),
+          .load32 (1049916 : UInt32),
           .localSet 3,
           .localGet 3,
           .const (1 : UInt32),
@@ -4024,11 +4378,11 @@ def func56 : Wasm.Program :=
           .localGet 3,
           .localGet 2,
           .or,
-          .store32 (1049624 : UInt32),
+          .store32 (1049916 : UInt32),
           .localGet 0,
           .const (248 : UInt32),
           .and,
-          .const (1049360 : UInt32),
+          .const (1049652 : UInt32),
           .add,
           .localSet 0,
           .localGet 0,
@@ -4040,11 +4394,11 @@ def func56 : Wasm.Program :=
         .and,
         .localSet 0,
         .localGet 0,
-        .const (1049360 : UInt32),
+        .const (1049652 : UInt32),
         .add,
         .localSet 3,
         .localGet 0,
-        .const (1049368 : UInt32),
+        .const (1049660 : UInt32),
         .add,
         .load32 (0 : UInt32),
         .localSet 0
@@ -4066,7 +4420,7 @@ def func56 : Wasm.Program :=
     .block 0 0 [
       .block 0 0 [
         .const (0 : UInt32),
-        .load32 (1049352 : UInt32),
+        .load32 (1049644 : UInt32),
         .localSet 0,
         .localGet 0,
         .br_if 0,
@@ -4097,21 +4451,21 @@ def func56 : Wasm.Program :=
     ],
     .const (0 : UInt32),
     .localGet 1,
-    .store32 (1049664 : UInt32),
+    .store32 (1049956 : UInt32),
     .localGet 4,
     .localGet 2,
     .leU,
     .br_if 0,
     .const (0 : UInt32),
     .const (4294967295 : UInt32),
-    .store32 (1049656 : UInt32)
+    .store32 (1049948 : UInt32)
   ]
 ]
 
-def func56Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func56, results := [] }
+def func66Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32, .i32, .i32], body := func66, results := [] }
 
-def func57 : Wasm.Program :=
+def func67 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -4166,7 +4520,7 @@ def func57 : Wasm.Program :=
                       .br_if 0,
                       .localGet 2,
                       .localGet 3,
-                      .call 52,
+                      .call 62,
                       .localSet 2,
                       .localGet 2,
                       .br_if 1,
@@ -4229,13 +4583,13 @@ def func57 : Wasm.Program :=
                         .br_if 0,
                         .localGet 7,
                         .const (0 : UInt32),
-                        .load32 (1049644 : UInt32),
+                        .load32 (1049936 : UInt32),
                         .eq,
                         .br_if 1,
                         .block 0 0 [
                           .localGet 7,
                           .const (0 : UInt32),
-                          .load32 (1049640 : UInt32),
+                          .load32 (1049932 : UInt32),
                           .eq,
                           .br_if 0,
                           .localGet 7,
@@ -4259,7 +4613,7 @@ def func57 : Wasm.Program :=
                           .br_if 9,
                           .localGet 7,
                           .localGet 9,
-                          .call 58,
+                          .call 68,
                           .block 0 0 [
                             .localGet 5,
                             .localGet 1,
@@ -4300,7 +4654,7 @@ def func57 : Wasm.Program :=
                             .store32 (4 : UInt32),
                             .localGet 1,
                             .localGet 7,
-                            .call 59,
+                            .call 69,
                             .br 9
                           ],
                           .localGet 4,
@@ -4326,7 +4680,7 @@ def func57 : Wasm.Program :=
                           .br 8
                         ],
                         .const (0 : UInt32),
-                        .load32 (1049632 : UInt32),
+                        .load32 (1049924 : UInt32),
                         .localGet 6,
                         .add,
                         .localSet 7,
@@ -4403,10 +4757,10 @@ def func57 : Wasm.Program :=
                         ],
                         .const (0 : UInt32),
                         .localGet 1,
-                        .store32 (1049640 : UInt32),
+                        .store32 (1049932 : UInt32),
                         .const (0 : UInt32),
                         .localGet 6,
-                        .store32 (1049632 : UInt32),
+                        .store32 (1049924 : UInt32),
                         .br 7
                       ],
                       .localGet 6,
@@ -4443,11 +4797,11 @@ def func57 : Wasm.Program :=
                       .store32 (4 : UInt32),
                       .localGet 1,
                       .localGet 6,
-                      .call 59,
+                      .call 69,
                       .br 6
                     ],
                     .const (0 : UInt32),
-                    .load32 (1049636 : UInt32),
+                    .load32 (1049928 : UInt32),
                     .localGet 6,
                     .add,
                     .localSet 7,
@@ -4500,28 +4854,28 @@ def func57 : Wasm.Program :=
                   .localGet 8,
                   .leU,
                   .br_if 6,
-                  .const (1048892 : UInt32),
+                  .const (1048952 : UInt32),
                   .const (46 : UInt32),
-                  .const (1048940 : UInt32),
-                  .call 82,
+                  .const (1049000 : UInt32),
+                  .call 92,
                   .unreachable
                 ],
-                .const (1048827 : UInt32),
+                .const (1048887 : UInt32),
                 .const (46 : UInt32),
-                .const (1048876 : UInt32),
-                .call 82,
+                .const (1048936 : UInt32),
+                .call 92,
                 .unreachable
               ],
-              .const (1048892 : UInt32),
+              .const (1048952 : UInt32),
               .const (46 : UInt32),
-              .const (1048940 : UInt32),
-              .call 82,
+              .const (1049000 : UInt32),
+              .call 92,
               .unreachable
             ],
-            .const (1048827 : UInt32),
+            .const (1048887 : UInt32),
             .const (46 : UInt32),
-            .const (1048876 : UInt32),
-            .call 82,
+            .const (1048936 : UInt32),
+            .call 92,
             .unreachable
           ],
           .localGet 4,
@@ -4548,10 +4902,10 @@ def func57 : Wasm.Program :=
           .store32 (4 : UInt32),
           .const (0 : UInt32),
           .localGet 1,
-          .store32 (1049636 : UInt32),
+          .store32 (1049928 : UInt32),
           .const (0 : UInt32),
           .localGet 5,
-          .store32 (1049644 : UInt32)
+          .store32 (1049936 : UInt32)
         ],
         .localGet 8,
         .eqz,
@@ -4560,7 +4914,7 @@ def func57 : Wasm.Program :=
         .ret
       ],
       .localGet 3,
-      .call 53,
+      .call 63,
       .localSet 1,
       .localGet 1,
       .eqz,
@@ -4599,15 +4953,15 @@ def func57 : Wasm.Program :=
       .localSet 2
     ],
     .localGet 0,
-    .call 56
+    .call 66
   ],
   .localGet 2
 ]
 
-def func57Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func57, results := [.i32] }
+def func67Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func67, results := [.i32] }
 
-def func58 : Wasm.Program :=
+def func68 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (12 : UInt32),
@@ -4709,7 +5063,7 @@ def func58 : Wasm.Program :=
               .load32 (28 : UInt32),
               .const (2 : UInt32),
               .shl,
-              .const (1049216 : UInt32),
+              .const (1049508 : UInt32),
               .add,
               .localSet 1,
               .localGet 1,
@@ -4761,14 +5115,14 @@ def func58 : Wasm.Program :=
         ],
         .const (0 : UInt32),
         .const (0 : UInt32),
-        .load32 (1049624 : UInt32),
+        .load32 (1049916 : UInt32),
         .const (4294967294 : UInt32),
         .localGet 1,
         .const (3 : UInt32),
         .shrU,
         .rotl,
         .and,
-        .store32 (1049624 : UInt32),
+        .store32 (1049916 : UInt32),
         .ret
       ],
       .localGet 2,
@@ -4806,19 +5160,19 @@ def func58 : Wasm.Program :=
   ],
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049628 : UInt32),
+  .load32 (1049920 : UInt32),
   .const (4294967294 : UInt32),
   .localGet 0,
   .load32 (28 : UInt32),
   .rotl,
   .and,
-  .store32 (1049628 : UInt32)
+  .store32 (1049920 : UInt32)
 ]
 
-def func58Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func58, results := [] }
+def func68Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func68, results := [] }
 
-def func59 : Wasm.Program :=
+def func69 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -4852,7 +5206,7 @@ def func59 : Wasm.Program :=
         .localSet 0,
         .localGet 0,
         .const (0 : UInt32),
-        .load32 (1049640 : UInt32),
+        .load32 (1049932 : UInt32),
         .ne,
         .br_if 0,
         .localGet 2,
@@ -4864,7 +5218,7 @@ def func59 : Wasm.Program :=
         .br_if 1,
         .const (0 : UInt32),
         .localGet 1,
-        .store32 (1049632 : UInt32),
+        .store32 (1049924 : UInt32),
         .localGet 2,
         .localGet 2,
         .load32 (4 : UInt32),
@@ -4883,7 +5237,7 @@ def func59 : Wasm.Program :=
       ],
       .localGet 0,
       .localGet 3,
-      .call 58
+      .call 68
     ],
     .block 0 0 [
       .block 0 0 [
@@ -4898,12 +5252,12 @@ def func59 : Wasm.Program :=
             .br_if 0,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049644 : UInt32),
+            .load32 (1049936 : UInt32),
             .eq,
             .br_if 2,
             .localGet 2,
             .const (0 : UInt32),
-            .load32 (1049640 : UInt32),
+            .load32 (1049932 : UInt32),
             .eq,
             .br_if 3,
             .localGet 2,
@@ -4912,7 +5266,7 @@ def func59 : Wasm.Program :=
             .and,
             .localSet 3,
             .localGet 3,
-            .call 58,
+            .call 68,
             .localGet 0,
             .localGet 3,
             .localGet 1,
@@ -4929,12 +5283,12 @@ def func59 : Wasm.Program :=
             .store32 (0 : UInt32),
             .localGet 0,
             .const (0 : UInt32),
-            .load32 (1049640 : UInt32),
+            .load32 (1049932 : UInt32),
             .ne,
             .br_if 1,
             .const (0 : UInt32),
             .localGet 1,
-            .store32 (1049632 : UInt32),
+            .store32 (1049924 : UInt32),
             .ret
           ],
           .localGet 2,
@@ -4960,13 +5314,13 @@ def func59 : Wasm.Program :=
           .br_if 0,
           .localGet 0,
           .localGet 1,
-          .call 63,
+          .call 73,
           .ret
         ],
         .block 0 0 [
           .block 0 0 [
             .const (0 : UInt32),
-            .load32 (1049624 : UInt32),
+            .load32 (1049916 : UInt32),
             .localSet 2,
             .localGet 2,
             .const (1 : UInt32),
@@ -4982,11 +5336,11 @@ def func59 : Wasm.Program :=
             .localGet 2,
             .localGet 3,
             .or,
-            .store32 (1049624 : UInt32),
+            .store32 (1049916 : UInt32),
             .localGet 1,
             .const (248 : UInt32),
             .and,
-            .const (1049360 : UInt32),
+            .const (1049652 : UInt32),
             .add,
             .localSet 1,
             .localGet 1,
@@ -4998,11 +5352,11 @@ def func59 : Wasm.Program :=
           .and,
           .localSet 1,
           .localGet 1,
-          .const (1049360 : UInt32),
+          .const (1049652 : UInt32),
           .add,
           .localSet 2,
           .localGet 1,
-          .const (1049368 : UInt32),
+          .const (1049660 : UInt32),
           .add,
           .load32 (0 : UInt32),
           .localSet 1
@@ -5023,15 +5377,15 @@ def func59 : Wasm.Program :=
       ],
       .const (0 : UInt32),
       .localGet 0,
-      .store32 (1049644 : UInt32),
+      .store32 (1049936 : UInt32),
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .load32 (1049636 : UInt32),
+      .load32 (1049928 : UInt32),
       .localGet 1,
       .add,
       .localSet 1,
       .localGet 1,
-      .store32 (1049636 : UInt32),
+      .store32 (1049928 : UInt32),
       .localGet 0,
       .localGet 1,
       .const (1 : UInt32),
@@ -5039,28 +5393,28 @@ def func59 : Wasm.Program :=
       .store32 (4 : UInt32),
       .localGet 0,
       .const (0 : UInt32),
-      .load32 (1049640 : UInt32),
+      .load32 (1049932 : UInt32),
       .ne,
       .br_if 1,
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .store32 (1049632 : UInt32),
+      .store32 (1049924 : UInt32),
       .const (0 : UInt32),
       .const (0 : UInt32),
-      .store32 (1049640 : UInt32),
+      .store32 (1049932 : UInt32),
       .ret
     ],
     .const (0 : UInt32),
     .localGet 0,
-    .store32 (1049640 : UInt32),
+    .store32 (1049932 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049632 : UInt32),
+    .load32 (1049924 : UInt32),
     .localGet 1,
     .add,
     .localSet 1,
     .localGet 1,
-    .store32 (1049632 : UInt32),
+    .store32 (1049924 : UInt32),
     .localGet 0,
     .localGet 1,
     .const (1 : UInt32),
@@ -5075,10 +5429,10 @@ def func59 : Wasm.Program :=
   ]
 ]
 
-def func59Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func59, results := [] }
+def func69Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func69, results := [] }
 
-def func60 : Wasm.Program :=
+def func70 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -5098,25 +5452,25 @@ def func60 : Wasm.Program :=
   .localGet 1,
   .const (4 : UInt32),
   .add,
-  .call 45,
+  .call 55,
   .unreachable
 ]
 
-def func60Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i64], body := func60, results := [] }
+def func70Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i64], body := func70, results := [] }
 
-def func61 : Wasm.Program :=
+def func71 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 62,
+  .call 72,
   .unreachable
 ]
 
-def func61Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func61, results := [] }
+def func71Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func71, results := [] }
 
-def func62 : Wasm.Program :=
+def func72 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -5133,14 +5487,14 @@ def func62 : Wasm.Program :=
   .localGet 2,
   .const (8 : UInt32),
   .add,
-  .call 43,
+  .call 53,
   .unreachable
 ]
 
-def func62Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32], body := func62, results := [] }
+def func72Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32], body := func72, results := [] }
 
-def func63 : Wasm.Program :=
+def func73 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 2,
@@ -5185,12 +5539,12 @@ def func63 : Wasm.Program :=
   .localGet 2,
   .const (2 : UInt32),
   .shl,
-  .const (1049216 : UInt32),
+  .const (1049508 : UInt32),
   .add,
   .localSet 3,
   .block 0 0 [
     .const (0 : UInt32),
-    .load32 (1049628 : UInt32),
+    .load32 (1049920 : UInt32),
     .const (1 : UInt32),
     .localGet 2,
     .shl,
@@ -5212,10 +5566,10 @@ def func63 : Wasm.Program :=
     .store32 (8 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049628 : UInt32),
+    .load32 (1049920 : UInt32),
     .localGet 4,
     .or,
-    .store32 (1049628 : UInt32),
+    .store32 (1049920 : UInt32),
     .ret
   ],
   .block 0 0 [
@@ -5314,21 +5668,21 @@ def func63 : Wasm.Program :=
   .store32 (8 : UInt32)
 ]
 
-def func63Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func63, results := [] }
+def func73Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32], body := func73, results := [] }
 
-def func64 : Wasm.Program :=
+def func74 : Wasm.Program :=
   [
   .const (0 : UInt32),
   .localSet 1,
   .const (0 : UInt32),
   .const (0 : UInt32),
-  .load32 (1049212 : UInt32),
+  .load32 (1049504 : UInt32),
   .localSet 2,
   .localGet 2,
   .const (1 : UInt32),
   .add,
-  .store32 (1049212 : UInt32),
+  .store32 (1049504 : UInt32),
   .block 0 0 [
     .localGet 2,
     .const (0 : UInt32),
@@ -5337,57 +5691,57 @@ def func64 : Wasm.Program :=
     .const (1 : UInt32),
     .localSet 1,
     .const (0 : UInt32),
-    .load8U (1049192 : UInt32),
+    .load8U (1049484 : UInt32),
     .br_if 0,
     .const (0 : UInt32),
     .localGet 0,
-    .store8 (1049192 : UInt32),
+    .store8 (1049484 : UInt32),
     .const (0 : UInt32),
     .const (0 : UInt32),
-    .load32 (1049188 : UInt32),
+    .load32 (1049480 : UInt32),
     .const (1 : UInt32),
     .add,
-    .store32 (1049188 : UInt32),
+    .store32 (1049480 : UInt32),
     .const (2 : UInt32),
     .localSet 1
   ],
   .localGet 1
 ]
 
-def func64Def : Wasm.Function :=
-  { params := [.i32], locals := [.i32, .i32], body := func64, results := [.i32] }
+def func74Def : Wasm.Function :=
+  { params := [.i32], locals := [.i32, .i32], body := func74, results := [.i32] }
 
-def func65 : Wasm.Program :=
+def func75 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048776 : UInt32),
+  .load64 (1048836 : UInt32),
   .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048768 : UInt32),
+  .load64 (1048828 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func65Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func65, results := [] }
+def func75Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func75, results := [] }
 
-def func66 : Wasm.Program :=
+def func76 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048760 : UInt32),
+  .load64 (1048820 : UInt32),
   .store64 (8 : UInt32),
   .localGet 0,
   .const (0 : UInt32),
-  .load64 (1048752 : UInt32),
+  .load64 (1048812 : UInt32),
   .store64 (0 : UInt32)
 ]
 
-def func66Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func66, results := [] }
+def func76Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func76, results := [] }
 
-def func67 : Wasm.Program :=
+def func77 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5400,7 +5754,7 @@ def func67 : Wasm.Program :=
     .load32 (4 : UInt32),
     .localGet 0,
     .load32 (8 : UInt32),
-    .call 85,
+    .call 99,
     .ret
   ],
   .localGet 1,
@@ -5415,26 +5769,26 @@ def func67 : Wasm.Program :=
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 84
+  .call 95
 ]
 
-def func67Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func67, results := [.i32] }
+def func77Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func77, results := [.i32] }
 
-def func68 : Wasm.Program :=
+def func78 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048956 : UInt32),
+  .const (1049016 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func68Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func68, results := [] }
+def func78Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func78, results := [] }
 
-def func69 : Wasm.Program :=
+def func79 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -5442,10 +5796,10 @@ def func69 : Wasm.Program :=
   .store64 (0 : UInt32)
 ]
 
-def func69Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func69, results := [] }
+def func79Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func79, results := [] }
 
-def func70 : Wasm.Program :=
+def func80 : Wasm.Program :=
   [
   .localGet 1,
   .load32 (4 : UInt32),
@@ -5453,17 +5807,17 @@ def func70 : Wasm.Program :=
   .localGet 1,
   .load32 (0 : UInt32),
   .localSet 3,
-  .call 37,
+  .call 47,
   .block 0 0 [
     .const (8 : UInt32),
     .const (4 : UInt32),
-    .call 34,
+    .call 44,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (8 : UInt32),
-    .call 80,
+    .call 90,
     .unreachable
   ],
   .localGet 1,
@@ -5473,30 +5827,30 @@ def func70 : Wasm.Program :=
   .localGet 3,
   .store32 (0 : UInt32),
   .localGet 0,
-  .const (1048956 : UInt32),
+  .const (1049016 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
   .store32 (0 : UInt32)
 ]
 
-def func70Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32], body := func70, results := [] }
+def func80Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32], body := func80, results := [] }
 
-def func71 : Wasm.Program :=
+def func81 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
   .load32 (0 : UInt32),
   .localGet 0,
   .load32 (4 : UInt32),
-  .call 85
+  .call 99
 ]
 
-def func71Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func71, results := [.i32] }
+def func81Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func81, results := [.i32] }
 
-def func72 : Wasm.Program :=
+def func82 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (8 : UInt32),
@@ -5543,7 +5897,7 @@ def func72 : Wasm.Program :=
     .localGet 3,
     .const (1 : UInt32),
     .const (1 : UInt32),
-    .call 39,
+    .call 49,
     .localGet 0,
     .load32 (8 : UInt32),
     .localSet 4
@@ -5646,10 +6000,10 @@ def func72 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func72Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func72, results := [.i32] }
+def func82Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32], body := func82, results := [.i32] }
 
-def func73 : Wasm.Program :=
+def func83 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5669,7 +6023,7 @@ def func73 : Wasm.Program :=
         .localGet 2,
         .const (1 : UInt32),
         .const (1 : UInt32),
-        .call 39,
+        .call 49,
         .localGet 0,
         .load32 (8 : UInt32),
         .localSet 3,
@@ -5698,10 +6052,10 @@ def func73 : Wasm.Program :=
   .const (0 : UInt32)
 ]
 
-def func73Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func73, results := [.i32] }
+def func83Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func83, results := [.i32] }
 
-def func74 : Wasm.Program :=
+def func84 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -5727,7 +6081,7 @@ def func74 : Wasm.Program :=
     .localGet 2,
     .const (20 : UInt32),
     .add,
-    .const (1048672 : UInt32),
+    .const (1048732 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5735,7 +6089,7 @@ def func74 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 84,
+    .call 95,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5757,7 +6111,7 @@ def func74 : Wasm.Program :=
     .store64 (0 : UInt32)
   ],
   .localGet 0,
-  .const (1048972 : UInt32),
+  .const (1049032 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5768,10 +6122,10 @@ def func74 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func74Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func74, results := [] }
+def func84Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func84, results := [] }
 
-def func75 : Wasm.Program :=
+def func85 : Wasm.Program :=
   [
   .globalGet 0,
   .const (48 : UInt32),
@@ -5797,7 +6151,7 @@ def func75 : Wasm.Program :=
     .localGet 2,
     .const (36 : UInt32),
     .add,
-    .const (1048672 : UInt32),
+    .const (1048732 : UInt32),
     .localGet 3,
     .load32 (0 : UInt32),
     .localSet 3,
@@ -5805,7 +6159,7 @@ def func75 : Wasm.Program :=
     .load32 (0 : UInt32),
     .localGet 3,
     .load32 (4 : UInt32),
-    .call 84,
+    .call 95,
     .drop,
     .localGet 2,
     .localGet 2,
@@ -5844,17 +6198,17 @@ def func75 : Wasm.Program :=
   .localGet 2,
   .localGet 4,
   .store64 (8 : UInt32),
-  .call 37,
+  .call 47,
   .block 0 0 [
     .const (12 : UInt32),
     .const (4 : UInt32),
-    .call 34,
+    .call 44,
     .localSet 1,
     .localGet 1,
     .br_if 0,
     .const (4 : UInt32),
     .const (12 : UInt32),
-    .call 80,
+    .call 90,
     .unreachable
   ],
   .localGet 1,
@@ -5866,7 +6220,7 @@ def func75 : Wasm.Program :=
   .load64 (8 : UInt32),
   .store64 (0 : UInt32),
   .localGet 0,
-  .const (1048972 : UInt32),
+  .const (1049032 : UInt32),
   .store32 (4 : UInt32),
   .localGet 0,
   .localGet 1,
@@ -5877,32 +6231,32 @@ def func75 : Wasm.Program :=
   .globalSet 0
 ]
 
-def func75Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func75, results := [] }
+def func85Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64], body := func85, results := [] }
 
-def func76 : Wasm.Program :=
+def func86 : Wasm.Program :=
   [
   .localGet 0,
   .const (0 : UInt32),
   .store32 (0 : UInt32)
 ]
 
-def func76Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func76, results := [] }
+def func86Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func86, results := [] }
 
-def func77 : Wasm.Program :=
+def func87 : Wasm.Program :=
   [
   .localGet 0,
-  .const (1048672 : UInt32),
+  .const (1048732 : UInt32),
   .localGet 1,
   .localGet 2,
-  .call 84
+  .call 95
 ]
 
-def func77Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func77, results := [.i32] }
+def func87Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func87, results := [.i32] }
 
-def func78 : Wasm.Program :=
+def func88 : Wasm.Program :=
   [
   .block 0 0 [
     .block 0 0 [
@@ -5960,10 +6314,10 @@ def func78 : Wasm.Program :=
   .store32 (0 : UInt32)
 ]
 
-def func78Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func78, results := [] }
+def func88Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32, .i32], body := func88, results := [] }
 
-def func79 : Wasm.Program :=
+def func89 : Wasm.Program :=
   [
   .block 0 0 [
     .localGet 0,
@@ -5971,40 +6325,40 @@ def func79 : Wasm.Program :=
     .br_if 0,
     .localGet 0,
     .localGet 1,
-    .call 80,
+    .call 90,
     .unreachable
   ],
-  .call 81,
+  .call 91,
   .unreachable
 ]
 
-def func79Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func79, results := [] }
+def func89Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func89, results := [] }
 
-def func80 : Wasm.Program :=
+def func90 : Wasm.Program :=
   [
   .localGet 1,
   .localGet 0,
-  .call 61,
+  .call 71,
   .unreachable
 ]
 
-def func80Def : Wasm.Function :=
-  { params := [.i32, .i32], locals := [], body := func80, results := [] }
+def func90Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [], body := func90, results := [] }
 
-def func81 : Wasm.Program :=
+def func91 : Wasm.Program :=
   [
-  .const (1049069 : UInt32),
+  .const (1049129 : UInt32),
   .const (35 : UInt32),
-  .const (1049088 : UInt32),
-  .call 83,
+  .const (1049148 : UInt32),
+  .call 93,
   .unreachable
 ]
 
-def func81Def : Wasm.Function :=
-  { params := [], locals := [], body := func81, results := [] }
+def func91Def : Wasm.Function :=
+  { params := [], locals := [], body := func91, results := [] }
 
-def func82 : Wasm.Program :=
+def func92 : Wasm.Program :=
   [
   .localGet 0,
   .localGet 1,
@@ -6013,14 +6367,14 @@ def func82 : Wasm.Program :=
   .const (1 : UInt32),
   .or,
   .localGet 2,
-  .call 83,
+  .call 93,
   .unreachable
 ]
 
-def func82Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func82, results := [] }
+def func92Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func92, results := [] }
 
-def func83 : Wasm.Program :=
+def func93 : Wasm.Program :=
   [
   .globalGet 0,
   .const (32 : UInt32),
@@ -6048,14 +6402,183 @@ def func83 : Wasm.Program :=
   .localGet 3,
   .const (20 : UInt32),
   .add,
-  .call 60,
+  .call 70,
   .unreachable
 ]
 
-def func83Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [.i32], body := func83, results := [] }
+def func93Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [.i32], body := func93, results := [] }
 
-def func84 : Wasm.Program :=
+def func94 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (32 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .const (20 : UInt32),
+  .localSet 3,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 4,
+  .localGet 4,
+  .localSet 5,
+  .block 0 0 [
+    .localGet 4,
+    .constI64 (1000 : UInt64),
+    .ltUI64,
+    .br_if 0,
+    .const (20 : UInt32),
+    .localSet 3,
+    .localGet 4,
+    .localSet 5,
+    .loop 0 0 [
+      .localGet 2,
+      .const (12 : UInt32),
+      .add,
+      .localGet 3,
+      .add,
+      .localSet 0,
+      .localGet 0,
+      .const (4294967292 : UInt32),
+      .add,
+      .localGet 5,
+      .localSet 6,
+      .localGet 6,
+      .localGet 6,
+      .constI64 (10000 : UInt64),
+      .divUI64,
+      .localSet 5,
+      .localGet 5,
+      .constI64 (10000 : UInt64),
+      .mulI64,
+      .subI64,
+      .wrapI64,
+      .localSet 7,
+      .localGet 7,
+      .const (65535 : UInt32),
+      .and,
+      .const (100 : UInt32),
+      .divU,
+      .localSet 8,
+      .localGet 8,
+      .const (1 : UInt32),
+      .shl,
+      .load16U (1049180 : UInt32),
+      .store16 (0 : UInt32),
+      .localGet 0,
+      .const (4294967294 : UInt32),
+      .add,
+      .localGet 7,
+      .localGet 8,
+      .const (100 : UInt32),
+      .mul,
+      .sub,
+      .const (65535 : UInt32),
+      .and,
+      .const (1 : UInt32),
+      .shl,
+      .load16U (1049180 : UInt32),
+      .store16 (0 : UInt32),
+      .localGet 3,
+      .const (4294967292 : UInt32),
+      .add,
+      .localSet 3,
+      .localGet 6,
+      .constI64 (9999999 : UInt64),
+      .gtUI64,
+      .br_if 0
+    ]
+  ],
+  .block 0 0 [
+    .localGet 5,
+    .constI64 (9 : UInt64),
+    .leUI64,
+    .br_if 0,
+    .localGet 2,
+    .const (12 : UInt32),
+    .add,
+    .localGet 3,
+    .const (4294967294 : UInt32),
+    .add,
+    .localSet 3,
+    .localGet 3,
+    .add,
+    .localGet 5,
+    .wrapI64,
+    .localSet 0,
+    .localGet 0,
+    .localGet 0,
+    .const (65535 : UInt32),
+    .and,
+    .const (100 : UInt32),
+    .divU,
+    .localSet 0,
+    .localGet 0,
+    .const (100 : UInt32),
+    .mul,
+    .sub,
+    .const (65535 : UInt32),
+    .and,
+    .const (1 : UInt32),
+    .shl,
+    .load16U (1049180 : UInt32),
+    .store16 (0 : UInt32),
+    .localGet 0,
+    .extendUI32,
+    .localSet 5
+  ],
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 4,
+      .eqzI64,
+      .br_if 0,
+      .localGet 5,
+      .eqzI64,
+      .br_if 1
+    ],
+    .localGet 2,
+    .const (12 : UInt32),
+    .add,
+    .localGet 3,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 3,
+    .localGet 3,
+    .add,
+    .localGet 5,
+    .wrapI64,
+    .const (1 : UInt32),
+    .shl,
+    .load8U (1049181 : UInt32),
+    .store8 (0 : UInt32)
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1 : UInt32),
+  .const (0 : UInt32),
+  .localGet 2,
+  .const (12 : UInt32),
+  .add,
+  .localGet 3,
+  .add,
+  .const (20 : UInt32),
+  .localGet 3,
+  .sub,
+  .call 96,
+  .localSet 3,
+  .localGet 2,
+  .const (32 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 3
+]
+
+def func94Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i64, .i64, .i64, .i32, .i32], body := func94, results := [.i32] }
+
+def func95 : Wasm.Program :=
   [
   .globalGet 0,
   .const (16 : UInt32),
@@ -6363,10 +6886,935 @@ def func84 : Wasm.Program :=
   .localGet 5
 ]
 
-def func84Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func84, results := [.i32] }
+def func95Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func95, results := [.i32] }
 
-def func85 : Wasm.Program :=
+def func96 : Wasm.Program :=
+  [
+  .const (43 : UInt32),
+  .const (1114112 : UInt32),
+  .localGet 0,
+  .load32 (8 : UInt32),
+  .localSet 6,
+  .localGet 6,
+  .const (2097152 : UInt32),
+  .and,
+  .localSet 7,
+  .localGet 7,
+  .select,
+  .localSet 8,
+  .localGet 7,
+  .const (21 : UInt32),
+  .shrU,
+  .const (1 : UInt32),
+  .localGet 1,
+  .select,
+  .localGet 5,
+  .add,
+  .localSet 9,
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 6,
+      .const (8388608 : UInt32),
+      .and,
+      .br_if 0,
+      .const (0 : UInt32),
+      .localSet 2,
+      .br 1
+    ],
+    .block 0 0 [
+      .block 0 0 [
+        .localGet 3,
+        .const (16 : UInt32),
+        .ltU,
+        .br_if 0,
+        .localGet 2,
+        .localGet 3,
+        .call 97,
+        .localSet 7,
+        .br 1
+      ],
+      .block 0 0 [
+        .localGet 3,
+        .br_if 0,
+        .const (0 : UInt32),
+        .localSet 7,
+        .br 1
+      ],
+      .localGet 3,
+      .const (3 : UInt32),
+      .and,
+      .localSet 10,
+      .const (0 : UInt32),
+      .localSet 11,
+      .const (0 : UInt32),
+      .localSet 7,
+      .block 0 0 [
+        .localGet 3,
+        .const (4 : UInt32),
+        .ltU,
+        .br_if 0,
+        .localGet 3,
+        .const (12 : UInt32),
+        .and,
+        .localSet 12,
+        .const (0 : UInt32),
+        .localSet 11,
+        .const (0 : UInt32),
+        .localSet 7,
+        .loop 0 0 [
+          .localGet 7,
+          .localGet 2,
+          .localGet 11,
+          .add,
+          .localSet 13,
+          .localGet 13,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (1 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (2 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localGet 13,
+          .const (3 : UInt32),
+          .add,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localSet 7,
+          .localGet 12,
+          .localGet 11,
+          .const (4 : UInt32),
+          .add,
+          .localSet 11,
+          .localGet 11,
+          .ne,
+          .br_if 0
+        ],
+        .localGet 10,
+        .eqz,
+        .br_if 1
+      ],
+      .localGet 2,
+      .localGet 11,
+      .add,
+      .localSet 13,
+      .loop 0 0 [
+        .localGet 7,
+        .localGet 13,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7,
+        .localGet 13,
+        .const (1 : UInt32),
+        .add,
+        .localSet 13,
+        .localGet 10,
+        .const (4294967295 : UInt32),
+        .add,
+        .localSet 10,
+        .localGet 10,
+        .br_if 0
+      ]
+    ],
+    .localGet 7,
+    .localGet 9,
+    .add,
+    .localSet 9
+  ],
+  .localGet 8,
+  .const (45 : UInt32),
+  .localGet 1,
+  .select,
+  .localSet 12,
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 9,
+      .localGet 0,
+      .load16U (12 : UInt32),
+      .localSet 1,
+      .localGet 1,
+      .geU,
+      .br_if 0,
+      .block 0 0 [
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 6,
+            .const (16777216 : UInt32),
+            .and,
+            .br_if 0,
+            .localGet 1,
+            .localGet 9,
+            .sub,
+            .localSet 8,
+            .const (0 : UInt32),
+            .localSet 7,
+            .const (0 : UInt32),
+            .localSet 1,
+            .block 0 0 [
+              .block 0 0 [
+                .block 0 0 [
+                  .localGet 6,
+                  .const (29 : UInt32),
+                  .shrU,
+                  .const (3 : UInt32),
+                  .and,
+                  .brTable [2, 0, 1, 0] 2
+                ],
+                .localGet 8,
+                .localSet 1,
+                .br 1
+              ],
+              .localGet 8,
+              .const (65534 : UInt32),
+              .and,
+              .const (1 : UInt32),
+              .shrU,
+              .localSet 1
+            ],
+            .localGet 6,
+            .const (2097151 : UInt32),
+            .and,
+            .localSet 9,
+            .localGet 0,
+            .load32 (4 : UInt32),
+            .localSet 11,
+            .localGet 0,
+            .load32 (0 : UInt32),
+            .localSet 10,
+            .loop 0 0 [
+              .localGet 7,
+              .const (65535 : UInt32),
+              .and,
+              .localGet 1,
+              .const (65535 : UInt32),
+              .and,
+              .geU,
+              .br_if 2,
+              .const (1 : UInt32),
+              .localSet 13,
+              .localGet 7,
+              .const (1 : UInt32),
+              .add,
+              .localSet 7,
+              .localGet 10,
+              .localGet 9,
+              .localGet 11,
+              .load32 (16 : UInt32),
+              .callIndirect 2 0,
+              .eqz,
+              .br_if 0,
+              .br 5
+            ]
+          ],
+          .localGet 0,
+          .localGet 0,
+          .load64 (8 : UInt32),
+          .localSet 14,
+          .localGet 14,
+          .wrapI64,
+          .const (2682257408 : UInt32),
+          .and,
+          .const (536870960 : UInt32),
+          .or,
+          .store32 (8 : UInt32),
+          .const (1 : UInt32),
+          .localSet 13,
+          .localGet 0,
+          .load32 (0 : UInt32),
+          .localSet 10,
+          .localGet 10,
+          .localGet 0,
+          .load32 (4 : UInt32),
+          .localSet 11,
+          .localGet 11,
+          .localGet 12,
+          .localGet 2,
+          .localGet 3,
+          .call 98,
+          .br_if 3,
+          .const (0 : UInt32),
+          .localSet 7,
+          .localGet 1,
+          .localGet 9,
+          .sub,
+          .const (65535 : UInt32),
+          .and,
+          .localSet 2,
+          .loop 0 0 [
+            .localGet 7,
+            .const (65535 : UInt32),
+            .and,
+            .localGet 2,
+            .geU,
+            .br_if 2,
+            .const (1 : UInt32),
+            .localSet 13,
+            .localGet 7,
+            .const (1 : UInt32),
+            .add,
+            .localSet 7,
+            .localGet 10,
+            .const (48 : UInt32),
+            .localGet 11,
+            .load32 (16 : UInt32),
+            .callIndirect 2 0,
+            .eqz,
+            .br_if 0,
+            .br 4
+          ]
+        ],
+        .const (1 : UInt32),
+        .localSet 13,
+        .localGet 10,
+        .localGet 11,
+        .localGet 12,
+        .localGet 2,
+        .localGet 3,
+        .call 98,
+        .br_if 2,
+        .localGet 10,
+        .localGet 4,
+        .localGet 5,
+        .localGet 11,
+        .load32 (12 : UInt32),
+        .callIndirect 1 0,
+        .br_if 2,
+        .const (0 : UInt32),
+        .localSet 7,
+        .localGet 8,
+        .localGet 1,
+        .sub,
+        .const (65535 : UInt32),
+        .and,
+        .localSet 0,
+        .loop 0 0 [
+          .localGet 7,
+          .const (65535 : UInt32),
+          .and,
+          .localSet 2,
+          .localGet 2,
+          .localGet 0,
+          .ltU,
+          .localSet 13,
+          .localGet 2,
+          .localGet 0,
+          .geU,
+          .br_if 3,
+          .localGet 7,
+          .const (1 : UInt32),
+          .add,
+          .localSet 7,
+          .localGet 10,
+          .localGet 9,
+          .localGet 11,
+          .load32 (16 : UInt32),
+          .callIndirect 2 0,
+          .eqz,
+          .br_if 0,
+          .br 3
+        ]
+      ],
+      .const (1 : UInt32),
+      .localSet 13,
+      .localGet 10,
+      .localGet 4,
+      .localGet 5,
+      .localGet 11,
+      .load32 (12 : UInt32),
+      .callIndirect 1 0,
+      .br_if 1,
+      .localGet 0,
+      .localGet 14,
+      .store64 (8 : UInt32),
+      .const (0 : UInt32),
+      .ret
+    ],
+    .const (1 : UInt32),
+    .localSet 13,
+    .localGet 0,
+    .load32 (0 : UInt32),
+    .localSet 7,
+    .localGet 7,
+    .localGet 0,
+    .load32 (4 : UInt32),
+    .localSet 10,
+    .localGet 10,
+    .localGet 12,
+    .localGet 2,
+    .localGet 3,
+    .call 98,
+    .br_if 0,
+    .localGet 7,
+    .localGet 4,
+    .localGet 5,
+    .localGet 10,
+    .load32 (12 : UInt32),
+    .callIndirect 1 0,
+    .localSet 13
+  ],
+  .localGet 13
+]
+
+def func96Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32, .i64], body := func96, results := [.i32] }
+
+def func97 : Wasm.Program :=
+  [
+  .block 0 0 [
+    .block 0 0 [
+      .localGet 1,
+      .localGet 0,
+      .const (3 : UInt32),
+      .add,
+      .const (4294967292 : UInt32),
+      .and,
+      .localSet 2,
+      .localGet 2,
+      .localGet 0,
+      .sub,
+      .localSet 3,
+      .localGet 3,
+      .ltU,
+      .br_if 0,
+      .localGet 1,
+      .localGet 3,
+      .sub,
+      .localSet 4,
+      .localGet 4,
+      .const (2 : UInt32),
+      .shrU,
+      .localSet 5,
+      .localGet 5,
+      .eqz,
+      .br_if 0,
+      .localGet 4,
+      .const (3 : UInt32),
+      .and,
+      .localSet 6,
+      .const (0 : UInt32),
+      .localSet 7,
+      .const (0 : UInt32),
+      .localSet 1,
+      .block 0 0 [
+        .localGet 2,
+        .localGet 0,
+        .eq,
+        .br_if 0,
+        .const (0 : UInt32),
+        .localSet 8,
+        .const (0 : UInt32),
+        .localSet 1,
+        .block 0 0 [
+          .localGet 0,
+          .localGet 2,
+          .sub,
+          .localSet 9,
+          .localGet 9,
+          .const (4294967292 : UInt32),
+          .gtU,
+          .br_if 0,
+          .const (0 : UInt32),
+          .localSet 8,
+          .const (0 : UInt32),
+          .localSet 1,
+          .loop 0 0 [
+            .localGet 1,
+            .localGet 0,
+            .localGet 8,
+            .add,
+            .localSet 2,
+            .localGet 2,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (1 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (2 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localGet 2,
+            .const (3 : UInt32),
+            .add,
+            .load8S (0 : UInt32),
+            .const (4294967231 : UInt32),
+            .gtS,
+            .add,
+            .localSet 1,
+            .localGet 8,
+            .const (4 : UInt32),
+            .add,
+            .localSet 8,
+            .localGet 8,
+            .br_if 0
+          ]
+        ],
+        .localGet 0,
+        .localGet 8,
+        .add,
+        .localSet 2,
+        .loop 0 0 [
+          .localGet 1,
+          .localGet 2,
+          .load8S (0 : UInt32),
+          .const (4294967231 : UInt32),
+          .gtS,
+          .add,
+          .localSet 1,
+          .localGet 2,
+          .const (1 : UInt32),
+          .add,
+          .localSet 2,
+          .localGet 9,
+          .const (1 : UInt32),
+          .add,
+          .localSet 9,
+          .localGet 9,
+          .br_if 0
+        ]
+      ],
+      .localGet 0,
+      .localGet 3,
+      .add,
+      .localSet 9,
+      .block 0 0 [
+        .localGet 6,
+        .eqz,
+        .br_if 0,
+        .localGet 9,
+        .localGet 4,
+        .const (2147483644 : UInt32),
+        .and,
+        .add,
+        .localSet 2,
+        .localGet 2,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .localSet 7,
+        .localGet 6,
+        .const (1 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 7,
+        .localGet 2,
+        .load8S (1 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7,
+        .localGet 6,
+        .const (2 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 7,
+        .localGet 2,
+        .load8S (2 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 7
+      ],
+      .localGet 7,
+      .localGet 1,
+      .add,
+      .localSet 8,
+      .loop 0 0 [
+        .localGet 9,
+        .localSet 3,
+        .localGet 5,
+        .eqz,
+        .br_if 2,
+        .localGet 5,
+        .const (192 : UInt32),
+        .localGet 5,
+        .const (192 : UInt32),
+        .ltU,
+        .select,
+        .localSet 7,
+        .localGet 7,
+        .const (3 : UInt32),
+        .and,
+        .localSet 6,
+        .block 0 0 [
+          .block 0 0 [
+            .localGet 7,
+            .const (2 : UInt32),
+            .shl,
+            .localSet 4,
+            .localGet 4,
+            .const (1008 : UInt32),
+            .and,
+            .localSet 1,
+            .localGet 1,
+            .br_if 0,
+            .const (0 : UInt32),
+            .localSet 2,
+            .br 1
+          ],
+          .localGet 3,
+          .localGet 1,
+          .add,
+          .localSet 0,
+          .const (0 : UInt32),
+          .localSet 2,
+          .localGet 3,
+          .localSet 1,
+          .loop 0 0 [
+            .localGet 1,
+            .const (12 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .const (8 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .const (4 : UInt32),
+            .add,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 1,
+            .load32 (0 : UInt32),
+            .localSet 9,
+            .localGet 9,
+            .const (4294967295 : UInt32),
+            .xor,
+            .const (7 : UInt32),
+            .shrU,
+            .localGet 9,
+            .const (6 : UInt32),
+            .shrU,
+            .or,
+            .const (16843009 : UInt32),
+            .and,
+            .localGet 2,
+            .add,
+            .add,
+            .add,
+            .add,
+            .localSet 2,
+            .localGet 1,
+            .const (16 : UInt32),
+            .add,
+            .localSet 1,
+            .localGet 1,
+            .localGet 0,
+            .ne,
+            .br_if 0
+          ]
+        ],
+        .localGet 5,
+        .localGet 7,
+        .sub,
+        .localSet 5,
+        .localGet 3,
+        .localGet 4,
+        .add,
+        .localSet 9,
+        .localGet 2,
+        .const (8 : UInt32),
+        .shrU,
+        .const (16711935 : UInt32),
+        .and,
+        .localGet 2,
+        .const (16711935 : UInt32),
+        .and,
+        .add,
+        .const (65537 : UInt32),
+        .mul,
+        .const (16 : UInt32),
+        .shrU,
+        .localGet 8,
+        .add,
+        .localSet 8,
+        .localGet 6,
+        .eqz,
+        .br_if 0
+      ],
+      .localGet 3,
+      .localGet 7,
+      .const (252 : UInt32),
+      .and,
+      .const (2 : UInt32),
+      .shl,
+      .add,
+      .localSet 2,
+      .localGet 2,
+      .load32 (0 : UInt32),
+      .localSet 1,
+      .localGet 1,
+      .const (4294967295 : UInt32),
+      .xor,
+      .const (7 : UInt32),
+      .shrU,
+      .localGet 1,
+      .const (6 : UInt32),
+      .shrU,
+      .or,
+      .const (16843009 : UInt32),
+      .and,
+      .localSet 1,
+      .block 0 0 [
+        .localGet 6,
+        .const (1 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 2,
+        .load32 (4 : UInt32),
+        .localSet 9,
+        .localGet 9,
+        .const (4294967295 : UInt32),
+        .xor,
+        .const (7 : UInt32),
+        .shrU,
+        .localGet 9,
+        .const (6 : UInt32),
+        .shrU,
+        .or,
+        .const (16843009 : UInt32),
+        .and,
+        .localGet 1,
+        .add,
+        .localSet 1,
+        .localGet 6,
+        .const (2 : UInt32),
+        .eq,
+        .br_if 0,
+        .localGet 2,
+        .load32 (8 : UInt32),
+        .localSet 2,
+        .localGet 2,
+        .const (4294967295 : UInt32),
+        .xor,
+        .const (7 : UInt32),
+        .shrU,
+        .localGet 2,
+        .const (6 : UInt32),
+        .shrU,
+        .or,
+        .const (16843009 : UInt32),
+        .and,
+        .localGet 1,
+        .add,
+        .localSet 1
+      ],
+      .localGet 1,
+      .const (8 : UInt32),
+      .shrU,
+      .const (459007 : UInt32),
+      .and,
+      .localGet 1,
+      .const (16711935 : UInt32),
+      .and,
+      .add,
+      .const (65537 : UInt32),
+      .mul,
+      .const (16 : UInt32),
+      .shrU,
+      .localGet 8,
+      .add,
+      .localSet 8,
+      .br 1
+    ],
+    .block 0 0 [
+      .localGet 1,
+      .br_if 0,
+      .const (0 : UInt32),
+      .ret
+    ],
+    .localGet 1,
+    .const (3 : UInt32),
+    .and,
+    .localSet 2,
+    .const (0 : UInt32),
+    .localSet 9,
+    .const (0 : UInt32),
+    .localSet 8,
+    .block 0 0 [
+      .localGet 1,
+      .const (4 : UInt32),
+      .ltU,
+      .br_if 0,
+      .localGet 1,
+      .const (4294967292 : UInt32),
+      .and,
+      .localSet 5,
+      .const (0 : UInt32),
+      .localSet 8,
+      .const (0 : UInt32),
+      .localSet 9,
+      .loop 0 0 [
+        .localGet 8,
+        .localGet 0,
+        .localGet 9,
+        .add,
+        .localSet 1,
+        .localGet 1,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (1 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (2 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localGet 1,
+        .const (3 : UInt32),
+        .add,
+        .load8S (0 : UInt32),
+        .const (4294967231 : UInt32),
+        .gtS,
+        .add,
+        .localSet 8,
+        .localGet 5,
+        .localGet 9,
+        .const (4 : UInt32),
+        .add,
+        .localSet 9,
+        .localGet 9,
+        .ne,
+        .br_if 0
+      ],
+      .localGet 2,
+      .eqz,
+      .br_if 1
+    ],
+    .localGet 0,
+    .localGet 9,
+    .add,
+    .localSet 1,
+    .loop 0 0 [
+      .localGet 8,
+      .localGet 1,
+      .load8S (0 : UInt32),
+      .const (4294967231 : UInt32),
+      .gtS,
+      .add,
+      .localSet 8,
+      .localGet 1,
+      .const (1 : UInt32),
+      .add,
+      .localSet 1,
+      .localGet 2,
+      .const (4294967295 : UInt32),
+      .add,
+      .localSet 2,
+      .localGet 2,
+      .br_if 0
+    ]
+  ],
+  .localGet 8
+]
+
+def func97Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i32, .i32, .i32, .i32, .i32, .i32, .i32], body := func97, results := [.i32] }
+
+def func98 : Wasm.Program :=
+  [
+  .block 0 0 [
+    .localGet 2,
+    .const (1114112 : UInt32),
+    .eq,
+    .br_if 0,
+    .localGet 0,
+    .localGet 2,
+    .localGet 1,
+    .load32 (16 : UInt32),
+    .callIndirect 2 0,
+    .eqz,
+    .br_if 0,
+    .const (1 : UInt32),
+    .ret
+  ],
+  .block 0 0 [
+    .localGet 3,
+    .br_if 0,
+    .const (0 : UInt32),
+    .ret
+  ],
+  .localGet 0,
+  .localGet 3,
+  .localGet 4,
+  .localGet 1,
+  .load32 (12 : UInt32),
+  .callIndirect 1 0
+]
+
+def func98Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32, .i32, .i32], locals := [], body := func98, results := [.i32] }
+
+def func99 : Wasm.Program :=
   [
   .localGet 0,
   .load32 (0 : UInt32),
@@ -6378,32 +7826,156 @@ def func85 : Wasm.Program :=
   .callIndirect 1 0
 ]
 
-def func85Def : Wasm.Function :=
-  { params := [.i32, .i32, .i32], locals := [], body := func85, results := [.i32] }
+def func99Def : Wasm.Function :=
+  { params := [.i32, .i32, .i32], locals := [], body := func99, results := [.i32] }
 
-def func86 : Wasm.Program :=
+def func100 : Wasm.Program :=
   [
-  .const (1049104 : UInt32),
+  .const (1049380 : UInt32),
   .const (51 : UInt32),
   .localGet 0,
-  .call 83,
+  .call 93,
   .unreachable
 ]
 
-def func86Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func86, results := [] }
+def func100Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func100, results := [] }
 
-def func87 : Wasm.Program :=
+def func101 : Wasm.Program :=
   [
-  .const (1049129 : UInt32),
+  .const (1049405 : UInt32),
   .const (115 : UInt32),
   .localGet 0,
-  .call 83,
+  .call 93,
   .unreachable
 ]
 
-def func87Def : Wasm.Function :=
-  { params := [.i32], locals := [], body := func87, results := [] }
+def func101Def : Wasm.Function :=
+  { params := [.i32], locals := [], body := func101, results := [] }
+
+def func102 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 3,
+  .const (0 : UInt32),
+  .localSet 0,
+  .loop 0 0 [
+    .localGet 2,
+    .localGet 0,
+    .add,
+    .const (15 : UInt32),
+    .add,
+    .localGet 3,
+    .wrapI64,
+    .const (15 : UInt32),
+    .and,
+    .load8U (1049164 : UInt32),
+    .store8 (0 : UInt32),
+    .localGet 0,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 0,
+    .localGet 3,
+    .constI64 (4 : UInt64),
+    .shrUI64,
+    .localSet 3,
+    .localGet 3,
+    .constI64 (0 : UInt64),
+    .neI64,
+    .br_if 0
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1049462 : UInt32),
+  .const (2 : UInt32),
+  .localGet 2,
+  .localGet 0,
+  .add,
+  .const (16 : UInt32),
+  .add,
+  .const (0 : UInt32),
+  .localGet 0,
+  .sub,
+  .call 96,
+  .localSet 0,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 0
+]
+
+def func102Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i64], body := func102, results := [.i32] }
+
+def func103 : Wasm.Program :=
+  [
+  .globalGet 0,
+  .const (16 : UInt32),
+  .sub,
+  .localSet 2,
+  .localGet 2,
+  .globalSet 0,
+  .localGet 0,
+  .load64 (0 : UInt32),
+  .localSet 3,
+  .const (0 : UInt32),
+  .localSet 0,
+  .loop 0 0 [
+    .localGet 2,
+    .localGet 0,
+    .add,
+    .const (15 : UInt32),
+    .add,
+    .localGet 3,
+    .wrapI64,
+    .const (15 : UInt32),
+    .and,
+    .load8U (1049464 : UInt32),
+    .store8 (0 : UInt32),
+    .localGet 0,
+    .const (4294967295 : UInt32),
+    .add,
+    .localSet 0,
+    .localGet 3,
+    .constI64 (4 : UInt64),
+    .shrUI64,
+    .localSet 3,
+    .localGet 3,
+    .constI64 (0 : UInt64),
+    .neI64,
+    .br_if 0
+  ],
+  .localGet 1,
+  .const (1 : UInt32),
+  .const (1049462 : UInt32),
+  .const (2 : UInt32),
+  .localGet 2,
+  .localGet 0,
+  .add,
+  .const (16 : UInt32),
+  .add,
+  .const (0 : UInt32),
+  .localGet 0,
+  .sub,
+  .call 96,
+  .localSet 0,
+  .localGet 2,
+  .const (16 : UInt32),
+  .add,
+  .globalSet 0,
+  .localGet 0
+]
+
+def func103Def : Wasm.Function :=
+  { params := [.i32, .i32], locals := [.i32, .i64], body := func103, results := [.i32] }
 
 def «module» : Wasm.Module :=
 {
@@ -6496,59 +8068,82 @@ def «module» : Wasm.Module :=
     func84Def,
     func85Def,
     func86Def,
-    func87Def
+    func87Def,
+    func88Def,
+    func89Def,
+    func90Def,
+    func91Def,
+    func92Def,
+    func93Def,
+    func94Def,
+    func95Def,
+    func96Def,
+    func97Def,
+    func98Def,
+    func99Def,
+    func100Def,
+    func101Def,
+    func102Def,
+    func103Def
   ],
   exports := [
-    { name := "add_chain", funcIdx := 0 },
-    { name := "add_then_mul", funcIdx := 1 },
-    { name := "and_chain", funcIdx := 2 },
-    { name := "and_then_or", funcIdx := 3 },
-    { name := "div_then_add", funcIdx := 4 },
-    { name := "div_then_mul", funcIdx := 5 },
-    { name := "eq_two", funcIdx := 6 },
-    { name := "eq_u64", funcIdx := 7 },
-    { name := "ge_two", funcIdx := 8 },
-    { name := "ge_u64", funcIdx := 9 },
-    { name := "gt_two", funcIdx := 10 },
-    { name := "gt_u64", funcIdx := 11 },
-    { name := "le_two", funcIdx := 12 },
-    { name := "le_u64", funcIdx := 13 },
-    { name := "lt_two", funcIdx := 14 },
-    { name := "lt_u64", funcIdx := 15 },
-    { name := "mul_chain", funcIdx := 16 },
-    { name := "mul_then_add", funcIdx := 17 },
-    { name := "ne_two", funcIdx := 18 },
-    { name := "ne_u64", funcIdx := 19 },
-    { name := "not_then_xor", funcIdx := 20 },
-    { name := "not_twice", funcIdx := 21 },
-    { name := "or_chain", funcIdx := 22 },
-    { name := "or_then_xor", funcIdx := 23 },
-    { name := "rem_then_add", funcIdx := 24 },
-    { name := "rem_then_mul", funcIdx := 25 },
-    { name := "shl_then_add", funcIdx := 26 },
-    { name := "shl_twice", funcIdx := 27 },
-    { name := "shr_then_sub", funcIdx := 28 },
-    { name := "shr_twice", funcIdx := 29 },
-    { name := "sub_chain", funcIdx := 30 },
-    { name := "sub_then_add", funcIdx := 31 },
-    { name := "xor_chain", funcIdx := 32 },
-    { name := "xor_then_and", funcIdx := 33 }
+    { name := "add_chain", funcIdx := 4 },
+    { name := "add_then_mul", funcIdx := 5 },
+    { name := "and_chain", funcIdx := 6 },
+    { name := "and_then_or", funcIdx := 7 },
+    { name := "clamp_add", funcIdx := 8 },
+    { name := "clamp_mul", funcIdx := 9 },
+    { name := "div_then_add", funcIdx := 10 },
+    { name := "div_then_mul", funcIdx := 11 },
+    { name := "eq_two", funcIdx := 12 },
+    { name := "eq_u64", funcIdx := 13 },
+    { name := "ge_two", funcIdx := 14 },
+    { name := "ge_u64", funcIdx := 15 },
+    { name := "gt_two", funcIdx := 16 },
+    { name := "gt_u64", funcIdx := 17 },
+    { name := "le_two", funcIdx := 18 },
+    { name := "le_u64", funcIdx := 19 },
+    { name := "lt_two", funcIdx := 20 },
+    { name := "lt_u64", funcIdx := 21 },
+    { name := "max_add", funcIdx := 22 },
+    { name := "max_chain", funcIdx := 23 },
+    { name := "min_add", funcIdx := 24 },
+    { name := "min_chain", funcIdx := 25 },
+    { name := "mul_chain", funcIdx := 26 },
+    { name := "mul_then_add", funcIdx := 27 },
+    { name := "ne_two", funcIdx := 28 },
+    { name := "ne_u64", funcIdx := 29 },
+    { name := "not_then_xor", funcIdx := 30 },
+    { name := "not_twice", funcIdx := 31 },
+    { name := "or_chain", funcIdx := 32 },
+    { name := "or_then_xor", funcIdx := 33 },
+    { name := "rem_then_add", funcIdx := 34 },
+    { name := "rem_then_mul", funcIdx := 35 },
+    { name := "shl_then_add", funcIdx := 36 },
+    { name := "shl_twice", funcIdx := 37 },
+    { name := "shr_then_sub", funcIdx := 38 },
+    { name := "shr_twice", funcIdx := 39 },
+    { name := "sub_chain", funcIdx := 40 },
+    { name := "sub_then_add", funcIdx := 41 },
+    { name := "xor_chain", funcIdx := 42 },
+    { name := "xor_then_and", funcIdx := 43 }
   ],
   memory := some { pagesMin := (17 : UInt32), pagesMax := none, data := [
-    { offset := some (1048576 : UInt32), bytes := [(114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (95 : UInt8), (116 : UInt8), (101 : UInt8), (115 : UInt8), (116 : UInt8), (115 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (48 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (51 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (52 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (208 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (208 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (2 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (156 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8)] }
+    { offset := some (1048576 : UInt32), bytes := [(17 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (32 : UInt8), (62 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (46 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (32 : UInt8), (61 : UInt8), (32 : UInt8), (192 : UInt8), (8 : UInt8), (44 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (32 : UInt8), (61 : UInt8), (32 : UInt8), (192 : UInt8), (0 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (95 : UInt8), (117 : UInt8), (54 : UInt8), (52 : UInt8), (95 : UInt8), (116 : UInt8), (101 : UInt8), (115 : UInt8), (116 : UInt8), (115 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (101 : UInt8), (120 : UInt8), (112 : UInt8), (111 : UInt8), (114 : UInt8), (116 : UInt8), (115 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (83 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (95 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (84 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (95 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (48 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (51 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (30 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (29 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (52 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (86 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (6 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (7 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (10 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (11 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (14 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (15 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (109 : UInt8), (93 : UInt8), (203 : UInt8), (214 : UInt8), (44 : UInt8), (80 : UInt8), (235 : UInt8), (99 : UInt8), (120 : UInt8), (65 : UInt8), (166 : UInt8), (87 : UInt8), (113 : UInt8), (27 : UInt8), (139 : UInt8), (185 : UInt8), (21 : UInt8), (162 : UInt8), (92 : UInt8), (85 : UInt8), (52 : UInt8), (85 : UInt8), (7 : UInt8), (212 : UInt8), (83 : UInt8), (120 : UInt8), (173 : UInt8), (129 : UInt8), (81 : UInt8), (240 : UInt8), (163 : UInt8), (247 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (47 : UInt8), (100 : UInt8), (101 : UInt8), (112 : UInt8), (115 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (45 : UInt8), (48 : UInt8), (46 : UInt8), (50 : UInt8), (46 : UInt8), (49 : UInt8), (49 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (100 : UInt8), (108 : UInt8), (109 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (62 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (105 : UInt8), (110 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (177 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (9 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (97 : UInt8), (115 : UInt8), (115 : UInt8), (101 : UInt8), (114 : UInt8), (116 : UInt8), (105 : UInt8), (111 : UInt8), (110 : UInt8), (32 : UInt8), (102 : UInt8), (97 : UInt8), (105 : UInt8), (108 : UInt8), (101 : UInt8), (100 : UInt8), (58 : UInt8), (32 : UInt8), (112 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (60 : UInt8), (61 : UInt8), (32 : UInt8), (115 : UInt8), (105 : UInt8), (122 : UInt8), (101 : UInt8), (32 : UInt8), (43 : UInt8), (32 : UInt8), (109 : UInt8), (97 : UInt8), (120 : UInt8), (95 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (104 : UInt8), (101 : UInt8), (97 : UInt8), (100 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (42 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (183 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (13 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (8 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (16 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (3 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (12 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (4 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (17 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (47 : UInt8), (114 : UInt8), (117 : UInt8), (115 : UInt8), (116 : UInt8), (99 : UInt8), (47 : UInt8), (53 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (55 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (101 : UInt8), (49 : UInt8), (102 : UInt8), (97 : UInt8), (50 : UInt8), (53 : UInt8), (52 : UInt8), (48 : UInt8), (55 : UInt8), (50 : UInt8), (52 : UInt8), (98 : UInt8), (102 : UInt8), (98 : UInt8), (97 : UInt8), (99 : UInt8), (49 : UInt8), (52 : UInt8), (100 : UInt8), (55 : UInt8), (57 : UInt8), (55 : UInt8), (54 : UInt8), (100 : UInt8), (55 : UInt8), (101 : UInt8), (52 : UInt8), (97 : UInt8), (51 : UInt8), (56 : UInt8), (54 : UInt8), (48 : UInt8), (47 : UInt8), (108 : UInt8), (105 : UInt8), (98 : UInt8), (114 : UInt8), (97 : UInt8), (114 : UInt8), (121 : UInt8), (47 : UInt8), (97 : UInt8), (108 : UInt8), (108 : UInt8), (111 : UInt8), (99 : UInt8), (47 : UInt8), (115 : UInt8), (114 : UInt8), (99 : UInt8), (47 : UInt8), (114 : UInt8), (97 : UInt8), (119 : UInt8), (95 : UInt8), (118 : UInt8), (101 : UInt8), (99 : UInt8), (47 : UInt8), (109 : UInt8), (111 : UInt8), (100 : UInt8), (46 : UInt8), (114 : UInt8), (115 : UInt8), (0 : UInt8), (99 : UInt8), (97 : UInt8), (112 : UInt8), (97 : UInt8), (99 : UInt8), (105 : UInt8), (116 : UInt8), (121 : UInt8), (32 : UInt8), (111 : UInt8), (118 : UInt8), (101 : UInt8), (114 : UInt8), (102 : UInt8), (108 : UInt8), (111 : UInt8), (119 : UInt8), (0 : UInt8), (0 : UInt8), (216 : UInt8), (1 : UInt8), (16 : UInt8), (0 : UInt8), (80 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (28 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (5 : UInt8), (0 : UInt8), (0 : UInt8), (0 : UInt8), (48 : UInt8), (49 : UInt8), (50 : UInt8), (51 : UInt8), (52 : UInt8), (53 : UInt8), (54 : UInt8), (55 : UInt8), (56 : UInt8), (57 : UInt8), (97 : UInt8), (98 : UInt8), (99 : UInt8), (100 : UInt8), (101 : UInt8), (102 : UInt8), (48 : UInt8), (48 : UInt8), (48 : UInt8), (49 : UInt8), (48 : UInt8), (50 : UInt8), (48 : UInt8), (51 : UInt8), (48 : UInt8), (52 : UInt8), (48 : UInt8), (53 : UInt8), (48 : UInt8), (54 : UInt8), (48 : UInt8), (55 : UInt8), (48 : UInt8), (56 : UInt8), (48 : UInt8), (57 : UInt8), (49 : UInt8), (48 : UInt8), (49 : UInt8), (49 : UInt8), (49 : UInt8), (50 : UInt8), (49 : UInt8), (51 : UInt8), (49 : UInt8), (52 : UInt8), (49 : UInt8), (53 : UInt8), (49 : UInt8), (54 : UInt8), (49 : UInt8), (55 : UInt8), (49 : UInt8), (56 : UInt8), (49 : UInt8), (57 : UInt8), (50 : UInt8), (48 : UInt8), (50 : UInt8), (49 : UInt8), (50 : UInt8), (50 : UInt8), (50 : UInt8), (51 : UInt8), (50 : UInt8), (52 : UInt8), (50 : UInt8), (53 : UInt8), (50 : UInt8), (54 : UInt8), (50 : UInt8), (55 : UInt8), (50 : UInt8), (56 : UInt8), (50 : UInt8), (57 : UInt8), (51 : UInt8), (48 : UInt8), (51 : UInt8), (49 : UInt8), (51 : UInt8), (50 : UInt8), (51 : UInt8), (51 : UInt8), (51 : UInt8), (52 : UInt8), (51 : UInt8), (53 : UInt8), (51 : UInt8), (54 : UInt8), (51 : UInt8), (55 : UInt8), (51 : UInt8), (56 : UInt8), (51 : UInt8), (57 : UInt8), (52 : UInt8), (48 : UInt8), (52 : UInt8), (49 : UInt8), (52 : UInt8), (50 : UInt8), (52 : UInt8), (51 : UInt8), (52 : UInt8), (52 : UInt8), (52 : UInt8), (53 : UInt8), (52 : UInt8), (54 : UInt8), (52 : UInt8), (55 : UInt8), (52 : UInt8), (56 : UInt8), (52 : UInt8), (57 : UInt8), (53 : UInt8), (48 : UInt8), (53 : UInt8), (49 : UInt8), (53 : UInt8), (50 : UInt8), (53 : UInt8), (51 : UInt8), (53 : UInt8), (52 : UInt8), (53 : UInt8), (53 : UInt8), (53 : UInt8), (54 : UInt8), (53 : UInt8), (55 : UInt8), (53 : UInt8), (56 : UInt8), (53 : UInt8), (57 : UInt8), (54 : UInt8), (48 : UInt8), (54 : UInt8), (49 : UInt8), (54 : UInt8), (50 : UInt8), (54 : UInt8), (51 : UInt8), (54 : UInt8), (52 : UInt8), (54 : UInt8), (53 : UInt8), (54 : UInt8), (54 : UInt8), (54 : UInt8), (55 : UInt8), (54 : UInt8), (56 : UInt8), (54 : UInt8), (57 : UInt8), (55 : UInt8), (48 : UInt8), (55 : UInt8), (49 : UInt8), (55 : UInt8), (50 : UInt8), (55 : UInt8), (51 : UInt8), (55 : UInt8), (52 : UInt8), (55 : UInt8), (53 : UInt8), (55 : UInt8), (54 : UInt8), (55 : UInt8), (55 : UInt8), (55 : UInt8), (56 : UInt8), (55 : UInt8), (57 : UInt8), (56 : UInt8), (48 : UInt8), (56 : UInt8), (49 : UInt8), (56 : UInt8), (50 : UInt8), (56 : UInt8), (51 : UInt8), (56 : UInt8), (52 : UInt8), (56 : UInt8), (53 : UInt8), (56 : UInt8), (54 : UInt8), (56 : UInt8), (55 : UInt8), (56 : UInt8), (56 : UInt8), (56 : UInt8), (57 : UInt8), (57 : UInt8), (48 : UInt8), (57 : UInt8), (49 : UInt8), (57 : UInt8), (50 : UInt8), (57 : UInt8), (51 : UInt8), (57 : UInt8), (52 : UInt8), (57 : UInt8), (53 : UInt8), (57 : UInt8), (54 : UInt8), (57 : UInt8), (55 : UInt8), (57 : UInt8), (56 : UInt8), (57 : UInt8), (57 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (100 : UInt8), (101 : UInt8), (32 : UInt8), (98 : UInt8), (121 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (97 : UInt8), (116 : UInt8), (116 : UInt8), (101 : UInt8), (109 : UInt8), (112 : UInt8), (116 : UInt8), (32 : UInt8), (116 : UInt8), (111 : UInt8), (32 : UInt8), (99 : UInt8), (97 : UInt8), (108 : UInt8), (99 : UInt8), (117 : UInt8), (108 : UInt8), (97 : UInt8), (116 : UInt8), (101 : UInt8), (32 : UInt8), (116 : UInt8), (104 : UInt8), (101 : UInt8), (32 : UInt8), (114 : UInt8), (101 : UInt8), (109 : UInt8), (97 : UInt8), (105 : UInt8), (110 : UInt8), (100 : UInt8), (101 : UInt8), (114 : UInt8), (32 : UInt8), (119 : UInt8), (105 : UInt8), (116 : UInt8), (104 : UInt8), (32 : UInt8), (97 : UInt8), (32 : UInt8), (100 : UInt8), (105 : UInt8), (118 : UInt8), (105 : UInt8), (115 : UInt8), (111 : UInt8), (114 : UInt8), (32 : UInt8), (111 : UInt8), (102 : UInt8), (32 : UInt8), (122 : UInt8), (101 : UInt8), (114 : UInt8), (111 : UInt8), (48 : UInt8), (120 : UInt8), (48 : UInt8), (49 : UInt8), (50 : UInt8), (51 : UInt8), (52 : UInt8), (53 : UInt8), (54 : UInt8), (55 : UInt8), (56 : UInt8), (57 : UInt8), (65 : UInt8), (66 : UInt8), (67 : UInt8), (68 : UInt8), (69 : UInt8), (70 : UInt8)] }
   ] },
   globals := [
     { init := .i32 (1048576 : UInt32) },
-    { init := .i32 (1049669 : UInt32) },
-    { init := .i32 (1049680 : UInt32) }
+    { init := .i32 (1049961 : UInt32) },
+    { init := .i32 (1049968 : UInt32) }
   ],
   types := [
     { params := [.i32, .i32], results := [] },
     { params := [.i32, .i32, .i32], results := [.i32] },
     { params := [.i32, .i32], results := [.i32] },
+    { params := [.i64, .i64], results := [.i64] },
+    { params := [.i64, .i64, .i64, .i32], results := [.i64] },
     { params := [.i64, .i64, .i64], results := [.i64] },
     { params := [.i64, .i64, .i64, .i64], results := [.i64] },
-    { params := [.i64, .i64], results := [.i64] },
     { params := [.i64], results := [.i64] },
     { params := [.i64, .i32, .i64], results := [.i64] },
     { params := [.i64, .i32, .i32], results := [.i64] },
@@ -6558,13 +8153,15 @@ def «module» : Wasm.Module :=
     { params := [.i32, .i32, .i32, .i32, .i32], results := [] },
     { params := [.i32], results := [] },
     { params := [.i32, .i32, .i32, .i32, .i32, .i32], results := [] },
-    { params := [.i32], results := [.i32] }
+    { params := [.i32], results := [.i32] },
+    { params := [.i32, .i32, .i32, .i32, .i32, .i32], results := [.i32] },
+    { params := [.i32, .i32, .i32, .i32, .i32], results := [.i32] }
   ],
   tables := [
-    { min := 17, max := some 17, elemType := .funcref }
+    { min := 18, max := some 18, elemType := .funcref }
   ],
   elements := [
-    { tableIdx := some 0, offset := some 1, funcs := [some 49, some 41, some 73, some 72, some 77, some 71, some 70, some 68, some 69, some 42, some 67, some 75, some 74, some 76, some 66, some 65] }
+    { tableIdx := some 0, offset := some 1, funcs := [some 3, some 59, some 51, some 83, some 82, some 87, some 81, some 80, some 78, some 79, some 52, some 77, some 85, some 84, some 86, some 76, some 75] }
   ]
 }
 

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -62,14 +62,14 @@ theorem add_then_mul_correct : AddThenMulSpec := by
 /-! ## sub -/
 @[spec_of "rust-exported" "rust_u64_tests::sub_chain"]
 def SubChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 18 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 30 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a - b - c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.SubChainSpec]
 theorem sub_chain_correct : SubChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func18Def) rfl
-  unfold func18Def func18
+  apply TerminatesWith.of_wp_entry_for (f := func30Def) rfl
+  unfold func30Def func30
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -78,14 +78,14 @@ theorem sub_chain_correct : SubChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::sub_then_add"]
 def SubThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 19 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 31 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a - b) + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.SubThenAddSpec]
 theorem sub_then_add_correct : SubThenAddSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func19Def) rfl
-  unfold func19Def func19
+  apply TerminatesWith.of_wp_entry_for (f := func31Def) rfl
+  unfold func31Def func31
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -95,14 +95,14 @@ theorem sub_then_add_correct : SubThenAddSpec := by
 /-! ## mul -/
 @[spec_of "rust-exported" "rust_u64_tests::mul_chain"]
 def MulChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 6 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 16 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a * b * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.MulChainSpec]
 theorem mul_chain_correct : MulChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func6Def) rfl
-  unfold func6Def func6
+  apply TerminatesWith.of_wp_entry_for (f := func16Def) rfl
+  unfold func16Def func16
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -111,14 +111,14 @@ theorem mul_chain_correct : MulChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::mul_then_add"]
 def MulThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 7 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 17 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a * b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.MulThenAddSpec]
 theorem mul_then_add_correct : MulThenAddSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func7Def) rfl
-  unfold func7Def func7
+  apply TerminatesWith.of_wp_entry_for (f := func17Def) rfl
+  unfold func17Def func17
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -161,14 +161,14 @@ theorem and_then_or_correct : AndThenOrSpec := by
 /-! ## bitor -/
 @[spec_of "rust-exported" "rust_u64_tests::or_chain"]
 def OrChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 10 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 22 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a ||| b ||| c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.OrChainSpec]
 theorem or_chain_correct : OrChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func10Def) rfl
-  unfold func10Def func10
+  apply TerminatesWith.of_wp_entry_for (f := func22Def) rfl
+  unfold func22Def func22
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -177,14 +177,14 @@ theorem or_chain_correct : OrChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::or_then_xor"]
 def OrThenXorSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 11 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 23 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a ||| b) ^^^ c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.OrThenXorSpec]
 theorem or_then_xor_correct : OrThenXorSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func11Def) rfl
-  unfold func11Def func11
+  apply TerminatesWith.of_wp_entry_for (f := func23Def) rfl
+  unfold func23Def func23
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -194,14 +194,14 @@ theorem or_then_xor_correct : OrThenXorSpec := by
 /-! ## bitxor -/
 @[spec_of "rust-exported" "rust_u64_tests::xor_chain"]
 def XorChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 20 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 32 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a ^^^ b ^^^ c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.XorChainSpec]
 theorem xor_chain_correct : XorChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func20Def) rfl
-  unfold func20Def func20
+  apply TerminatesWith.of_wp_entry_for (f := func32Def) rfl
+  unfold func32Def func32
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -210,14 +210,14 @@ theorem xor_chain_correct : XorChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::xor_then_and"]
 def XorThenAndSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 21 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 33 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a ^^^ b) &&& c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.XorThenAndSpec]
 theorem xor_then_and_correct : XorThenAndSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func21Def) rfl
-  unfold func21Def func21
+  apply TerminatesWith.of_wp_entry_for (f := func33Def) rfl
+  unfold func33Def func33
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -227,14 +227,14 @@ theorem xor_then_and_correct : XorThenAndSpec := by
 /-! ## not -/
 @[spec_of "rust-exported" "rust_u64_tests::not_twice"]
 def NotTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64),
-  TerminatesWith env «module» 9 «module».initialStore [.i64 a]
+  TerminatesWith env «module» 21 «module».initialStore [.i64 a]
     (fun _ rs => rs = [.i64 (~~~(~~~a))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NotTwiceSpec]
 theorem not_twice_correct : NotTwiceSpec := by
   intro env a
-  apply TerminatesWith.of_wp_entry_for (f := func9Def) rfl
-  unfold func9Def func9
+  apply TerminatesWith.of_wp_entry_for (f := func21Def) rfl
+  unfold func21Def func21
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -243,14 +243,14 @@ theorem not_twice_correct : NotTwiceSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::not_then_xor"]
 def NotThenXorSpec : Prop := ∀ (env : HostEnv Unit) (a b : UInt64),
-  TerminatesWith env «module» 8 «module».initialStore [.i64 b, .i64 a]
+  TerminatesWith env «module» 20 «module».initialStore [.i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((~~~a) ^^^ b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NotThenXorSpec]
 theorem not_then_xor_correct : NotThenXorSpec := by
   intro env a b
-  apply TerminatesWith.of_wp_entry_for (f := func8Def) rfl
-  unfold func8Def func8
+  apply TerminatesWith.of_wp_entry_for (f := func20Def) rfl
+  unfold func20Def func20
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -307,14 +307,14 @@ theorem div_then_mul_correct : DivThenMulSpec := by
 /-! ## rem (divisor nonzero) -/
 @[spec_of "rust-exported" "rust_u64_tests::rem_then_add"]
 def RemThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 12 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 24 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a % b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.RemThenAddSpec]
 theorem rem_then_add_correct : RemThenAddSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func12Def) rfl
-  unfold func12Def func12
+  apply TerminatesWith.of_wp_entry_for (f := func24Def) rfl
+  unfold func24Def func24
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -330,14 +330,14 @@ theorem rem_then_add_correct : RemThenAddSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::rem_then_mul"]
 def RemThenMulSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 13 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 25 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a % b * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.RemThenMulSpec]
 theorem rem_then_mul_correct : RemThenMulSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func13Def) rfl
-  unfold func13Def func13
+  apply TerminatesWith.of_wp_entry_for (f := func25Def) rfl
+  unfold func25Def func25
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -354,14 +354,14 @@ theorem rem_then_mul_correct : RemThenMulSpec := by
 /-! ## shl / shr — width-specific mask-extend-shift (reusable theorem: `U64.shlBodyWp`) -/
 @[spec_of "rust-exported" "rust_u64_tests::shl_then_add"]
 def ShlThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
-  TerminatesWith env «module» 14 «module».initialStore [.i64 b, .i32 n, .i64 a]
+  TerminatesWith env «module» 26 «module».initialStore [.i64 b, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a <<< (n.toUInt64 % 64)) + b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShlThenAddSpec]
 theorem shl_then_add_correct : ShlThenAddSpec := by
   intro env a n b
-  apply TerminatesWith.of_wp_entry_for (f := func14Def) rfl
-  unfold func14Def func14
+  apply TerminatesWith.of_wp_entry_for (f := func26Def) rfl
+  unfold func26Def func26
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -370,14 +370,14 @@ theorem shl_then_add_correct : ShlThenAddSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shl_twice"]
 def ShlTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
-  TerminatesWith env «module» 15 «module».initialStore [.i32 m, .i32 n, .i64 a]
+  TerminatesWith env «module» 27 «module».initialStore [.i32 m, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a <<< (n.toUInt64 % 64)) <<< (m.toUInt64 % 64))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShlTwiceSpec]
 theorem shl_twice_correct : ShlTwiceSpec := by
   intro env a n m
-  apply TerminatesWith.of_wp_entry_for (f := func15Def) rfl
-  unfold func15Def func15
+  apply TerminatesWith.of_wp_entry_for (f := func27Def) rfl
+  unfold func27Def func27
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -386,14 +386,14 @@ theorem shl_twice_correct : ShlTwiceSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_then_sub"]
 def ShrThenSubSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
-  TerminatesWith env «module» 16 «module».initialStore [.i64 b, .i32 n, .i64 a]
+  TerminatesWith env «module» 28 «module».initialStore [.i64 b, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a >>> (n.toUInt64 % 64)) - b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShrThenSubSpec]
 theorem shr_then_sub_correct : ShrThenSubSpec := by
   intro env a n b
-  apply TerminatesWith.of_wp_entry_for (f := func16Def) rfl
-  unfold func16Def func16
+  apply TerminatesWith.of_wp_entry_for (f := func28Def) rfl
+  unfold func28Def func28
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -402,18 +402,54 @@ theorem shr_then_sub_correct : ShrThenSubSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_twice"]
 def ShrTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
-  TerminatesWith env «module» 17 «module».initialStore [.i32 m, .i32 n, .i64 a]
+  TerminatesWith env «module» 29 «module».initialStore [.i32 m, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a >>> (n.toUInt64 % 64)) >>> (m.toUInt64 % 64))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShrTwiceSpec]
 theorem shr_twice_correct : ShrTwiceSpec := by
   intro env a n m
-  apply TerminatesWith.of_wp_entry_for (f := func17Def) rfl
-  unfold func17Def func17
+  apply TerminatesWith.of_wp_entry_for (f := func29Def) rfl
+  unfold func29Def func29
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, shr_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
     and_true, List.append_nil]
+
+/-! ## eq — `(a == b) as u64` reuses the masked chunk `eq_seq` inline (the op's own
+atomic `wp_eqI64_cons` is excluded from the `simp` set, so the proof is forced
+through `eq_seq`; the trailing arithmetic reuses `add_seq`). -/
+@[spec_of "rust-exported" "rust_u64_tests::eq_u64"]
+def EqU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 7 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a = b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.EqU64Spec]
+theorem eq_u64_correct : EqU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func7Def) rfl
+  unfold func7Def func7
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, eq_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::eq_two"]
+def EqTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 6 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a = b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c = d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.EqTwoSpec]
+theorem eq_two_correct : EqTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func6Def) rfl
+  unfold func6Def func6
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, eq_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
 
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -554,4 +554,38 @@ theorem le_two_correct : LeTwoSpec := by
     List.drop, le_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
 
+/-! ## gt — `(a > b) as u64` reuses `gt_seq` inline (`wp_gtUI64_cons` excluded). -/
+@[spec_of "rust-exported" "rust_u64_tests::gt_u64"]
+def GtU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 11 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a > b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.GtU64Spec]
+theorem gt_u64_correct : GtU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func11Def) rfl
+  unfold func11Def func11
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, gt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::gt_two"]
+def GtTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 10 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a > b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c > d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.GtTwoSpec]
+theorem gt_two_correct : GtTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func10Def) rfl
+  unfold func10Def func10
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, gt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -588,4 +588,38 @@ theorem gt_two_correct : GtTwoSpec := by
     List.drop, gt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
 
+/-! ## ge — `(a >= b) as u64` reuses `ge_seq` inline (`wp_geUI64_cons` excluded). -/
+@[spec_of "rust-exported" "rust_u64_tests::ge_u64"]
+def GeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 9 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≥ b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.GeU64Spec]
+theorem ge_u64_correct : GeU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func9Def) rfl
+  unfold func9Def func9
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, ge_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::ge_two"]
+def GeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 8 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≥ b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c ≥ d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.GeTwoSpec]
+theorem ge_two_correct : GeTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func8Def) rfl
+  unfold func8Def func8
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, ge_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -486,4 +486,38 @@ theorem ne_two_correct : NeTwoSpec := by
     List.drop, ne_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
 
+/-! ## lt — `(a < b) as u64` reuses `lt_seq` inline (`wp_ltUI64_cons` excluded). -/
+@[spec_of "rust-exported" "rust_u64_tests::lt_u64"]
+def LtU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 15 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a < b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.LtU64Spec]
+theorem lt_u64_correct : LtU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func15Def) rfl
+  unfold func15Def func15
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, lt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::lt_two"]
+def LtTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 14 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a < b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c < d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.LtTwoSpec]
+theorem lt_two_correct : LtTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func14Def) rfl
+  unfold func14Def func14
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, lt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -520,4 +520,38 @@ theorem lt_two_correct : LtTwoSpec := by
     List.drop, lt_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
 
+/-! ## le — `(a <= b) as u64` reuses `le_seq` inline (`wp_leUI64_cons` excluded). -/
+@[spec_of "rust-exported" "rust_u64_tests::le_u64"]
+def LeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 13 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≤ b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.LeU64Spec]
+theorem le_u64_correct : LeU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func13Def) rfl
+  unfold func13Def func13
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, le_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::le_two"]
+def LeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 12 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≤ b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c ≤ d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.LeTwoSpec]
+theorem le_two_correct : LeTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func12Def) rfl
+  unfold func12Def func12
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, le_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -1,4 +1,5 @@
 import Project.RustU64Tests.Program
+import Interpreter.Wasm.Wp.Call
 
 /-!
 # Reuse tests for the `CodeLib/RustStd/U64` corpus
@@ -29,14 +30,14 @@ open Wasm Wasm.RustStd Wasm.RustStd.U64
 /-! ## add -/
 @[spec_of "rust-exported" "rust_u64_tests::add_chain"]
 def AddChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 0 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 4 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a + b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.AddChainSpec]
 theorem add_chain_correct : AddChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func0Def) rfl
-  unfold func0Def func0
+  apply TerminatesWith.of_wp_entry_for (f := func4Def) rfl
+  unfold func4Def func4
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -45,14 +46,14 @@ theorem add_chain_correct : AddChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::add_then_mul"]
 def AddThenMulSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 1 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 5 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a + b) * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.AddThenMulSpec]
 theorem add_then_mul_correct : AddThenMulSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func1Def) rfl
-  unfold func1Def func1
+  apply TerminatesWith.of_wp_entry_for (f := func5Def) rfl
+  unfold func5Def func5
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -62,14 +63,14 @@ theorem add_then_mul_correct : AddThenMulSpec := by
 /-! ## sub -/
 @[spec_of "rust-exported" "rust_u64_tests::sub_chain"]
 def SubChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 30 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 40 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a - b - c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.SubChainSpec]
 theorem sub_chain_correct : SubChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func30Def) rfl
-  unfold func30Def func30
+  apply TerminatesWith.of_wp_entry_for (f := func40Def) rfl
+  unfold func40Def func40
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -78,14 +79,14 @@ theorem sub_chain_correct : SubChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::sub_then_add"]
 def SubThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 31 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 41 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a - b) + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.SubThenAddSpec]
 theorem sub_then_add_correct : SubThenAddSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func31Def) rfl
-  unfold func31Def func31
+  apply TerminatesWith.of_wp_entry_for (f := func41Def) rfl
+  unfold func41Def func41
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -95,14 +96,14 @@ theorem sub_then_add_correct : SubThenAddSpec := by
 /-! ## mul -/
 @[spec_of "rust-exported" "rust_u64_tests::mul_chain"]
 def MulChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 16 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 26 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a * b * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.MulChainSpec]
 theorem mul_chain_correct : MulChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func16Def) rfl
-  unfold func16Def func16
+  apply TerminatesWith.of_wp_entry_for (f := func26Def) rfl
+  unfold func26Def func26
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -111,14 +112,14 @@ theorem mul_chain_correct : MulChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::mul_then_add"]
 def MulThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 17 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 27 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a * b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.MulThenAddSpec]
 theorem mul_then_add_correct : MulThenAddSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func17Def) rfl
-  unfold func17Def func17
+  apply TerminatesWith.of_wp_entry_for (f := func27Def) rfl
+  unfold func27Def func27
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -128,14 +129,14 @@ theorem mul_then_add_correct : MulThenAddSpec := by
 /-! ## bitand -/
 @[spec_of "rust-exported" "rust_u64_tests::and_chain"]
 def AndChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 2 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 6 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a &&& b &&& c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.AndChainSpec]
 theorem and_chain_correct : AndChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func2Def) rfl
-  unfold func2Def func2
+  apply TerminatesWith.of_wp_entry_for (f := func6Def) rfl
+  unfold func6Def func6
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -144,14 +145,14 @@ theorem and_chain_correct : AndChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::and_then_or"]
 def AndThenOrSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 3 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 7 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a &&& b) ||| c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.AndThenOrSpec]
 theorem and_then_or_correct : AndThenOrSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func3Def) rfl
-  unfold func3Def func3
+  apply TerminatesWith.of_wp_entry_for (f := func7Def) rfl
+  unfold func7Def func7
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -161,14 +162,14 @@ theorem and_then_or_correct : AndThenOrSpec := by
 /-! ## bitor -/
 @[spec_of "rust-exported" "rust_u64_tests::or_chain"]
 def OrChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 22 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 32 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a ||| b ||| c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.OrChainSpec]
 theorem or_chain_correct : OrChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func22Def) rfl
-  unfold func22Def func22
+  apply TerminatesWith.of_wp_entry_for (f := func32Def) rfl
+  unfold func32Def func32
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -177,14 +178,14 @@ theorem or_chain_correct : OrChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::or_then_xor"]
 def OrThenXorSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 23 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 33 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a ||| b) ^^^ c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.OrThenXorSpec]
 theorem or_then_xor_correct : OrThenXorSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func23Def) rfl
-  unfold func23Def func23
+  apply TerminatesWith.of_wp_entry_for (f := func33Def) rfl
+  unfold func33Def func33
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -194,14 +195,14 @@ theorem or_then_xor_correct : OrThenXorSpec := by
 /-! ## bitxor -/
 @[spec_of "rust-exported" "rust_u64_tests::xor_chain"]
 def XorChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 32 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 42 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a ^^^ b ^^^ c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.XorChainSpec]
 theorem xor_chain_correct : XorChainSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func32Def) rfl
-  unfold func32Def func32
+  apply TerminatesWith.of_wp_entry_for (f := func42Def) rfl
+  unfold func42Def func42
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -210,14 +211,14 @@ theorem xor_chain_correct : XorChainSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::xor_then_and"]
 def XorThenAndSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 33 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 43 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((a ^^^ b) &&& c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.XorThenAndSpec]
 theorem xor_then_and_correct : XorThenAndSpec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func33Def) rfl
-  unfold func33Def func33
+  apply TerminatesWith.of_wp_entry_for (f := func43Def) rfl
+  unfold func43Def func43
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -227,14 +228,14 @@ theorem xor_then_and_correct : XorThenAndSpec := by
 /-! ## not -/
 @[spec_of "rust-exported" "rust_u64_tests::not_twice"]
 def NotTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64),
-  TerminatesWith env «module» 21 «module».initialStore [.i64 a]
+  TerminatesWith env «module» 31 «module».initialStore [.i64 a]
     (fun _ rs => rs = [.i64 (~~~(~~~a))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NotTwiceSpec]
 theorem not_twice_correct : NotTwiceSpec := by
   intro env a
-  apply TerminatesWith.of_wp_entry_for (f := func21Def) rfl
-  unfold func21Def func21
+  apply TerminatesWith.of_wp_entry_for (f := func31Def) rfl
+  unfold func31Def func31
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -243,14 +244,14 @@ theorem not_twice_correct : NotTwiceSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::not_then_xor"]
 def NotThenXorSpec : Prop := ∀ (env : HostEnv Unit) (a b : UInt64),
-  TerminatesWith env «module» 20 «module».initialStore [.i64 b, .i64 a]
+  TerminatesWith env «module» 30 «module».initialStore [.i64 b, .i64 a]
     (fun _ rs => rs = [.i64 ((~~~a) ^^^ b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NotThenXorSpec]
 theorem not_then_xor_correct : NotThenXorSpec := by
   intro env a b
-  apply TerminatesWith.of_wp_entry_for (f := func20Def) rfl
-  unfold func20Def func20
+  apply TerminatesWith.of_wp_entry_for (f := func30Def) rfl
+  unfold func30Def func30
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -260,14 +261,14 @@ theorem not_then_xor_correct : NotThenXorSpec := by
 /-! ## div (divisor nonzero) — peel the guard, then reuse `div_chunk` -/
 @[spec_of "rust-exported" "rust_u64_tests::div_then_add"]
 def DivThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 4 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 10 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a / b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.DivThenAddSpec]
 theorem div_then_add_correct : DivThenAddSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func4Def) rfl
-  unfold func4Def func4
+  apply TerminatesWith.of_wp_entry_for (f := func10Def) rfl
+  unfold func10Def func10
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -283,14 +284,14 @@ theorem div_then_add_correct : DivThenAddSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::div_then_mul"]
 def DivThenMulSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 5 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 11 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a / b * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.DivThenMulSpec]
 theorem div_then_mul_correct : DivThenMulSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func5Def) rfl
-  unfold func5Def func5
+  apply TerminatesWith.of_wp_entry_for (f := func11Def) rfl
+  unfold func11Def func11
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -307,14 +308,14 @@ theorem div_then_mul_correct : DivThenMulSpec := by
 /-! ## rem (divisor nonzero) -/
 @[spec_of "rust-exported" "rust_u64_tests::rem_then_add"]
 def RemThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 24 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 34 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a % b + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.RemThenAddSpec]
 theorem rem_then_add_correct : RemThenAddSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func24Def) rfl
-  unfold func24Def func24
+  apply TerminatesWith.of_wp_entry_for (f := func34Def) rfl
+  unfold func34Def func34
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -330,14 +331,14 @@ theorem rem_then_add_correct : RemThenAddSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::rem_then_mul"]
 def RemThenMulSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
-  TerminatesWith env «module» 25 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 35 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (a % b * c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.RemThenMulSpec]
 theorem rem_then_mul_correct : RemThenMulSpec := by
   intro env a b c hb
-  apply TerminatesWith.of_wp_entry_for (f := func25Def) rfl
-  unfold func25Def func25
+  apply TerminatesWith.of_wp_entry_for (f := func35Def) rfl
+  unfold func35Def func35
   apply wp_block_cons
   have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
@@ -354,14 +355,14 @@ theorem rem_then_mul_correct : RemThenMulSpec := by
 /-! ## shl / shr — width-specific mask-extend-shift (reusable theorem: `U64.shlBodyWp`) -/
 @[spec_of "rust-exported" "rust_u64_tests::shl_then_add"]
 def ShlThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
-  TerminatesWith env «module» 26 «module».initialStore [.i64 b, .i32 n, .i64 a]
+  TerminatesWith env «module» 36 «module».initialStore [.i64 b, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a <<< (n.toUInt64 % 64)) + b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShlThenAddSpec]
 theorem shl_then_add_correct : ShlThenAddSpec := by
   intro env a n b
-  apply TerminatesWith.of_wp_entry_for (f := func26Def) rfl
-  unfold func26Def func26
+  apply TerminatesWith.of_wp_entry_for (f := func36Def) rfl
+  unfold func36Def func36
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -370,14 +371,14 @@ theorem shl_then_add_correct : ShlThenAddSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shl_twice"]
 def ShlTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
-  TerminatesWith env «module» 27 «module».initialStore [.i32 m, .i32 n, .i64 a]
+  TerminatesWith env «module» 37 «module».initialStore [.i32 m, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a <<< (n.toUInt64 % 64)) <<< (m.toUInt64 % 64))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShlTwiceSpec]
 theorem shl_twice_correct : ShlTwiceSpec := by
   intro env a n m
-  apply TerminatesWith.of_wp_entry_for (f := func27Def) rfl
-  unfold func27Def func27
+  apply TerminatesWith.of_wp_entry_for (f := func37Def) rfl
+  unfold func37Def func37
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -386,14 +387,14 @@ theorem shl_twice_correct : ShlTwiceSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_then_sub"]
 def ShrThenSubSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
-  TerminatesWith env «module» 28 «module».initialStore [.i64 b, .i32 n, .i64 a]
+  TerminatesWith env «module» 38 «module».initialStore [.i64 b, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a >>> (n.toUInt64 % 64)) - b)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShrThenSubSpec]
 theorem shr_then_sub_correct : ShrThenSubSpec := by
   intro env a n b
-  apply TerminatesWith.of_wp_entry_for (f := func28Def) rfl
-  unfold func28Def func28
+  apply TerminatesWith.of_wp_entry_for (f := func38Def) rfl
+  unfold func38Def func38
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -402,14 +403,14 @@ theorem shr_then_sub_correct : ShrThenSubSpec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_twice"]
 def ShrTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
-  TerminatesWith env «module» 29 «module».initialStore [.i32 m, .i32 n, .i64 a]
+  TerminatesWith env «module» 39 «module».initialStore [.i32 m, .i32 n, .i64 a]
     (fun _ rs => rs = [.i64 ((a >>> (n.toUInt64 % 64)) >>> (m.toUInt64 % 64))])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.ShrTwiceSpec]
 theorem shr_twice_correct : ShrTwiceSpec := by
   intro env a n m
-  apply TerminatesWith.of_wp_entry_for (f := func29Def) rfl
-  unfold func29Def func29
+  apply TerminatesWith.of_wp_entry_for (f := func39Def) rfl
+  unfold func39Def func39
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -421,14 +422,14 @@ atomic `wp_eqI64_cons` is excluded from the `simp` set, so the proof is forced
 through `eq_seq`; the trailing arithmetic reuses `add_seq`). -/
 @[spec_of "rust-exported" "rust_u64_tests::eq_u64"]
 def EqU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 7 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 13 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a = b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.EqU64Spec]
 theorem eq_u64_correct : EqU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func7Def) rfl
-  unfold func7Def func7
+  apply TerminatesWith.of_wp_entry_for (f := func13Def) rfl
+  unfold func13Def func13
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -437,15 +438,15 @@ theorem eq_u64_correct : EqU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::eq_two"]
 def EqTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 6 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 12 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a = b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c = d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.EqTwoSpec]
 theorem eq_two_correct : EqTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func6Def) rfl
-  unfold func6Def func6
+  apply TerminatesWith.of_wp_entry_for (f := func12Def) rfl
+  unfold func12Def func12
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -455,14 +456,14 @@ theorem eq_two_correct : EqTwoSpec := by
 /-! ## ne — `(a != b) as u64` reuses `ne_seq` inline (`wp_neI64_cons` excluded). -/
 @[spec_of "rust-exported" "rust_u64_tests::ne_u64"]
 def NeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 19 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 29 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≠ b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NeU64Spec]
 theorem ne_u64_correct : NeU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func19Def) rfl
-  unfold func19Def func19
+  apply TerminatesWith.of_wp_entry_for (f := func29Def) rfl
+  unfold func29Def func29
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -471,15 +472,15 @@ theorem ne_u64_correct : NeU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::ne_two"]
 def NeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 18 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 28 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≠ b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c ≠ d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.NeTwoSpec]
 theorem ne_two_correct : NeTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func18Def) rfl
-  unfold func18Def func18
+  apply TerminatesWith.of_wp_entry_for (f := func28Def) rfl
+  unfold func28Def func28
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -489,14 +490,14 @@ theorem ne_two_correct : NeTwoSpec := by
 /-! ## lt — `(a < b) as u64` reuses `lt_seq` inline (`wp_ltUI64_cons` excluded). -/
 @[spec_of "rust-exported" "rust_u64_tests::lt_u64"]
 def LtU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 15 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 21 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a < b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.LtU64Spec]
 theorem lt_u64_correct : LtU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func15Def) rfl
-  unfold func15Def func15
+  apply TerminatesWith.of_wp_entry_for (f := func21Def) rfl
+  unfold func21Def func21
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -505,15 +506,15 @@ theorem lt_u64_correct : LtU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::lt_two"]
 def LtTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 14 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 20 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a < b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c < d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.LtTwoSpec]
 theorem lt_two_correct : LtTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func14Def) rfl
-  unfold func14Def func14
+  apply TerminatesWith.of_wp_entry_for (f := func20Def) rfl
+  unfold func20Def func20
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -523,14 +524,14 @@ theorem lt_two_correct : LtTwoSpec := by
 /-! ## le — `(a <= b) as u64` reuses `le_seq` inline (`wp_leUI64_cons` excluded). -/
 @[spec_of "rust-exported" "rust_u64_tests::le_u64"]
 def LeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 13 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 19 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≤ b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.LeU64Spec]
 theorem le_u64_correct : LeU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func13Def) rfl
-  unfold func13Def func13
+  apply TerminatesWith.of_wp_entry_for (f := func19Def) rfl
+  unfold func19Def func19
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -539,15 +540,15 @@ theorem le_u64_correct : LeU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::le_two"]
 def LeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 12 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 18 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≤ b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c ≤ d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.LeTwoSpec]
 theorem le_two_correct : LeTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func12Def) rfl
-  unfold func12Def func12
+  apply TerminatesWith.of_wp_entry_for (f := func18Def) rfl
+  unfold func18Def func18
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -557,14 +558,14 @@ theorem le_two_correct : LeTwoSpec := by
 /-! ## gt — `(a > b) as u64` reuses `gt_seq` inline (`wp_gtUI64_cons` excluded). -/
 @[spec_of "rust-exported" "rust_u64_tests::gt_u64"]
 def GtU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 11 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 17 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a > b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.GtU64Spec]
 theorem gt_u64_correct : GtU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func11Def) rfl
-  unfold func11Def func11
+  apply TerminatesWith.of_wp_entry_for (f := func17Def) rfl
+  unfold func17Def func17
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -573,15 +574,15 @@ theorem gt_u64_correct : GtU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::gt_two"]
 def GtTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 10 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 16 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a > b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c > d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.GtTwoSpec]
 theorem gt_two_correct : GtTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func10Def) rfl
-  unfold func10Def func10
+  apply TerminatesWith.of_wp_entry_for (f := func16Def) rfl
+  unfold func16Def func16
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -591,14 +592,14 @@ theorem gt_two_correct : GtTwoSpec := by
 /-! ## ge — `(a >= b) as u64` reuses `ge_seq` inline (`wp_geUI64_cons` excluded). -/
 @[spec_of "rust-exported" "rust_u64_tests::ge_u64"]
 def GeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
-  TerminatesWith env «module» 9 «module».initialStore [.i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 15 «module».initialStore [.i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≥ b then (1 : UInt32) else 0).toNat + c)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.GeU64Spec]
 theorem ge_u64_correct : GeU64Spec := by
   intro env a b c
-  apply TerminatesWith.of_wp_entry_for (f := func9Def) rfl
-  unfold func9Def func9
+  apply TerminatesWith.of_wp_entry_for (f := func15Def) rfl
+  unfold func15Def func15
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -607,19 +608,173 @@ theorem ge_u64_correct : GeU64Spec := by
 
 @[spec_of "rust-exported" "rust_u64_tests::ge_two"]
 def GeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
-  TerminatesWith env «module» 8 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+  TerminatesWith env «module» 14 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
     (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≥ b then (1 : UInt32) else 0).toNat
                           + UInt64.ofNat (if c ≥ d then (1 : UInt32) else 0).toNat)])
 set_option maxRecDepth 4096 in
 @[proves Project.RustU64Tests.Spec.GeTwoSpec]
 theorem ge_two_correct : GeTwoSpec := by
   intro env a b c d
-  apply TerminatesWith.of_wp_entry_for (f := func8Def) rfl
-  unfold func8Def func8
+  apply TerminatesWith.of_wp_entry_for (f := func14Def) rfl
+  unfold func14Def func14
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, ge_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
+
+/-! ## Ord: min / max / clamp — call-reuse tests. `a.min/max/clamp(..)` compiles to
+a `call` to the framed inner fn, so each test reuses the CodeLib body theorem
+(`max_wp`/`min_wp`/`clamp_wp`) across the `call` via `wp_call_tw` — exactly like
+`total_variation` reuses `absDiff_wp`. The inner fns sit at test-`«module»` 0/1/2. -/
+
+private theorem tmax_call {env : HostEnv Unit} (st : Store Unit) (a b : UInt64) (rest : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 1048576)) (hhi : 1048576 ≤ st.mem.pages * 65536) :
+    TerminatesWith env «module» 0 st (.i64 b :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if b < a then a else b) :: rest
+        ∧ st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := maxFunc)
+    (rs := [.i64 (if b < a then a else b)]) rfl rfl
+    (max_wp st 1048576 a b [] hsp (by decide) hhi) rfl
+
+private theorem tmin_call {env : HostEnv Unit} (st : Store Unit) (a b : UInt64) (rest : List Value)
+    (hsp : st.globals.globals[0]? = some (.i32 1048576)) (hhi : 1048576 ≤ st.mem.pages * 65536) :
+    TerminatesWith env «module» 1 st (.i64 b :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if b < a then b else a) :: rest
+        ∧ st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := minFunc)
+    (rs := [.i64 (if b < a then b else a)]) rfl rfl
+    (min_wp st 1048576 a b [] hsp (by decide) hhi) rfl
+
+private theorem tclamp_call {env : HostEnv Unit} (st : Store Unit) (a lo hi : UInt64) (loc : UInt32)
+    (rest : List Value) (hsp : st.globals.globals[0]? = some (.i32 1048576))
+    (hhi : 1048576 ≤ st.mem.pages * 65536) (hlohi : lo ≤ hi) :
+    TerminatesWith env «module» 2 st (.i32 loc :: .i64 hi :: .i64 lo :: .i64 a :: rest)
+      (fun st' vs => vs = .i64 (if a < lo then lo else if a > hi then hi else a) :: rest
+        ∧ st'.mem.pages = st.mem.pages) :=
+  TerminatesWith.of_returns_wp (f := clampFunc 93)
+    (rs := [.i64 (if a < lo then lo else if a > hi then hi else a)]) rfl rfl
+    (clamp_wp st 93 1048576 a lo hi loc [] hsp (by decide) hhi hlohi) rfl
+
+/-! ## max -/
+@[spec_of "rust-exported" "rust_u64_tests::max_add"]
+def MaxAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 22 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 ((if b < a then a else b) + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.MaxAddSpec]
+theorem max_add_correct : MaxAddSpec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func22Def) rfl
+  unfold func22Def func22
+  wp_run
+  apply wp_call_tw (tmax_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
+
+@[spec_of "rust-exported" "rust_u64_tests::max_chain"]
+def MaxChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 23 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (if c < (if b < a then a else b) then (if b < a then a else b) else c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.MaxChainSpec]
+theorem max_chain_correct : MaxChainSpec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func23Def) rfl
+  unfold func23Def func23
+  wp_run
+  apply wp_call_tw (tmax_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, hg1, hp1⟩ := h1
+  subst hvs1
+  wp_run
+  apply wp_call_tw (tmax_call st1 (if b < a then a else b) c [] (by rw [hg1]; rfl) (by rw [hp1]; decide))
+  intro st2 vs2 h2
+  obtain ⟨hvs2, _, _⟩ := h2
+  subst hvs2
+  wp_run
+  simp
+
+/-! ## min -/
+@[spec_of "rust-exported" "rust_u64_tests::min_add"]
+def MinAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 24 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 ((if b < a then b else a) + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.MinAddSpec]
+theorem min_add_correct : MinAddSpec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func24Def) rfl
+  unfold func24Def func24
+  wp_run
+  apply wp_call_tw (tmin_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
+
+@[spec_of "rust-exported" "rust_u64_tests::min_chain"]
+def MinChainSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 25 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (if c < (if b < a then b else a) then c else (if b < a then b else a))])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.MinChainSpec]
+theorem min_chain_correct : MinChainSpec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func25Def) rfl
+  unfold func25Def func25
+  wp_run
+  apply wp_call_tw (tmin_call «module».initialStore a b [] rfl (by decide))
+  intro st1 vs1 h1
+  obtain ⟨hvs1, hg1, hp1⟩ := h1
+  subst hvs1
+  wp_run
+  apply wp_call_tw (tmin_call st1 (if b < a then b else a) c [] (by rw [hg1]; rfl) (by rw [hp1]; decide))
+  intro st2 vs2 h2
+  obtain ⟨hvs2, _, _⟩ := h2
+  subst hvs2
+  wp_run
+  simp
+
+/-! ## clamp (precondition `lo ≤ hi`) -/
+@[spec_of "rust-exported" "rust_u64_tests::clamp_add"]
+def ClampAddSpec : Prop := ∀ (env : HostEnv Unit) (a lo hi c : UInt64), lo ≤ hi →
+  TerminatesWith env «module» 8 «module».initialStore [.i64 c, .i64 hi, .i64 lo, .i64 a]
+    (fun _ rs => rs = [.i64 ((if a < lo then lo else if a > hi then hi else a) + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.ClampAddSpec]
+theorem clamp_add_correct : ClampAddSpec := by
+  intro env a lo hi c hlohi
+  apply TerminatesWith.of_wp_entry_for (f := func8Def) rfl
+  unfold func8Def func8
+  wp_run
+  apply wp_call_tw (tclamp_call «module».initialStore a lo hi 1048636 [] rfl (by decide) hlohi)
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
+
+@[spec_of "rust-exported" "rust_u64_tests::clamp_mul"]
+def ClampMulSpec : Prop := ∀ (env : HostEnv Unit) (a lo hi c : UInt64), lo ≤ hi →
+  TerminatesWith env «module» 9 «module».initialStore [.i64 c, .i64 hi, .i64 lo, .i64 a]
+    (fun _ rs => rs = [.i64 ((if a < lo then lo else if a > hi then hi else a) * c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.ClampMulSpec]
+theorem clamp_mul_correct : ClampMulSpec := by
+  intro env a lo hi c hlohi
+  apply TerminatesWith.of_wp_entry_for (f := func9Def) rfl
+  unfold func9Def func9
+  wp_run
+  apply wp_call_tw (tclamp_call «module».initialStore a lo hi 1048652 [] rfl (by decide) hlohi)
+  intro st1 vs1 h1
+  obtain ⟨hvs1, _⟩ := h1
+  subst hvs1
+  wp_run
+  simp
 
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -452,4 +452,38 @@ theorem eq_two_correct : EqTwoSpec := by
     List.drop, eq_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
     List.cons.injEq, and_true, List.append_nil]
 
+/-! ## ne — `(a != b) as u64` reuses `ne_seq` inline (`wp_neI64_cons` excluded). -/
+@[spec_of "rust-exported" "rust_u64_tests::ne_u64"]
+def NeU64Spec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64),
+  TerminatesWith env «module» 19 «module».initialStore [.i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≠ b then (1 : UInt32) else 0).toNat + c)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.NeU64Spec]
+theorem ne_u64_correct : NeU64Spec := by
+  intro env a b c
+  apply TerminatesWith.of_wp_entry_for (f := func19Def) rfl
+  unfold func19Def func19
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, ne_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
+@[spec_of "rust-exported" "rust_u64_tests::ne_two"]
+def NeTwoSpec : Prop := ∀ (env : HostEnv Unit) (a b c d : UInt64),
+  TerminatesWith env «module» 18 «module».initialStore [.i64 d, .i64 c, .i64 b, .i64 a]
+    (fun _ rs => rs = [.i64 (UInt64.ofNat (if a ≠ b then (1 : UInt32) else 0).toNat
+                          + UInt64.ofNat (if c ≠ d then (1 : UInt32) else 0).toNat)])
+set_option maxRecDepth 4096 in
+@[proves Project.RustU64Tests.Spec.NeTwoSpec]
+theorem ne_two_correct : NeTwoSpec := by
+  intro env a b c d
+  apply TerminatesWith.of_wp_entry_for (f := func18Def) rfl
+  unfold func18Def func18
+  simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
+    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
+    List.drop, ne_seq, wp_extendUI32_cons, add_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
+
 end Project.RustU64Tests.Spec

--- a/programs/rust/rust_u64/src/exports.rs
+++ b/programs/rust/rust_u64/src/exports.rs
@@ -63,6 +63,37 @@ pub extern "C" fn shr(a: u64, b: u32) -> u64 {
     a >> b
 }
 
+// ── Comparisons (eq .. ge) ─────────────────────────────────────────────────
+#[unsafe(no_mangle)]
+pub extern "C" fn eq(a: u64, b: u64) -> bool {
+    a == b
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn ne(a: u64, b: u64) -> bool {
+    a != b
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lt(a: u64, b: u64) -> bool {
+    a < b
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn le(a: u64, b: u64) -> bool {
+    a <= b
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn gt(a: u64, b: u64) -> bool {
+    a > b
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn ge(a: u64, b: u64) -> bool {
+    a >= b
+}
+
 
 #[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(a: u64, b: u64, n: u32) {

--- a/programs/rust/rust_u64/src/exports.rs
+++ b/programs/rust/rust_u64/src/exports.rs
@@ -94,6 +94,22 @@ pub extern "C" fn ge(a: u64, b: u64) -> bool {
     a >= b
 }
 
+// ── Ord: min / max / clamp ─────────────────────────────────────────────────
+#[unsafe(no_mangle)]
+pub extern "C" fn min(a: u64, b: u64) -> u64 {
+    a.min(b)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn max(a: u64, b: u64) -> u64 {
+    a.max(b)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn clamp(a: u64, lo: u64, hi: u64) -> u64 {
+    a.clamp(lo, hi)
+}
+
 
 #[unsafe(no_mangle)]
 pub extern "C" fn entrypoint(a: u64, b: u64, n: u32) {

--- a/programs/rust/rust_u64_tests/src/exports.rs
+++ b/programs/rust/rust_u64_tests/src/exports.rs
@@ -50,3 +50,24 @@
 // ── rem (divisors nonzero) ──────────────────────────────────────────────────
 #[unsafe(no_mangle)] pub extern "C" fn rem_then_add(a: u64, b: u64, c: u64) -> u64 { a % b + c }
 #[unsafe(no_mangle)] pub extern "C" fn rem_then_mul(a: u64, b: u64, c: u64) -> u64 { (a % b) * c }
+
+// ── Comparisons (eq .. ge): each `a OP b` inlines to `cmpOp; i32.const 1; i32.and`
+//    (the `bool` normalisation). Tests use it via `as u64` so the masked chunk is
+//    reused inline: one comparison + a scalar, and two comparisons summed.
+#[unsafe(no_mangle)] pub extern "C" fn eq_u64(a: u64, b: u64, c: u64) -> u64 { (a == b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn eq_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a == b) as u64 + (c == d) as u64 }
+
+#[unsafe(no_mangle)] pub extern "C" fn ne_u64(a: u64, b: u64, c: u64) -> u64 { (a != b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn ne_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a != b) as u64 + (c != d) as u64 }
+
+#[unsafe(no_mangle)] pub extern "C" fn lt_u64(a: u64, b: u64, c: u64) -> u64 { (a < b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn lt_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a < b) as u64 + (c < d) as u64 }
+
+#[unsafe(no_mangle)] pub extern "C" fn le_u64(a: u64, b: u64, c: u64) -> u64 { (a <= b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn le_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a <= b) as u64 + (c <= d) as u64 }
+
+#[unsafe(no_mangle)] pub extern "C" fn gt_u64(a: u64, b: u64, c: u64) -> u64 { (a > b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn gt_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a > b) as u64 + (c > d) as u64 }
+
+#[unsafe(no_mangle)] pub extern "C" fn ge_u64(a: u64, b: u64, c: u64) -> u64 { (a >= b) as u64 + c }
+#[unsafe(no_mangle)] pub extern "C" fn ge_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a >= b) as u64 + (c >= d) as u64 }

--- a/programs/rust/rust_u64_tests/src/exports.rs
+++ b/programs/rust/rust_u64_tests/src/exports.rs
@@ -71,3 +71,14 @@
 
 #[unsafe(no_mangle)] pub extern "C" fn ge_u64(a: u64, b: u64, c: u64) -> u64 { (a >= b) as u64 + c }
 #[unsafe(no_mangle)] pub extern "C" fn ge_two(a: u64, b: u64, c: u64, d: u64) -> u64 { (a >= b) as u64 + (c >= d) as u64 }
+
+// ── Ord: min / max / clamp — these compile to `call`s to the framed inner fns,
+//    so the tests are call-reuse demos (reuse <fn>_wp via the call rule).
+#[unsafe(no_mangle)] pub extern "C" fn max_add(a: u64, b: u64, c: u64) -> u64 { a.max(b) + c }
+#[unsafe(no_mangle)] pub extern "C" fn max_chain(a: u64, b: u64, c: u64) -> u64 { a.max(b).max(c) }
+
+#[unsafe(no_mangle)] pub extern "C" fn min_add(a: u64, b: u64, c: u64) -> u64 { a.min(b) + c }
+#[unsafe(no_mangle)] pub extern "C" fn min_chain(a: u64, b: u64, c: u64) -> u64 { a.min(b).min(c) }
+
+#[unsafe(no_mangle)] pub extern "C" fn clamp_add(a: u64, lo: u64, hi: u64, c: u64) -> u64 { a.clamp(lo, hi) + c }
+#[unsafe(no_mangle)] pub extern "C" fn clamp_mul(a: u64, lo: u64, hi: u64, c: u64) -> u64 { a.clamp(lo, hi) * c }


### PR DESCRIPTION
Continues the Rust-std → Wasm → Lean u64 corpus with the **comparisons + Ord** block. All proofs green, 0 `sorry`, 0 warnings.

## What's here (7 commits, one per function except the cohesive Ord block)

**Comparisons — new `cmp` shape (`eq ne lt le gt ge`).** Adds `CmpChunk`/`cmpBodyWp` to the type-agnostic trunk `CodeLib/RustStd/UInt.lean`: a comparison chunk whose result lands as the i32 boolean `0/1` (not a `toV`-carried `T`). A comparison `a OP b` compiles to `[cmpOp, i32.const 1, i32.and]`; the redundant `& 1` bool-mask is discharged inside each `<fn>_chunk`. `U64/Eq.lean` is the exemplar; `Ne/Lt/Le/Gt/Ge` mirror it (opcode + `res`). Each has the export-body theorem + an inline `_seq` restatement, with two structurally-distinct inline reuse tests in `rust_u64_tests` (the op's own `wp_*` atomic excluded from `simp`, delete-break-verified load-bearing).

**Ord — framed `select` shape (`min max clamp`).** These compile to wrapper exports that `call` framed inner functions (the abs_diff pattern), reused across the `call` boundary via `wp_call_tw`:
- `CodeLib/RustStd/U64/{Max,Min,Clamp}.lean`: body theorems `max_wp`/`min_wp`/`clamp_wp`. `clamp` panics if `lo > hi` (spec carries `lo ≤ hi`), saves/restores the global stack pointer, and is **tail-generic in the panic `call` index** so one theorem serves every crate's copy.
- `Frame.lean`: new `Mem.read64_write64_disjoint` (+ `write64_bytes_outside`) for the two-operand spill frames (min/max read back from adjacent 8-byte slots).
- Per-crate `MaxSpec`/`MinSpec`/`ClampSpec` prove the exported wrappers by reusing the inner body theorems via the call rule. Two call-reuse tests each in `rust_u64_tests` (`max_add`/`max_chain`, `min_add`/`min_chain`, `clamp_add`/`clamp_mul`).

## Notes for review
- Adding the Ord wrappers **renumbers the whole module** (`opt-0` inserts the framed inner fns at low indices): all merged + comparison spec indices were re-mapped, and the div/rem panic-tail `.call`/`.const` literals updated (72/73 → 83/84). The mechanical re-index is the bulk of the `RustU64/Spec.lean` / `Program.lean` diff.
- `clamp_wp` needs `maxHeartbeats 1000000` (~42s) — the nested-block `simp`; functionally fine, optimizable later.
- The `cmp` trunk shape and the operator trunk are polymorphic, so u32/u16/u8/signed reuse them (swap opcode + `res`); the framed `select` family will re-prove per width on `Frame.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)