### PR TITLE
interpreter: require subtype, not equality, in (return_)call_indirect (#95)

### DIFF
--- a/interpreter/Interpreter/Wasm/Examples/CallIndirect.lean
+++ b/interpreter/Interpreter/Wasm/Examples/CallIndirect.lean
@@ -69,7 +69,7 @@ theorem dispatchSpec (n : UInt32) :
   · rfl
   · rfl
   · rfl
-  · exact ⟨rfl, rfl⟩
+  · decide
   · exact incrSpec n
   · rfl
   · rintro st' vs rfl

--- a/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
+++ b/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
@@ -1,0 +1,101 @@
+import Interpreter.Wasm.Semantics
+
+/-! ## Example: `call_indirect` accepts a *supertype* (issue #95)
+
+    This file *reproduces* a known unsoundness; it does not fix it. See
+    https://github.com/cajal-technologies/talos/issues/95.
+
+    `call_indirect (type N)` is supposed to trap unless the stored
+    function's type is a **subtype** of the call-site type `N`. The
+    interpreter instead checks structural equality of `params`/`results`
+    (`Semantics.lean`, the `.callIndirect` arm):
+
+    ```
+    if fn.params = ty.params ∧ fn.results = ty.results then … else .Trap …
+    ```
+
+    Two *distinct* nominal types in a `rec`/`sub` hierarchy can share the
+    same params/results while **not** standing in the required subtype
+    relation — and then the equality check wrongly passes.
+
+    The module below is the one from the issue:
+
+    ```wat
+    (module
+      (rec
+        (type $super (sub (func (param i32) (result i32))))
+        (type $sub   (sub $super (func (param i32) (result i32)))))
+      (func $impl (type $super) (i32.add (local.get 0) (i32.const 1000)))
+      (table 1 funcref)
+      (elem (i32.const 0) $impl)
+      (func (export "f") (result i32)
+        (i32.const 7) (i32.const 0) (call_indirect (type $sub))))
+    ```
+
+    `$super` and `$sub` are distinct types with identical
+    `(param i32) (result i32)` shapes, and `$sub <: $super` — crucially
+    **not** `$super <: $sub`. The table holds `$impl : $super`; the call
+    site asks for `$sub`. Since `$super` is not a subtype of `$sub`, a
+    conformant engine must trap:
+
+    * wasmtime 43 → `indirect call type mismatch`
+    * V8 (Node 26) → `function signature mismatch`
+
+    Talos runs `$impl` anyway and returns `1007` (= `7 + 1000`). The
+    `native_decide` theorem below pins down that wrong result, so it will
+    start failing the day the relation is tightened from `=` to `<:` — at
+    which point this example should flip to asserting a trap.
+
+    Built by hand rather than through the `.wat` decoder: the unsoundness
+    lives in the semantics, and the decoder does not currently accept the
+    `(func (type $super) …)` header form used in the issue. -/
+
+namespace Wasm
+
+namespace CallIndirectSubtype
+
+/-- `$impl : $super` — the function the table holds. -/
+def Impl : Program := [.localGet 0, .const 1000, .add]
+
+/-- The exported `f`: push the argument `7` and the table index `0`, then
+`call_indirect (type $sub)` — i.e. `typeIdx = 1` (the `$sub` slot),
+`tableIdx = 0`. -/
+def F : Program := [.const 7, .const 0, .callIndirect 1 0]
+
+/-- The issue's module, by hand. `types`/`gcTypes` carry the two nominal
+types in source order: index 0 = `$super` (open for subtyping), index 1 =
+`$sub` declaring `$super` as its immediate supertype. The two `FuncType`s
+are structurally identical, which is exactly what fools the equality
+check. -/
+def m : Module :=
+  { types    := [{ params := [.i32], results := [.i32] },   -- 0: $super
+                 { params := [.i32], results := [.i32] }]    -- 1: $sub
+    gcTypes  := [{ comp := .func { params := [.i32], results := [.i32] }, super := none,   «final» := false },
+                 { comp := .func { params := [.i32], results := [.i32] }, super := some 0, «final» := true }]
+    funcs    := [{ params := [.i32], body := Impl, results := [.i32] },   -- 0: $impl
+                 { params := [],     body := F,    results := [.i32] }]    -- 1: f
+    tables   := [{ min := 1 }]
+    elements := [{ tableIdx := some 0, offset := some 0, funcs := [some 0] }] }
+
+/-- `$sub <: $super` holds (the legitimate direction). -/
+theorem sub_subtype_super : m.gcTypeSubtype 1 0 = true := by native_decide
+
+/-- `$super <: $sub` does **not** hold. This is the relation `call_indirect`
+*should* require of the stored function's type (`$super`) against the
+call-site type (`$sub`) — and it fails, so the call must trap. -/
+theorem super_not_subtype_sub : m.gcTypeSubtype 0 1 = false := by native_decide
+
+private def runResult : Result Unit :=
+  run 20 m 1 (m.initialStore (α := Unit)) []
+
+/-- **The bug.** Because `super_not_subtype_sub`, calling `$impl : $super`
+through `call_indirect (type $sub)` must trap. Instead the interpreter runs
+`$impl` and returns `7 + 1000 = 1007`. When the type check is tightened from
+`=` to `<:`, this theorem should be replaced by one asserting a trap, e.g.
+`∃ st, runResult = .Trap st "indirect call type mismatch"`. -/
+theorem reproduces_unsound_call :
+    (match runResult with | .Success vs _ => vs | _ => []) = [.i32 1007] := by
+  native_decide
+
+end CallIndirectSubtype
+end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
+++ b/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
@@ -1,24 +1,20 @@
 import Interpreter.Wasm.Semantics
 
-/-! ## Example: `call_indirect` accepts a *supertype* (issue #95)
+/-! ## Example: `(return_)call_indirect` rejects a non-subtype (issue #95)
 
-    This file *reproduces* a known unsoundness; it does not fix it. See
-    https://github.com/cajal-technologies/talos/issues/95.
+    `call_indirect (type N)` (and its tail-call sibling
+    `return_call_indirect`) must trap unless the stored function's type is a
+    **subtype** of the call-site type `N`. Issue #95 reported that the
+    interpreter checked only structural equality of `params`/`results`, so a
+    function whose type is a strict *supertype* of the call site was run
+    instead of trapping.
 
-    `call_indirect (type N)` is supposed to trap unless the stored
-    function's type is a **subtype** of the call-site type `N`. The
-    interpreter instead checks structural equality of `params`/`results`
-    (`Semantics.lean`, the `.callIndirect` arm):
-
-    ```
-    if fn.params = ty.params ∧ fn.results = ty.results then … else .Trap …
-    ```
-
-    Two *distinct* nominal types in a `rec`/`sub` hierarchy can share the
-    same params/results while **not** standing in the required subtype
-    relation — and then the equality check wrongly passes.
-
-    The module below is the one from the issue:
+    The module below is the one from the issue. `$super` and `$sub` are
+    distinct types with identical `(param i32) (result i32)` shapes, and
+    `$sub <: $super` — crucially **not** `$super <: $sub`. The table holds
+    `$impl : $super`; the call sites ask for `$sub`. Since `$super` is not a
+    subtype of `$sub`, a conformant engine must trap (wasmtime: `indirect
+    call type mismatch`; V8: `function signature mismatch`).
 
     ```wat
     (module
@@ -28,74 +24,80 @@ import Interpreter.Wasm.Semantics
       (func $impl (type $super) (i32.add (local.get 0) (i32.const 1000)))
       (table 1 funcref)
       (elem (i32.const 0) $impl)
-      (func (export "f") (result i32)
-        (i32.const 7) (i32.const 0) (call_indirect (type $sub))))
+      (func (export "f") (result i32) (i32.const 7) (i32.const 0) (call_indirect        (type $sub)))
+      (func (export "g") (result i32) (i32.const 7) (i32.const 0) (return_call_indirect (type $sub))))
     ```
 
-    `$super` and `$sub` are distinct types with identical
-    `(param i32) (result i32)` shapes, and `$sub <: $super` — crucially
-    **not** `$super <: $sub`. The table holds `$impl : $super`; the call
-    site asks for `$sub`. Since `$super` is not a subtype of `$sub`, a
-    conformant engine must trap:
+    The fix (this PR) records each function's declared `(type N)` in
+    `Function.typeIdx` and routes all four `(return_)call_indirect` arms
+    through `Module.indirectCallTypeOk`, which — when the declared type is
+    known — additionally requires `gcTypeSubtype` to hold. The theorems
+    below pin down that **both** instructions now trap. The companion
+    `Examples/CallIndirect.lean` covers the legitimate same-type case that
+    still succeeds.
 
-    * wasmtime 43 → `indirect call type mismatch`
-    * V8 (Node 26) → `function signature mismatch`
-
-    Talos runs `$impl` anyway and returns `1007` (= `7 + 1000`). The
-    `native_decide` theorem below pins down that wrong result, so it will
-    start failing the day the relation is tightened from `=` to `<:` — at
-    which point this example should flip to asserting a trap.
-
-    Built by hand rather than through the `.wat` decoder: the unsoundness
-    lives in the semantics, and the decoder does not currently accept the
-    `(func (type $super) …)` header form used in the issue. -/
+    Built by hand rather than through the `.wat` decoder: the soundness fix
+    lives in the semantics, the decoder does not currently accept the
+    `(func (type $super) …)` header form, and — pending structural
+    type-equality in `gcTypeSubtype` — the decoder still leaves `typeIdx`
+    unset (so decoded modules keep the pre-#95 structural-only behaviour). -/
 
 namespace Wasm
 
 namespace CallIndirectSubtype
 
-/-- `$impl : $super` — the function the table holds. -/
+/-- `$impl : $super` — the function the table holds. Its declared type is
+type index 0 (`$super`); this is the nominal information the fixed check
+consults. -/
 def Impl : Program := [.localGet 0, .const 1000, .add]
 
-/-- The exported `f`: push the argument `7` and the table index `0`, then
+/-- Exported `f`: push the argument `7` and the table index `0`, then
 `call_indirect (type $sub)` — i.e. `typeIdx = 1` (the `$sub` slot),
 `tableIdx = 0`. -/
 def F : Program := [.const 7, .const 0, .callIndirect 1 0]
 
+/-- Exported `g`: the tail-call sibling, `return_call_indirect (type $sub)`,
+exercising the second pair of arms flagged in the issue's comment. -/
+def G : Program := [.const 7, .const 0, .returnCallIndirect 1 0]
+
 /-- The issue's module, by hand. `types`/`gcTypes` carry the two nominal
 types in source order: index 0 = `$super` (open for subtyping), index 1 =
-`$sub` declaring `$super` as its immediate supertype. The two `FuncType`s
-are structurally identical, which is exactly what fools the equality
-check. -/
+`$sub` declaring `$super` as its immediate supertype. `$impl` records its
+declared type (`typeIdx := some 0`); the call sites use type index 1. -/
 def m : Module :=
   { types    := [{ params := [.i32], results := [.i32] },   -- 0: $super
                  { params := [.i32], results := [.i32] }]    -- 1: $sub
     gcTypes  := [{ comp := .func { params := [.i32], results := [.i32] }, super := none,   «final» := false },
                  { comp := .func { params := [.i32], results := [.i32] }, super := some 0, «final» := true }]
-    funcs    := [{ params := [.i32], body := Impl, results := [.i32] },   -- 0: $impl
-                 { params := [],     body := F,    results := [.i32] }]    -- 1: f
+    funcs    := [{ params := [.i32], body := Impl, results := [.i32], typeIdx := some 0 },   -- 0: $impl : $super
+                 { params := [],     body := F,    results := [.i32] },                       -- 1: f
+                 { params := [],     body := G,    results := [.i32] }]                        -- 2: g
     tables   := [{ min := 1 }]
     elements := [{ tableIdx := some 0, offset := some 0, funcs := [some 0] }] }
 
 /-- `$sub <: $super` holds (the legitimate direction). -/
 theorem sub_subtype_super : m.gcTypeSubtype 1 0 = true := by native_decide
 
-/-- `$super <: $sub` does **not** hold. This is the relation `call_indirect`
-*should* require of the stored function's type (`$super`) against the
-call-site type (`$sub`) — and it fails, so the call must trap. -/
+/-- `$super <: $sub` does **not** hold. This is the relation the call sites
+require of the stored function's type (`$super`) against the call-site type
+(`$sub`); it fails, so the calls must trap. -/
 theorem super_not_subtype_sub : m.gcTypeSubtype 0 1 = false := by native_decide
 
-private def runResult : Result Unit :=
-  run 20 m 1 (m.initialStore (α := Unit)) []
+private def trapMsg (r : Result Unit) : Option String :=
+  match r with | .Trap _ msg => some msg | _ => none
 
-/-- **The bug.** Because `super_not_subtype_sub`, calling `$impl : $super`
-through `call_indirect (type $sub)` must trap. Instead the interpreter runs
-`$impl` and returns `7 + 1000 = 1007`. When the type check is tightened from
-`=` to `<:`, this theorem should be replaced by one asserting a trap, e.g.
-`∃ st, runResult = .Trap st "indirect call type mismatch"`. -/
-theorem reproduces_unsound_call :
-    (match runResult with | .Success vs _ => vs | _ => []) = [.i32 1007] := by
-  native_decide
+/-- `call_indirect (type $sub)` against `$impl : $super` traps: `$super` is
+not a subtype of `$sub` (`super_not_subtype_sub`). Before #95 this returned
+`7 + 1000 = 1007`. -/
+theorem call_indirect_traps :
+    trapMsg (run 20 m 1 (m.initialStore (α := Unit)) []) =
+      some "indirect call type mismatch" := by native_decide
+
+/-- `return_call_indirect (type $sub)` traps for the same reason — the
+issue's comment noted the bug was duplicated in the tail-call arms. -/
+theorem return_call_indirect_traps :
+    trapMsg (run 20 m 2 (m.initialStore (α := Unit)) []) =
+      some "indirect call type mismatch" := by native_decide
 
 end CallIndirectSubtype
 end Wasm

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -1114,7 +1114,7 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
               match m.types[typeIdx]? with
               | none    => .Invalid s!"returnCallIndirect: type index {typeIdx} out of range"
               | some ty =>
-                if fn.params = ty.params ∧ fn.results = ty.results then
+                if m.indirectCallTypeOk fid typeIdx fn ty = true then
                   .ReturnCall fid st rest
                 else .Trap st "indirect call type mismatch"
           | some _ => .Invalid "returnCallIndirect: non-funcref table entry"
@@ -1132,7 +1132,7 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
               match m.types[typeIdx]? with
               | none    => .Invalid s!"returnCallIndirect: type index {typeIdx} out of range"
               | some ty =>
-                if fn.params = ty.params ∧ fn.results = ty.results then
+                if m.indirectCallTypeOk fid typeIdx fn ty = true then
                   .ReturnCall fid st rest
                 else .Trap st "indirect call type mismatch"
           | some _ => .Invalid "returnCallIndirect: non-funcref table entry"
@@ -1254,7 +1254,7 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
               match m.types[typeIdx]? with
               | none    => .Invalid s!"callIndirect: type index {typeIdx} out of range"
               | some ty =>
-                if fn.params = ty.params ∧ fn.results = ty.results then
+                if m.indirectCallTypeOk fid typeIdx fn ty = true then
                   match run f m fid st rest env with
                   | .Success vs st' => .Fallthrough st' { s with values := vs }
                   | .Trap st' msg   => .Trap st' msg
@@ -1279,7 +1279,7 @@ def execOne (fuel : Nat) (m : Module) (st : Store α) (s : Locals) (inst : Instr
               match m.types[typeIdx]? with
               | none    => .Invalid s!"callIndirect: type index {typeIdx} out of range"
               | some ty =>
-                if fn.params = ty.params ∧ fn.results = ty.results then
+                if m.indirectCallTypeOk fid typeIdx fn ty = true then
                   match run f m fid st rest env with
                   | .Success vs st' => .Fallthrough st' { s with values := vs }
                   | .Trap st' msg   => .Trap st' msg

--- a/interpreter/Interpreter/Wasm/Semantics/Lemmas.lean
+++ b/interpreter/Interpreter/Wasm/Semantics/Lemmas.lean
@@ -215,7 +215,7 @@ theorem fuel_mono_aux : ∀ (f₁ : Nat),
                     · rcases hty : m.types[ti]? with _ | ty
                       · simp only [execOne.eq_def, hvals, hv, htbl, hslot, hslot', hr, hfn, hty]
                       · by_cases hsig :
-                            fn.params = ty.params ∧ fn.results = ty.results
+                            m.indirectCallTypeOk fid ti fn ty = true
                         · have hrun : run k m fid st rest env ≠ .OutOfFuel := by
                             intro h; apply hne
                             simp only [execOne.eq_def, hvals, hv, htbl, hslot, hslot', hr,
@@ -253,7 +253,7 @@ theorem fuel_mono_aux : ∀ (f₁ : Nat),
                     · rcases hty : m.types[ti]? with _ | ty
                       · simp only [execOne.eq_def, hvals, hv, htbl, hslot, hslot', hr, hfn, hty]
                       · by_cases hsig :
-                            fn.params = ty.params ∧ fn.results = ty.results
+                            m.indirectCallTypeOk fid ti fn ty = true
                         · have hrun : run k m fid st rest env ≠ .OutOfFuel := by
                             intro h; apply hne
                             simp only [execOne.eq_def, hvals, hv, htbl, hslot, hslot', hr,
@@ -490,7 +490,7 @@ theorem exec_callIndirect_cons {α : Type}
     (hSlot : tbl[i.toNat]? = some (.funcref (some fid)))
     (hFn   : m.funcSig? fid = some fn)
     (hTy   : m.types[ti]? = some ty)
-    (hSig  : fn.params = ty.params ∧ fn.results = ty.results) :
+    (hSig  : m.indirectCallTypeOk fid ti fn ty = true) :
     exec (fuel + 1) m st s (.callIndirect ti tj :: rest) env =
       (match run fuel m fid st vs0 env with
        | .Success vs st' => exec (fuel + 1) m st' { s with values := vs } rest env

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -568,6 +568,14 @@ structure Function where
   local 0 is the first (deepest) argument, and the top `results.length`
   values are returned to the caller on exit. -/
   results : List ValueType := []
+  /-- Index into `Module.types`/`gcTypes` of the function's declared
+  `(type N)`, when known. `(return_)call_indirect` consults this to check
+  the *nominal* subtype relation against the call-site type — structural
+  equality of `params`/`results` is necessary but not sufficient once a
+  `rec`/`sub` hierarchy is in play (issue #95). `none` means the declared
+  type is unrecorded, and the indirect-call check falls back to structural
+  equality alone. -/
+  typeIdx : Option Nat := none
 deriving Repr, Inhabited
 
 @[inline] def Function.numParams (f : Function) : Nat := f.params.length
@@ -917,6 +925,15 @@ def Module.funcSig? (m : Module) (i : Nat) : Option FuncType :=
     | some f => some { params := f.params, results := f.results }
     | none   => none
 
+/-- Declared nominal type index of a function in the *unified* index space,
+when recorded. Imports carry no declared `(type N)` here, so they return
+`none`; in-module functions return their `Function.typeIdx`. Used by the
+`(return_)call_indirect` type check to consult the `rec`/`sub` hierarchy. -/
+def Module.funcTypeIdx? (m : Module) (i : Nat) : Option Nat :=
+  match m.imports[i]? with
+  | some _ => none
+  | none   => (m.funcs[i - m.imports.length]?).bind (·.typeIdx)
+
 /-- Whether GC type index `a` is a (reflexive, transitive) subtype of `b`,
 following the declared `sub $super` chain. Bounded by the type-table size
 so a malformed cyclic chain still terminates. -/
@@ -931,6 +948,27 @@ def Module.gcTypeSubtype (m : Module) (a b : Nat) : Bool :=
           | none   => false
         | none   => false
   go m.gcTypes.length a
+
+/-- Runtime type check shared by all four `(return_)call_indirect` arms
+(issue #95). A table entry resolving to function `fid` is callable at the
+call-site type `typeIdx` when:
+
+* the looked-up structural signatures match (`fn` is the target's
+  `funcSig?`, `ty` is `types[typeIdx]`) — necessary for the calling
+  convention; and
+* the target's declared nominal type, when recorded (`funcTypeIdx?`), is a
+  **subtype** of `typeIdx`. A function typed `$super` must *not* satisfy a
+  call site expecting `$sub` even though their params/results coincide.
+
+When the target's declared type is unrecorded (`funcTypeIdx? = none`) the
+nominal clause is vacuously satisfied and the check degrades to the
+structural comparison the interpreter used before issue #95. -/
+def Module.indirectCallTypeOk (m : Module) (fid typeIdx : Nat)
+    (fn ty : FuncType) : Bool :=
+  fn.params == ty.params && fn.results == ty.results &&
+  (match m.funcTypeIdx? fid with
+   | some src => m.gcTypeSubtype src typeIdx
+   | none     => true)
 
 /-- Look up the struct/array composite type at index `i`. -/
 def Module.gcComposite? (m : Module) (i : Nat) : Option CompositeType :=

--- a/interpreter/Interpreter/Wasm/Wp/Call.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Call.lean
@@ -91,7 +91,7 @@ theorem wp_callIndirect_at {α : Type} {env : HostEnv α}
     (hSlot : tbl[i.toNat]? = some (.funcref (some fid)))
     (hFn   : m.funcSig? fid = some fn)
     (hTy   : m.types[ti]? = some ty)
-    (hSig  : fn.params = ty.params ∧ fn.results = ty.results)
+    (hSig  : m.indirectCallTypeOk fid ti fn ty = true)
     (hRun  : ∃ N, ∀ fuel ≥ N, ∃ vs st',
               run fuel m fid st vs0 env = .Success vs st' ∧ Post st' vs)
     (hPost : ∀ st' vs, Post st' vs → wp m rest Q st' { s with values := vs } env) :
@@ -130,7 +130,7 @@ theorem wp_callIndirect_cons {α : Type} {env : HostEnv α}
     (hSlot : tbl[i.toNat]? = some (.funcref (some fid)))
     (hFn   : m.funcSig? fid = some fn)
     (hTy   : m.types[ti]? = some ty)
-    (hSig  : fn.params = ty.params ∧ fn.results = ty.results)
+    (hSig  : m.indirectCallTypeOk fid ti fn ty = true)
     (spec  : FuncSpec env m fid Pre Post)
     (hPre  : Pre vs0)
     (hPost : ∀ st' vs, Post st' vs → wp m rest Q st' { s with values := vs } env) :
@@ -150,7 +150,7 @@ theorem wp_callIndirect_tw {α : Type} {env : HostEnv α}
     (hSlot : tbl[i.toNat]? = some (.funcref (some fid)))
     (hFn   : m.funcSig? fid = some fn)
     (hTy   : m.types[ti]? = some ty)
-    (hSig  : fn.params = ty.params ∧ fn.results = ty.results)
+    (hSig  : m.indirectCallTypeOk fid ti fn ty = true)
     (hRun  : TerminatesWith env m fid st vs0 Post)
     (hPost : ∀ st' vs, Post st' vs → wp m rest Q st' { s with values := vs } env) :
     wp m (.callIndirect ti tj :: rest) Q st s env :=

--- a/programs/lean/Project/NumInteger/Spec.lean
+++ b/programs/lean/Project/NumInteger/Spec.lean
@@ -388,7 +388,7 @@ theorem func1_terminates (env : HostEnv Unit) (st1 : Store Unit) (a b : UInt64)
       (fun st' vs => st'.globals = st1.globals ∧
         vs = .i64 (UInt64.ofNat (Nat.gcd a.toNat b.toNat)) :: tail) := by
   apply TerminatesWith.of_wp_entry_for
-    (f := ⟨[.i32, .i32], [.i32, .i32, .i32, .i32, .i64, .i32, .i64, .i32], func1, [.i64]⟩) rfl
+    (f := ⟨[.i32, .i32], [.i32, .i32, .i32, .i32, .i64, .i32, .i64, .i32], func1, [.i64], none⟩) rfl
   unfold func1
   wp_run
   rw [hg0]
@@ -481,7 +481,7 @@ theorem func0_terminates (env : HostEnv Unit) (a b : UInt64) :
   have hg : («module».initialStore : Store Unit).globals.globals[0]? = some (.i32 1048576) := by rfl
   have hp : («module».initialStore : Store Unit).mem.pages = 16 := by rfl
   apply TerminatesWith.of_wp_entry_for
-    (f := ⟨[.i64, .i64], [.i32, .i64], func0, [.i64]⟩) rfl
+    (f := ⟨[.i64, .i64], [.i32, .i64], func0, [.i64], none⟩) rfl
   unfold func0
   wp_run
   rw [hg]
@@ -523,7 +523,7 @@ theorem gcd_u64_correct : GcdU64Spec := by
   intro env initial a b hinit
   subst hinit
   -- `func2` is the exported wrapper: pushes both args and calls `func0`.
-  apply TerminatesWith.of_wp_entry_for (f := ⟨[.i64, .i64], [], func2, [.i64]⟩) rfl
+  apply TerminatesWith.of_wp_entry_for (f := ⟨[.i64, .i64], [], func2, [.i64], none⟩) rfl
   unfold func2
   wp_run
   apply wp_call_of_terminates (func0_terminates env a b)


### PR DESCRIPTION
Fixes #95.

## What

`call_indirect (type N)` (and `return_call_indirect`) must trap unless the stored function's type is a **subtype** of the call-site type `N`. The interpreter checked only structural equality of `params`/`results`, so a function typed `$super` was accepted at a call site expecting `$sub` — even though `$super` is *not* a subtype of `$sub`.

Per the issue's follow-up comment, the same check was **duplicated across four arms** (`call_indirect` i32/i64 and `return_call_indirect` i32/i64); all four are fixed.

## How

The structural check can't distinguish `$super` from `$sub` — they have identical params/results — so the fix adds nominal type information:

- `Function.typeIdx : Option Nat` records a function's declared `(type N)`.
- `Module.funcTypeIdx?` exposes it in the unified function index space.
- `Module.indirectCallTypeOk` is a single shared check now used by all four arms: it keeps the structural comparison **and**, when the target's declared type is known, additionally requires `gcTypeSubtype src typeIdx`.
- The four `Semantics.lean` arms, the `exec_callIndirect_cons` unfolding lemma, the fuel-monotonicity lemma, and the three `wp_callIndirect_*` rules in `Wp/Call.lean` are updated to thread the new condition.

Functions whose declared type is unrecorded (`typeIdx = none`) fall back to the prior structural-only behaviour, so existing examples, the WAT decoder path, and the testsuite do **not** regress.

## Test

`interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean` builds the issue's module by hand and proves (`native_decide`) that:

- `$sub <: $super` holds but `$super <: $sub` does not, and
- **both** `call_indirect` and `return_call_indirect` against `$impl : $super` now **trap** with `"indirect call type mismatch"` (previously returned `1007`).

The companion `Examples/CallIndirect.lean` (legitimate same-type dispatch) still succeeds.

## Notes for reviewers

- Built by hand rather than via the `.wat` decoder: the decoder doesn't accept the `(func (type $super) …)` header form from the issue's WAT, and it does not yet populate `Function.typeIdx`. Populating it safely needs `gcTypeSubtype` to also accept structurally-equal distinct type indices (two separate `(type)` defs with identical structure are equal types in wasm, but the current `gcTypeSubtype` only walks declared `sub` chains) — left as a follow-up to avoid regressing decoded modules.
- `lake build` passes for `interpreter` and `codelib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)