### PR TITLE
decoder: ref.null exn/noexn push a null exnref instead of trapping

### DIFF
--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -490,6 +490,9 @@ private def refNullInstr (types : Array TypeEntry) (ht : String) : Wasm.Instruct
   -- shared managed null `anyref`.
   else if ht == "any" || ht == "eq" || ht == "i31"
        || ht == "struct" || ht == "array" || ht == "none" then .gc .refNullAny
+  -- Exception heap types (exception-handling proposal): the null they denote
+  -- is the null `exnref`.
+  else if ht == "exn" || ht == "noexn" then .refNullExn
   -- Concrete heap types (`$t` / numeric): a struct/array type denotes the
   -- managed null; a function type denotes the null funcref.
   else if ht.startsWith "$" || ht.all Char.isDigit then

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -127,6 +127,7 @@ def evalConstRef : Program → Option Value
   | [.refFunc f]                 => some (.funcref (some f))
   | [.refNull]                   => some (.funcref none)
   | [.refNullExtern]             => some (.externref none)
+  | [.refNullExn]                => some (.exnref none)
   | [.gc .refNullAny]            => some (.anyref none)
   | [.const n]                   => some (.i32 n)
   | [.constI64 n]                => some (.i64 n)
@@ -1960,6 +1961,7 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
     -- value, `refIsNull` inspects one.
     | _, .refNull       => .Fallthrough st { s with values := .funcref none :: s.values }
     | _, .refNullExtern => .Fallthrough st { s with values := .externref none :: s.values }
+    | _, .refNullExn    => .Fallthrough st { s with values := .exnref none :: s.values }
     | _, .refFunc fidx  => .Fallthrough st { s with values := .funcref (some fidx) :: s.values }
     | _, .refIsNull => match s.values with
       | .funcref r :: vs =>

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -397,6 +397,7 @@ inductive Instruction where
   -- touch the store.
   | refNull   : Instruction        -- ref.null func: push the null funcref
   | refNullExtern : Instruction    -- ref.null extern: push the null externref
+  | refNullExn : Instruction       -- ref.null exn/noexn: push the null exnref
   | refFunc   : Nat → Instruction  -- ref.func i:    push a reference to function `i`
   | refIsNull : Instruction        -- ref.is_null:   pop a ref, push i32 1 if null else 0
 

--- a/interpreter/Interpreter/Wasm/Validate.lean
+++ b/interpreter/Interpreter/Wasm/Validate.lean
@@ -62,7 +62,7 @@ def Instruction.typeRefs : Instruction → List Nat
 (the forms a global / element initializer may contain). -/
 def Program.isConstExpr (p : Program) : Bool :=
   p.all fun i => match i with
-    | .const _ | .constI64 _ | .refNull | .refNullExtern | .refFunc _ => true
+    | .const _ | .constI64 _ | .refNull | .refNullExtern | .refNullExn | .refFunc _ => true
     | .globalGet _ => true
     | .gc g => match g with
       | .refI31 | .refNullAny | .structNew _ | .structNewDefault _

--- a/interpreter/Interpreter/Wasm/Wp/Atomic.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Atomic.lean
@@ -646,6 +646,11 @@ macro "wp_atomic" : tactic => `(tactic|
     wp m rest Q st { s with values := .externref none :: s.values } env := by
   wp_atomic
 
+@[simp, wp_simp] theorem wp_refNullExn_cons :
+    wp m (.refNullExn :: rest) Q st s env ↔
+    wp m rest Q st { s with values := .exnref none :: s.values } env := by
+  wp_atomic
+
 @[simp, wp_simp] theorem wp_refIsNull_cons :
     wp m (.refIsNull :: rest) Q st s env ↔
     (match s.values with

--- a/verifier/Verifier/Emit.lean
+++ b/verifier/Verifier/Emit.lean
@@ -286,6 +286,7 @@ private def emitInstrShort : Wasm.Instruction → String
         list (thn.map emitInstrShort) ++ " " ++ list (els.map emitInstrShort)
   -- Reference / table (wasm 2.0+)
   | .refNullExtern        => ".refNullExtern"
+  | .refNullExn           => ".refNullExn"
   | .tableSet t           => s!".tableSet {emitNat t}"
   | .tableGrow t          => s!".tableGrow {emitNat t}"
   | .tableFill t          => s!".tableFill {emitNat t}"


### PR DESCRIPTION
`ref.null exn` and `ref.null noexn` are valid instructions that push a null `exnref`. Talos decodes them to `unreachable`, so a valid module that uses them traps at runtime.

```wat
(module (func (export "f") (result i32) ref.null exn drop i32.const 1))
```
wasmtime / V8 → `1`. Talos → `trap: unreachable`.

Root cause: `refNullInstr` (`Decoder/Wat.lean:486`) maps the heap-type string to a null-ref push and ends in a catch-all `else => .unreachable` — branches for `func`/`extern`/the GC abstract types, none for `exn`/`noexn`.

Fix: a `refNullExn` instruction pushing `Value.exnref none` (the null exnref already exists; exceptions are otherwise modeled), wired into the decoder, `execOne`, and the const-expr paths (`isConstExpr`/`evalConstRef`) — wherever `ref.null func`/`extern` are handled.

(Aside: the same `.unreachable` fallback covers other unmodeled-but-valid instructions, e.g. the `atomic.*` catch-all in `Wat.lean`. For verification, lowering those to `.error` rather than `unreachable` would let a proof distinguish an unsupported instruction from a genuine wasm trap, instead of decoding successfully and trapping.)

Found differential-testing against wasmtime + V8.
