### PR TITLE
u64: generalize reusable integer chunks

### DIFF
--- a/codelib/CodeLib/RustStd/U64/Add.lean
+++ b/codelib/CodeLib/RustStd/U64/Add.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::add` — inlined to a single `i64.addI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::add` — inlined to local reads plus a single `i64.addI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.addI64]` computes `+` on stack operands (reusable wherever
-`a + b` is inlined). -/
+/-- The inlined chunk `[.addI64]` computes `+` after operands are read from locals. -/
 theorem add_chunk : BinChunk (T := UInt64) [.addI64] (· + ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_addI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_addI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::add`, built by reusing `add_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::add`, built by reusing `add_chunk`. -/
 theorem addBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.addI64] ++ [.ret])
-      (Returns (.i64 (a + b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp add_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.addI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a + b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp add_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement of `add_chunk` (matches emitted opcodes for `rw`
 at an inlined `i64.add`), proven *by reusing* the polymorphic `add_chunk`. -/
@@ -25,6 +30,6 @@ theorem add_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.addI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a + b) :: vs⟩ env :=
-  add_chunk a b vs
+  by simp only [wp_addI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Add.lean
+++ b/codelib/CodeLib/RustStd/U64/Add.lean
@@ -1,35 +1,23 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::add` — inlined to local reads plus a single `i64.addI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::add` — inlined to a single `i64.addI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.addI64]` computes `+` after operands are read from locals. -/
-theorem add_chunk : BinChunk (T := UInt64) [.addI64] (· + ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_addI64_cons]
+/-- The reusable chunk: `[.addI64]` computes `+` on stack operands. Feeds the
+export-body spec via `binBodyReturnsWp`; also `rw`-able at an inlined `i64.add`. -/
+theorem add_chunk : BinChunk [.addI64] ((· + ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_addI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::add`, built by reusing `add_chunk`. -/
-theorem addBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.addI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a + b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp add_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement of `add_chunk` (matches emitted opcodes for `rw`
-at an inlined `i64.add`), proven *by reusing* the polymorphic `add_chunk`. -/
+/-- Concrete `i64` restatement of `add_chunk` for `rw`/`simp` at an inlined `i64.add`. -/
 theorem add_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.addI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a + b) :: vs⟩ env :=
-  by simp only [wp_addI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a + b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using add_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Basic.lean
+++ b/codelib/CodeLib/RustStd/U64/Basic.lean
@@ -5,7 +5,8 @@ import CodeLib.RustStd.UInt
 
 The `UIntWasm UInt64` instance: a `u64` is carried as `Value.i64`. The trunk's
 generic chunk/body helpers specialise to this instance; each operator's own
-file (`U64/Add.lean`, …) supplies the concrete `i64.*` fragment.
+file (`U64/Add.lean`, …) supplies the concrete `i64.*` fragment. The `u32`
+shift-count encoding (`toV_u32`) that `Shl`/`Shr` use comes from the trunk.
 -/
 
 namespace Wasm.RustStd
@@ -28,6 +29,14 @@ abbrev shiftMask : UInt32 := 63
 as a Rust `u32`. -/
 abbrev shiftAmountFrag : Program := [.const shiftMask, .and, .extendUI32]
 
+/-- The mask-and-extend prefix normalises the shift count to `b % 64`. This is
+the only `bv_decide` for `u64` shifts; it speaks of the shift *amount* only (not
+the shift direction), so it is proven here once and reused by every shift
+(`shl`, `shr`, and any future shift-like op). -/
+theorem shiftAmount_norm (b : UInt32) :
+    UInt64.ofNat (shiftMask &&& b).toNat % 64 = b.toUInt64 % 64 := by
+  simp; bv_decide
+
 /-- The emitted nonzero-divisor guard prefix used before unsigned division and
 remainder. -/
 abbrev nonzeroGuard (i : Nat) : Program :=
@@ -46,6 +55,19 @@ theorem nonzeroGuardWp {α : Type} {m : Module} {env : HostEnv α} {Q : Assertio
   simp only [nonzeroGuard, List.cons_append, List.nil_append, wp_localGet_cons, hget,
     wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
     wp_br_if_cons, h10]
+
+/-- Cons-form restatement of `nonzeroGuardWp`, for `rw`/`simp` at an inlined,
+flat (generated) program where the guard is spelled out instead of appearing as
+`nonzeroGuard i ++ …`. Same fact, different program shape — the way `*_seq`
+relates to `*_chunk`. -/
+theorem nonzeroGuardSeq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program}
+    (i : Nat) (b : UInt64) (vs : List Value)
+    (hget : (⟨P, L, vs⟩ : Locals).get i = some (.i64 b)) (hb : b ≠ 0) :
+    wp m (.localGet i :: .constI64 0 :: .eqI64 :: .const 1 :: .and :: .br_if 0 :: rest)
+      Q st ⟨P, L, vs⟩ env ↔
+    wp m rest Q st ⟨P, L, vs⟩ env :=
+  nonzeroGuardWp i b vs hget hb
 
 end U64
 

--- a/codelib/CodeLib/RustStd/U64/Basic.lean
+++ b/codelib/CodeLib/RustStd/U64/Basic.lean
@@ -19,4 +19,34 @@ instance instUIntWasmUInt64 : UIntWasm UInt64 where
 the stack to concrete `i64` and the atomic `wp_*` lemmas fire. -/
 @[simp] theorem toV_u64 (a : UInt64) : (UIntWasm.toV a : Value) = .i64 a := rfl
 
+namespace U64
+
+/-- Wasm masks `u64` shift amounts to the low 6 bits. -/
+abbrev shiftMask : UInt32 := 63
+
+/-- The emitted mask-and-extend prefix shared by `u64` shifts whose count starts
+as a Rust `u32`. -/
+abbrev shiftAmountFrag : Program := [.const shiftMask, .and, .extendUI32]
+
+/-- The emitted nonzero-divisor guard prefix used before unsigned division and
+remainder. -/
+abbrev nonzeroGuard (i : Nat) : Program :=
+  [.localGet i, .constI64 0, .eqI64, .const 1, .and, .br_if 0]
+
+/-- The opt-0 unsigned-division guard falls through unchanged when the divisor
+local is a nonzero `u64`. -/
+theorem nonzeroGuardWp {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+    {st : Store α} {P L : List Value} {rest : Program}
+    (i : Nat) (b : UInt64) (vs : List Value)
+    (hget : (⟨P, L, vs⟩ : Locals).get i = some (.i64 b)) (hb : b ≠ 0) :
+    wp m (nonzeroGuard i ++ rest)
+      Q st ⟨P, L, vs⟩ env ↔
+    wp m rest Q st ⟨P, L, vs⟩ env := by
+  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
+  simp only [nonzeroGuard, List.cons_append, List.nil_append, wp_localGet_cons, hget,
+    wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
+    wp_br_if_cons, h10]
+
+end U64
+
 end Wasm.RustStd

--- a/codelib/CodeLib/RustStd/U64/BitAnd.lean
+++ b/codelib/CodeLib/RustStd/U64/BitAnd.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitand` — inlined to a single `i64.andI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::bitand` — inlined to local reads plus a single `i64.andI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.andI64]` computes `&&&` on stack operands (reusable wherever
-`a &&& b` is inlined). -/
+/-- The inlined chunk `[.andI64]` computes `&&&` after operands are read from locals. -/
 theorem bitand_chunk : BinChunk (T := UInt64) [.andI64] (· &&& ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_andI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_andI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::bitand`, built by reusing `bitand_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::bitand`, built by reusing `bitand_chunk`. -/
 theorem bitandBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.andI64] ++ [.ret])
-      (Returns (.i64 (a &&& b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitand_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.andI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a &&& b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp bitand_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
 inlined `i64.and`), reusing the polymorphic chunk. -/
@@ -25,6 +30,6 @@ theorem and_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.andI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a &&& b) :: vs⟩ env :=
-  bitand_chunk a b vs
+  by simp only [wp_andI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/BitAnd.lean
+++ b/codelib/CodeLib/RustStd/U64/BitAnd.lean
@@ -1,35 +1,22 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitand` — inlined to local reads plus a single `i64.andI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::bitand` — inlined to a single `i64.andI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.andI64]` computes `&&&` after operands are read from locals. -/
-theorem bitand_chunk : BinChunk (T := UInt64) [.andI64] (· &&& ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_andI64_cons]
+/-- The reusable chunk: `[.andI64]` computes `&&&` on stack operands. -/
+theorem bitand_chunk : BinChunk [.andI64] ((· &&& ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_andI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::bitand`, built by reusing `bitand_chunk`. -/
-theorem bitandBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.andI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a &&& b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitand_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
-inlined `i64.and`), reusing the polymorphic chunk. -/
+/-- Concrete `i64` restatement for `rw`/`simp` at an inlined `i64.and`. -/
 theorem and_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.andI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a &&& b) :: vs⟩ env :=
-  by simp only [wp_andI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a &&& b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using bitand_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/BitOr.lean
+++ b/codelib/CodeLib/RustStd/U64/BitOr.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitor` — inlined to a single `i64.orI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::bitor` — inlined to local reads plus a single `i64.orI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.orI64]` computes `|||` on stack operands (reusable wherever
-`a ||| b` is inlined). -/
+/-- The inlined chunk `[.orI64]` computes `|||` after operands are read from locals. -/
 theorem bitor_chunk : BinChunk (T := UInt64) [.orI64] (· ||| ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_orI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_orI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::bitor`, built by reusing `bitor_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::bitor`, built by reusing `bitor_chunk`. -/
 theorem bitorBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.orI64] ++ [.ret])
-      (Returns (.i64 (a ||| b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitor_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.orI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a ||| b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp bitor_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
 inlined `i64.or`), reusing the polymorphic chunk. -/
@@ -25,6 +30,6 @@ theorem or_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.orI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a ||| b) :: vs⟩ env :=
-  bitor_chunk a b vs
+  by simp only [wp_orI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/BitOr.lean
+++ b/codelib/CodeLib/RustStd/U64/BitOr.lean
@@ -1,35 +1,22 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitor` — inlined to local reads plus a single `i64.orI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::bitor` — inlined to a single `i64.orI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.orI64]` computes `|||` after operands are read from locals. -/
-theorem bitor_chunk : BinChunk (T := UInt64) [.orI64] (· ||| ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_orI64_cons]
+/-- The reusable chunk: `[.orI64]` computes `|||` on stack operands. -/
+theorem bitor_chunk : BinChunk [.orI64] ((· ||| ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_orI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::bitor`, built by reusing `bitor_chunk`. -/
-theorem bitorBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.orI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a ||| b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitor_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
-inlined `i64.or`), reusing the polymorphic chunk. -/
+/-- Concrete `i64` restatement for `rw`/`simp` at an inlined `i64.or`. -/
 theorem or_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.orI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a ||| b) :: vs⟩ env :=
-  by simp only [wp_orI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a ||| b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using bitor_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/BitXor.lean
+++ b/codelib/CodeLib/RustStd/U64/BitXor.lean
@@ -1,35 +1,22 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitxor` — inlined to local reads plus a single `i64.xorI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::bitxor` — inlined to a single `i64.xorI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.xorI64]` computes `^^^` after operands are read from locals. -/
-theorem bitxor_chunk : BinChunk (T := UInt64) [.xorI64] (· ^^^ ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_xorI64_cons]
+/-- The reusable chunk: `[.xorI64]` computes `^^^` on stack operands. -/
+theorem bitxor_chunk : BinChunk [.xorI64] ((· ^^^ ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_xorI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::bitxor`, built by reusing `bitxor_chunk`. -/
-theorem bitxorBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.xorI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a ^^^ b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitxor_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
-inlined `i64.xor`), reusing the polymorphic chunk. -/
+/-- Concrete `i64` restatement for `rw`/`simp` at an inlined `i64.xor`. -/
 theorem xor_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.xorI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a ^^^ b) :: vs⟩ env :=
-  by simp only [wp_xorI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a ^^^ b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using bitxor_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/BitXor.lean
+++ b/codelib/CodeLib/RustStd/U64/BitXor.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::bitxor` — inlined to a single `i64.xorI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::bitxor` — inlined to local reads plus a single `i64.xorI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.xorI64]` computes `^^^` on stack operands (reusable wherever
-`a ^^^ b` is inlined). -/
+/-- The inlined chunk `[.xorI64]` computes `^^^` after operands are read from locals. -/
 theorem bitxor_chunk : BinChunk (T := UInt64) [.xorI64] (· ^^^ ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_xorI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_xorI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::bitxor`, built by reusing `bitxor_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::bitxor`, built by reusing `bitxor_chunk`. -/
 theorem bitxorBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.xorI64] ++ [.ret])
-      (Returns (.i64 (a ^^^ b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp bitxor_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.xorI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a ^^^ b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp bitxor_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
 inlined `i64.xor`), reusing the polymorphic chunk. -/
@@ -25,6 +30,6 @@ theorem xor_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.xorI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a ^^^ b) :: vs⟩ env :=
-  bitxor_chunk a b vs
+  by simp only [wp_xorI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Div.lean
+++ b/codelib/CodeLib/RustStd/U64/Div.lean
@@ -1,55 +1,42 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::div` (`a / b`) — reusable pieces for the zero-divisor guard and `i64.div_u`. -/
+/-! `u64::div` (`a / b`) — a zero-divisor guard `block` around `i64.div_u`,
+reusing the trunk's `checkedBinBodyReturnsWp` template. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Local-read chunk for the bare `i64.div_u`, after a caller has established
-that the divisor is nonzero. -/
+/-- The reusable chunk for the bare `i64.div_u`, carrying the nonzero-divisor
+precondition. -/
 theorem div_chunk :
-    HBinChunkWhere (A := UInt64) (B := UInt64) (C := UInt64)
+    BinChunk (A := UInt64) (B := UInt64) (C := UInt64)
       [.divUI64] (· / ·) (fun _ b => b ≠ 0) := by
-  intro α m env Q st P L rest i j a b vs ha hb hne
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_divUI64_cons, hne, ↓reduceIte]
+  intro α m env Q st P L rest a b vs hne
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_divUI64_cons, hne, ↓reduceIte]
 
-/-- Stack convenience theorem for inlined proof sites after the guard has loaded operands. -/
+/-- Concrete restatement of `div_chunk` for `rw`/`simp` at an inlined `i64.div_u`
+once the guard has loaded operands. -/
 theorem div_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value)
     (hb : b ≠ 0) :
     wp m (.divUI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a / b) :: vs⟩ env := by
-  simp only [wp_divUI64_cons, hb, ↓reduceIte]
-
-/-- Guarded divide body fragment, parameterized by dividend/divisor locals. The
-panic tail emitted after the block is deliberately not part of this reusable
-fragment. -/
-abbrev divCheckedBody (i j : Nat) : Program :=
-  [.block 0 0 (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.divUI64, .ret])]
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using div_chunk (rest := rest) a b vs hb
 
 set_option maxRecDepth 4096 in
-/-- Checked divide body theorem for any dividend/divisor local pair. -/
+/-- Checked divide body for any dividend/divisor local pair, reusing the trunk's
+guarded-body template with the `nonzeroGuard` fall-through. The panic `tail` is
+arbitrary (unreachable when `b ≠ 0`). -/
 theorem divBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     {P L : List Value} (i j : Nat) (a b : UInt64) (vs : List Value) (tail : Program)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
     (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i64 b))
     (hne : b ≠ 0) :
-    wp m (divCheckedBody i j ++ tail) (Returns (.i64 (a / b) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env := by
-  unfold divCheckedBody Returns framePost
-  apply wp_block_cons
-  change wp m
-    (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.divUI64, .ret])
-    _ st ⟨P, L, vs⟩ env
-  rw [List.append_assoc (nonzeroGuard j) [.localGet i, .localGet j] [.divUI64, .ret]]
-  rw [nonzeroGuardWp j b vs hb hne]
-  change wp m ([.localGet i, .localGet j] ++ [.divUI64] ++ [.ret])
-    _ st ⟨P, L, vs⟩ env
-  rw [div_chunk i j a b vs ha hb hne]
-  simp
+    wp m (checkedBinBody (nonzeroGuard j) [.divUI64] i j ++ tail)
+      (Returns (.i64 (a / b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env :=
+  checkedBinBodyReturnsWp div_chunk st i j a b vs tail
+    (fun {_Q _rest} => nonzeroGuardWp j b vs hb hne) ha hb hne
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Div.lean
+++ b/codelib/CodeLib/RustStd/U64/Div.lean
@@ -1,40 +1,55 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::div` (`a / b`) — inlined as a zero-divisor guard `block` around `i64.div_u`. -/
+/-! `u64::div` (`a / b`) — reusable pieces for the zero-divisor guard and `i64.div_u`. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The bare `i64.div_u` chunk on stack operands, divisor ≠ 0 (reusable wherever
-the divide itself is inlined, once the guard is peeled). -/
-theorem div_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+/-- Local-read chunk for the bare `i64.div_u`, after a caller has established
+that the divisor is nonzero. -/
+theorem div_chunk :
+    HBinChunkWhere (A := UInt64) (B := UInt64) (C := UInt64)
+      [.divUI64] (· / ·) (fun _ b => b ≠ 0) := by
+  intro α m env Q st P L rest i j a b vs ha hb hne
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_divUI64_cons, hne, ↓reduceIte]
+
+/-- Stack convenience theorem for inlined proof sites after the guard has loaded operands. -/
+theorem div_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value)
     (hb : b ≠ 0) :
     wp m (.divUI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a / b) :: vs⟩ env := by
   simp only [wp_divUI64_cons, hb, ↓reduceIte]
 
-/-- Verbatim opt-0 body of `rust_u64::div`. -/
-def divBody : Program :=
-  [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
-                 .localGet 0, .localGet 1, .divUI64, .ret ],
-    .const 1048600, .call 66, .unreachable ]
+/-- Guarded divide body fragment, parameterized by dividend/divisor locals. The
+panic tail emitted after the block is deliberately not part of this reusable
+fragment. -/
+abbrev divCheckedBody (i j : Nat) : Program :=
+  [.block 0 0 (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.divUI64, .ret])]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::div` (divisor ≠ 0): peel the zero-divisor
-guard `block`, then **reuse `div_chunk`** for the divide itself (the `divUI64`
-atomic is excluded from the guard reduction so the chunk is the only path). -/
+/-- Checked divide body theorem for any dividend/divisor local pair. -/
 theorem divBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) (hb : b ≠ 0) :
-    wp m divBody (Returns (.i64 (a / b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env := by
-  unfold divBody Returns framePost
+    {P L : List Value} (i j : Nat) (a b : UInt64) (vs : List Value) (tail : Program)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i64 b))
+    (hne : b ≠ 0) :
+    wp m (divCheckedBody i j ++ tail) (Returns (.i64 (a / b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env := by
+  unfold divCheckedBody Returns framePost
   apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
-  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
-    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT,
-    reduceIte, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons,
-    wp_and_cons, wp_br_if_cons, h10]
-  rw [div_chunk a b _ hb]
+  change wp m
+    (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.divUI64, .ret])
+    _ st ⟨P, L, vs⟩ env
+  rw [List.append_assoc (nonzeroGuard j) [.localGet i, .localGet j] [.divUI64, .ret]]
+  rw [nonzeroGuardWp j b vs hb hne]
+  change wp m ([.localGet i, .localGet j] ++ [.divUI64] ++ [.ret])
+    _ st ⟨P, L, vs⟩ env
+  rw [div_chunk i j a b vs ha hb hne]
   simp
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Mul.lean
+++ b/codelib/CodeLib/RustStd/U64/Mul.lean
@@ -1,35 +1,22 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::mul` — inlined to local reads plus a single `i64.mulI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::mul` — inlined to a single `i64.mulI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.mulI64]` computes `*` after operands are read from locals. -/
-theorem mul_chunk : BinChunk (T := UInt64) [.mulI64] (· * ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_mulI64_cons]
+/-- The reusable chunk: `[.mulI64]` computes `*` on stack operands. -/
+theorem mul_chunk : BinChunk [.mulI64] ((· * ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_mulI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::mul`, built by reusing `mul_chunk`. -/
-theorem mulBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.mulI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a * b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp mul_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
-inlined `i64.mul`), reusing the polymorphic chunk. -/
+/-- Concrete `i64` restatement for `rw`/`simp` at an inlined `i64.mul`. -/
 theorem mul_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.mulI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a * b) :: vs⟩ env :=
-  by simp only [wp_mulI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a * b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using mul_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Mul.lean
+++ b/codelib/CodeLib/RustStd/U64/Mul.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::mul` — inlined to a single `i64.mulI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::mul` — inlined to local reads plus a single `i64.mulI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.mulI64]` computes `*` on stack operands (reusable wherever
-`a * b` is inlined). -/
+/-- The inlined chunk `[.mulI64]` computes `*` after operands are read from locals. -/
 theorem mul_chunk : BinChunk (T := UInt64) [.mulI64] (· * ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_mulI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_mulI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::mul`, built by reusing `mul_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::mul`, built by reusing `mul_chunk`. -/
 theorem mulBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.mulI64] ++ [.ret])
-      (Returns (.i64 (a * b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp mul_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.mulI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a * b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp mul_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
 inlined `i64.mul`), reusing the polymorphic chunk. -/
@@ -25,6 +30,6 @@ theorem mul_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.mulI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a * b) :: vs⟩ env :=
-  mul_chunk a b vs
+  by simp only [wp_mulI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Not.lean
+++ b/codelib/CodeLib/RustStd/U64/Not.lean
@@ -5,7 +5,7 @@ import CodeLib.RustStd.U64.Basic
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-def MAX_U64 : UInt64 := 0xFFFF_FFFF_FFFF_FFFF
+abbrev MAX_U64 : UInt64 := 0xFFFF_FFFF_FFFF_FFFF
 
 /-- The inlined chunk `[.constI64 allOnes, .xorI64]` computes `~~~a` after reading a local. -/
 theorem not_chunk : UnChunk (T := UInt64) [.constI64 MAX_U64, .xorI64] (~~~ ·) := by

--- a/codelib/CodeLib/RustStd/U64/Not.lean
+++ b/codelib/CodeLib/RustStd/U64/Not.lean
@@ -1,40 +1,26 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::not` (`!a`) — inlined to a local read, then `constI64 0xFFFF…FFFF; xor`. -/
+/-! `u64::not` (`!a`) — inlined to `constI64 0xFFFF…FFFF; xor`. The
+`a ^^^ MAX_U64 = ~~~a` identity is the only `bv_decide` here, proven once in the
+chunk and reused by the concrete restatement. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
 abbrev MAX_U64 : UInt64 := 0xFFFF_FFFF_FFFF_FFFF
 
-/-- The inlined chunk `[.constI64 allOnes, .xorI64]` computes `~~~a` after reading a local. -/
+/-- The reusable chunk: `[.constI64 MAX_U64, .xorI64]` computes `~~~` on a stack
+operand. The `a ^^^ MAX_U64 = ~~~a` `bv_decide` lives here, once. -/
 theorem not_chunk : UnChunk (T := UInt64) [.constI64 MAX_U64, .xorI64] (~~~ ·) := by
-  intro α m env Q st P L rest i a vs ha
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha,
-    wp_constI64_cons, wp_xorI64_cons]
-  rw [show a ^^^ MAX_U64 = ~~~a from by
-    simp [MAX_U64]
-    bv_decide]
-
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::not`, reusing `not_chunk`. -/
-theorem notBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a : UInt64) (vs : List Value) :
-    wp m ([.localGet 0] ++ [.constI64 MAX_U64, .xorI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a], [], .i64 (~~~a) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a], [], vs⟩ env :=
-  unBodyWp not_chunk st 0 a vs rfl
+  intro α m env Q st P L rest a vs
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_constI64_cons, wp_xorI64_cons]
+  rw [show a ^^^ MAX_U64 = ~~~a from by simp [MAX_U64]; bv_decide]
 
 /-- Concrete `i64` restatement of `not_chunk` for `rw`/`simp` at an inlined `not`. -/
 theorem not_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (vs : List Value) :
     wp m (.constI64 MAX_U64 :: .xorI64 :: rest) Q st ⟨P, L, .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (~~~a) :: vs⟩ env :=
-  by
-    simp only [wp_constI64_cons, wp_xorI64_cons]
-    rw [show a ^^^ MAX_U64 = ~~~a from by
-      simp [MAX_U64]
-      bv_decide]
+      wp m rest Q st ⟨P, L, .i64 (~~~a) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append] using not_chunk (rest := rest) a vs
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Not.lean
+++ b/codelib/CodeLib/RustStd/U64/Not.lean
@@ -1,29 +1,40 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::not` (`!a`) — inlined to `constI64 0xFFFF…FFFF; xor`. -/
+/-! `u64::not` (`!a`) — inlined to a local read, then `constI64 0xFFFF…FFFF; xor`. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.constI64 allOnes, .xorI64]` computes `~~~a`. -/
-theorem not_chunk : UnChunk (T := UInt64) [.constI64 18446744073709551615, .xorI64] (~~~ ·) := by
-  intro α m env Q st P L rest a vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_constI64_cons, wp_xorI64_cons]
-  rw [show a ^^^ 18446744073709551615 = ~~~a from by bv_decide]
+def MAX_U64 : UInt64 := 0xFFFF_FFFF_FFFF_FFFF
+
+/-- The inlined chunk `[.constI64 allOnes, .xorI64]` computes `~~~a` after reading a local. -/
+theorem not_chunk : UnChunk (T := UInt64) [.constI64 MAX_U64, .xorI64] (~~~ ·) := by
+  intro α m env Q st P L rest i a vs ha
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha,
+    wp_constI64_cons, wp_xorI64_cons]
+  rw [show a ^^^ MAX_U64 = ~~~a from by
+    simp [MAX_U64]
+    bv_decide]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::not`, reusing `not_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::not`, reusing `not_chunk`. -/
 theorem notBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a : UInt64) (vs : List Value) :
-    wp m ([.localGet 0] ++ [.constI64 18446744073709551615, .xorI64] ++ [.ret])
-      (Returns (.i64 (~~~a) :: vs) (framePost st)) st ⟨[.i64 a], [], vs⟩ env :=
-  unBodyWp not_chunk st a vs
+    wp m ([.localGet 0] ++ [.constI64 MAX_U64, .xorI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a], [], .i64 (~~~a) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a], [], vs⟩ env :=
+  unBodyWp not_chunk st 0 a vs rfl
 
 /-- Concrete `i64` restatement of `not_chunk` for `rw`/`simp` at an inlined `not`. -/
 theorem not_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (vs : List Value) :
-    wp m (.constI64 18446744073709551615 :: .xorI64 :: rest) Q st ⟨P, L, .i64 a :: vs⟩ env ↔
+    wp m (.constI64 MAX_U64 :: .xorI64 :: rest) Q st ⟨P, L, .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (~~~a) :: vs⟩ env :=
-  not_chunk a vs
+  by
+    simp only [wp_constI64_cons, wp_xorI64_cons]
+    rw [show a ^^^ MAX_U64 = ~~~a from by
+      simp [MAX_U64]
+      bv_decide]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Rem.lean
+++ b/codelib/CodeLib/RustStd/U64/Rem.lean
@@ -1,56 +1,42 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::rem` (`a % b`) — reusable pieces for the zero-divisor guard and `i64.rem_u`. -/
+/-! `u64::rem` (`a % b`) — a zero-divisor guard `block` around `i64.rem_u`,
+reusing the trunk's `checkedBinBodyReturnsWp` template. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Local-read chunk for the bare `i64.rem_u`, after a caller has established
-that the divisor is nonzero. -/
-
+/-- The reusable chunk for the bare `i64.rem_u`, carrying the nonzero-divisor
+precondition. -/
 theorem rem_chunk :
-    HBinChunkWhere (A := UInt64) (B := UInt64) (C := UInt64)
+    BinChunk (A := UInt64) (B := UInt64) (C := UInt64)
       [.remUI64] (· % ·) (fun _ b => b ≠ 0) := by
-  intro α m env Q st P L rest i j a b vs ha hb hne
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_remUI64_cons, hne, ↓reduceIte]
+  intro α m env Q st P L rest a b vs hne
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_remUI64_cons, hne, ↓reduceIte]
 
-/-- Stack convenience theorem for inlined proof sites after the guard has loaded operands. -/
+/-- Concrete restatement of `rem_chunk` for `rw`/`simp` at an inlined `i64.rem_u`
+once the guard has loaded operands. -/
 theorem rem_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value)
     (hb : b ≠ 0) :
     wp m (.remUI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a % b) :: vs⟩ env := by
-  simp only [wp_remUI64_cons, hb, ↓reduceIte]
-
-/-- Guarded remainder body fragment, parameterized by dividend/divisor locals.
-The panic tail emitted after the block is deliberately not part of this reusable
-fragment. -/
-abbrev remCheckedBody (i j : Nat) : Program :=
-  [.block 0 0 (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.remUI64, .ret])]
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using rem_chunk (rest := rest) a b vs hb
 
 set_option maxRecDepth 4096 in
-/-- Checked remainder body theorem for any dividend/divisor local pair. -/
+/-- Checked remainder body for any dividend/divisor local pair, reusing the
+trunk's guarded-body template with the `nonzeroGuard` fall-through. The panic
+`tail` is arbitrary (unreachable when `b ≠ 0`). -/
 theorem remBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     {P L : List Value} (i j : Nat) (a b : UInt64) (vs : List Value) (tail : Program)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
     (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i64 b))
     (hne : b ≠ 0) :
-    wp m (remCheckedBody i j ++ tail) (Returns (.i64 (a % b) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env := by
-  unfold remCheckedBody Returns framePost
-  apply wp_block_cons
-  change wp m
-    (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.remUI64, .ret])
-    _ st ⟨P, L, vs⟩ env
-  rw [List.append_assoc (nonzeroGuard j) [.localGet i, .localGet j] [.remUI64, .ret]]
-  rw [nonzeroGuardWp j b vs hb hne]
-  change wp m ([.localGet i, .localGet j] ++ [.remUI64] ++ [.ret])
-    _ st ⟨P, L, vs⟩ env
-  rw [rem_chunk i j a b vs ha hb hne]
-  simp
+    wp m (checkedBinBody (nonzeroGuard j) [.remUI64] i j ++ tail)
+      (Returns (.i64 (a % b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env :=
+  checkedBinBodyReturnsWp rem_chunk st i j a b vs tail
+    (fun {_Q _rest} => nonzeroGuardWp j b vs hb hne) ha hb hne
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Rem.lean
+++ b/codelib/CodeLib/RustStd/U64/Rem.lean
@@ -1,38 +1,56 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::rem` (`a % b`) — inlined as a zero-divisor guard `block` around `i64.rem_u`. -/
+/-! `u64::rem` (`a % b`) — reusable pieces for the zero-divisor guard and `i64.rem_u`. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The bare `i64.rem_u` chunk on stack operands, divisor ≠ 0. -/
-theorem rem_chunk {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
+/-- Local-read chunk for the bare `i64.rem_u`, after a caller has established
+that the divisor is nonzero. -/
+
+theorem rem_chunk :
+    HBinChunkWhere (A := UInt64) (B := UInt64) (C := UInt64)
+      [.remUI64] (· % ·) (fun _ b => b ≠ 0) := by
+  intro α m env Q st P L rest i j a b vs ha hb hne
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_remUI64_cons, hne, ↓reduceIte]
+
+/-- Stack convenience theorem for inlined proof sites after the guard has loaded operands. -/
+theorem rem_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value)
     (hb : b ≠ 0) :
     wp m (.remUI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a % b) :: vs⟩ env := by
   simp only [wp_remUI64_cons, hb, ↓reduceIte]
 
-/-- Verbatim opt-0 body of `rust_u64::rem`. -/
-def remBody : Program :=
-  [ .block 0 0 [ .localGet 1, .constI64 0, .eqI64, .const 1, .and, .br_if 0,
-                 .localGet 0, .localGet 1, .remUI64, .ret ],
-    .const 1048616, .call 67, .unreachable ]
+/-- Guarded remainder body fragment, parameterized by dividend/divisor locals.
+The panic tail emitted after the block is deliberately not part of this reusable
+fragment. -/
+abbrev remCheckedBody (i j : Nat) : Program :=
+  [.block 0 0 (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.remUI64, .ret])]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::rem` (divisor ≠ 0): peel the guard, then
-**reuse `rem_chunk`** for the remainder (the `remUI64` atomic is excluded). -/
+/-- Checked remainder body theorem for any dividend/divisor local pair. -/
 theorem remBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) (hb : b ≠ 0) :
-    wp m remBody (Returns (.i64 (a % b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env := by
-  unfold remBody Returns framePost
+    {P L : List Value} (i j : Nat) (a b : UInt64) (vs : List Value) (tail : Program)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i64 b))
+    (hne : b ≠ 0) :
+    wp m (remCheckedBody i j ++ tail) (Returns (.i64 (a % b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env := by
+  unfold remCheckedBody Returns framePost
   apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
-  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
-    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT,
-    reduceIte, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons,
-    wp_and_cons, wp_br_if_cons, h10]
-  rw [rem_chunk a b _ hb]
+  change wp m
+    (nonzeroGuard j ++ [.localGet i, .localGet j] ++ [.remUI64, .ret])
+    _ st ⟨P, L, vs⟩ env
+  rw [List.append_assoc (nonzeroGuard j) [.localGet i, .localGet j] [.remUI64, .ret]]
+  rw [nonzeroGuardWp j b vs hb hne]
+  change wp m ([.localGet i, .localGet j] ++ [.remUI64] ++ [.ret])
+    _ st ⟨P, L, vs⟩ env
+  rw [rem_chunk i j a b vs ha hb hne]
   simp
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Shl.lean
+++ b/codelib/CodeLib/RustStd/U64/Shl.lean
@@ -1,46 +1,31 @@
 import CodeLib.RustStd.U64.Basic
 
 /-! `u64::shl` (`a << b`, `b : u32`) — inlined as the shared mask-extend-shift
-prefix followed by `shlI64`, a shift by `b % 64`. -/
+prefix followed by `shlI64`, a shift by `b % 64`. The `b % 64` normalisation is
+the trunk-level `shiftAmount_norm` (shared with `shr`), so there is no
+`bv_decide` in this file. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Local-read chunk theorem for `a << b`; the `b % 64` normalisation is baked in once here. -/
+/-- The reusable chunk for `a << b` (heterogeneous: `a : u64`, `b : u32`): the
+mask-extend-shift sequence on stack operands, normalising the count via
+`shiftAmount_norm`. -/
 theorem shl_chunk :
-    HBinChunk (A := UInt64) (B := UInt32) (C := UInt64)
-      (shiftAmountFrag ++ [.shlI64])
-      (fun a b => a <<< (b.toUInt64 % 64)) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64, toV_u32] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i32 b) := by
-    simpa [Locals.get] using hb
-  have hamt : a <<< (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a <<< (b.toUInt64 % 64) := by
-    simp; bv_decide
-  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, wp_localGet_cons,
-    ha, hb', wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shlI64_cons, hamt]
+    BinChunk (A := UInt64) (B := UInt32) (C := UInt64)
+      (shiftAmountFrag ++ [.shlI64]) (fun a b => a <<< (b.toUInt64 % 64)) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, toV_u32,
+    wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shlI64_cons, shiftAmount_norm]
 
-/-- Stack convenience theorem for inlined proof sites that have already loaded operands. -/
+/-- Concrete restatement of `shl_chunk` for `rw`/`simp` at an inlined `a << b`. -/
 theorem shl_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (b : UInt32)
     (vs : List Value) :
     wp m (.const shiftMask :: .and :: .extendUI32 :: .shlI64 :: rest) Q st
         ⟨P, L, .i32 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a <<< (b.toUInt64 % 64)) :: vs⟩ env := by
-  have hamt : a <<< (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a <<< (b.toUInt64 % 64) := by
-    simp; bv_decide
-  simp only [wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shlI64_cons, hamt]
-
-/-- Fallthrough body theorem for `rust_u64::shl`, built by reusing `shl_chunk`. -/
-theorem shlBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a : UInt64) (b : UInt32) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i32 b)) :
-    wp m ([.localGet i, .localGet j] ++ shiftAmountFrag ++ [.shlI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, .i64 (a <<< (b.toUInt64 % 64)) :: vs⟩ ∧
-          framePost st st')
-      st ⟨P, L, vs⟩ env :=
-  hbinBodyWp shl_chunk st i j a b vs ha hb
+  simpa only [shiftAmountFrag, toV_u64, toV_u32, List.cons_append, List.nil_append]
+    using shl_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Shl.lean
+++ b/codelib/CodeLib/RustStd/U64/Shl.lean
@@ -1,46 +1,46 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::shl` (`a << b`, `b : u32`) — inlined as the mask-extend-shift sequence
-`const 63; and; extendUI32; shlI64`, a shift by `b % 64`.
-
-The reusable unit is `shl_seq`: a chunk theorem about that inlined sequence run
-on stack operands. It is width-specific (the `extendUI32` and the mask `63`), so
-it lives here rather than in the trunk, but it plays the same role as `add_seq`
-— the *same* theorem discharges an inlined `a << b` (rewrite it at the
-occurrence, with the `shlI64` atomic excluded) and the called export body
-(`shlBodyWp`). -/
+/-! `u64::shl` (`a << b`, `b : u32`) — inlined as the shared mask-extend-shift
+prefix followed by `shlI64`, a shift by `b % 64`. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Chunk theorem: the inlined `const 63; and; extendUI32; shlI64` sequence, run
-on `i32 b :: i64 a` operands, computes `a <<< (b % 64)`. Reuse this wherever
-`a << b` is inlined; the `b % 64` normalisation is baked in once here. -/
+/-- Local-read chunk theorem for `a << b`; the `b % 64` normalisation is baked in once here. -/
+theorem shl_chunk :
+    HBinChunk (A := UInt64) (B := UInt32) (C := UInt64)
+      (shiftAmountFrag ++ [.shlI64])
+      (fun a b => a <<< (b.toUInt64 % 64)) := by
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64, toV_u32] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i32 b) := by
+    simpa [Locals.get] using hb
+  have hamt : a <<< (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a <<< (b.toUInt64 % 64) := by
+    simp; bv_decide
+  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, wp_localGet_cons,
+    ha, hb', wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shlI64_cons, hamt]
+
+/-- Stack convenience theorem for inlined proof sites that have already loaded operands. -/
 theorem shl_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (b : UInt32)
     (vs : List Value) :
-    wp m (.const 63 :: .and :: .extendUI32 :: .shlI64 :: rest) Q st
+    wp m (.const shiftMask :: .and :: .extendUI32 :: .shlI64 :: rest) Q st
         ⟨P, L, .i32 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a <<< (b.toUInt64 % 64)) :: vs⟩ env := by
-  have hamt : a <<< (UInt64.ofNat (63 &&& b).toNat % 64) = a <<< (b.toUInt64 % 64) := by
+  have hamt : a <<< (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a <<< (b.toUInt64 % 64) := by
     simp; bv_decide
   simp only [wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shlI64_cons, hamt]
 
-/-- Verbatim opt-0 body of `rust_u64::shl`. -/
-def shlBody : Program :=
-  [ .localGet 0, .localGet 1, .const 63, .and, .extendUI32, .shlI64, .ret ]
-
-set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::shl`, built by **reusing** `shl_seq`
-(the `shlI64` atomic is never touched here — the chunk is the only path). -/
+/-- Fallthrough body theorem for `rust_u64::shl`, built by reusing `shl_chunk`. -/
 theorem shlBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a : UInt64) (b : UInt32) (vs : List Value) :
-    wp m shlBody (Returns (.i64 (a <<< (b.toUInt64 % 64)) :: vs) (framePost st))
-      st ⟨[.i64 a, .i32 b], [], vs⟩ env := by
-  unfold shlBody Returns framePost
-  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
-    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT,
-    reduceIte, shl_seq, wp_ret_cons]
-  simp
+    {P L : List Value} (i j : Nat) (a : UInt64) (b : UInt32) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i32 b)) :
+    wp m ([.localGet i, .localGet j] ++ shiftAmountFrag ++ [.shlI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, .i64 (a <<< (b.toUInt64 % 64)) :: vs⟩ ∧
+          framePost st st')
+      st ⟨P, L, vs⟩ env :=
+  hbinBodyWp shl_chunk st i j a b vs ha hb
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Shr.lean
+++ b/codelib/CodeLib/RustStd/U64/Shr.lean
@@ -1,42 +1,46 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::shr` (`a >> b`, `b : u32`) — inlined as the mask-extend-shift sequence
-`const 63; and; extendUI32; shrUI64`, a logical shift by `b % 64`.
-
-`shr_seq` is the reusable chunk theorem (see `Shl.lean` for the design notes);
-the *same* theorem discharges an inlined `a >> b` and the called export body
-`shrBodyWp`. -/
+/-! `u64::shr` (`a >> b`, `b : u32`) — inlined as the shared mask-extend-shift
+prefix followed by `shrUI64`, a logical shift by `b % 64`. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Chunk theorem: the inlined `const 63; and; extendUI32; shrUI64` sequence, run
-on `i32 b :: i64 a` operands, computes `a >>> (b % 64)`. Reuse this wherever
-`a >> b` is inlined. -/
+/-- Local-read chunk theorem for `a >> b`; the `b % 64` normalisation is baked in once here. -/
+theorem shr_chunk :
+    HBinChunk (A := UInt64) (B := UInt32) (C := UInt64)
+      (shiftAmountFrag ++ [.shrUI64])
+      (fun a b => a >>> (b.toUInt64 % 64)) := by
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64, toV_u32] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i32 b) := by
+    simpa [Locals.get] using hb
+  have hamt : a >>> (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a >>> (b.toUInt64 % 64) := by
+    simp; bv_decide
+  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, wp_localGet_cons,
+    ha, hb', wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shrUI64_cons, hamt]
+
+/-- Stack convenience theorem for inlined proof sites that have already loaded operands. -/
 theorem shr_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (b : UInt32)
     (vs : List Value) :
-    wp m (.const 63 :: .and :: .extendUI32 :: .shrUI64 :: rest) Q st
+    wp m (.const shiftMask :: .and :: .extendUI32 :: .shrUI64 :: rest) Q st
         ⟨P, L, .i32 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a >>> (b.toUInt64 % 64)) :: vs⟩ env := by
-  have hamt : a >>> (UInt64.ofNat (63 &&& b).toNat % 64) = a >>> (b.toUInt64 % 64) := by
+  have hamt : a >>> (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a >>> (b.toUInt64 % 64) := by
     simp; bv_decide
   simp only [wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shrUI64_cons, hamt]
 
-/-- Verbatim opt-0 body of `rust_u64::shr`. -/
-def shrBody : Program :=
-  [ .localGet 0, .localGet 1, .const 63, .and, .extendUI32, .shrUI64, .ret ]
-
-set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::shr`, built by **reusing** `shr_seq`. -/
+/-- Fallthrough body theorem for `rust_u64::shr`, built by reusing `shr_chunk`. -/
 theorem shrBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a : UInt64) (b : UInt32) (vs : List Value) :
-    wp m shrBody (Returns (.i64 (a >>> (b.toUInt64 % 64)) :: vs) (framePost st))
-      st ⟨[.i64 a, .i32 b], [], vs⟩ env := by
-  unfold shrBody Returns framePost
-  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
-    List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT,
-    reduceIte, shr_seq, wp_ret_cons]
-  simp
+    {P L : List Value} (i j : Nat) (a : UInt64) (b : UInt32) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i32 b)) :
+    wp m ([.localGet i, .localGet j] ++ shiftAmountFrag ++ [.shrUI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, .i64 (a >>> (b.toUInt64 % 64)) :: vs⟩ ∧
+          framePost st st')
+      st ⟨P, L, vs⟩ env :=
+  hbinBodyWp shr_chunk st i j a b vs ha hb
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Shr.lean
+++ b/codelib/CodeLib/RustStd/U64/Shr.lean
@@ -1,46 +1,31 @@
 import CodeLib.RustStd.U64.Basic
 
 /-! `u64::shr` (`a >> b`, `b : u32`) — inlined as the shared mask-extend-shift
-prefix followed by `shrUI64`, a logical shift by `b % 64`. -/
+prefix followed by `shrUI64`, a logical shift by `b % 64`. The `b % 64`
+normalisation is the trunk-level `shiftAmount_norm` (shared with `shl`), so there
+is no `bv_decide` in this file. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- Local-read chunk theorem for `a >> b`; the `b % 64` normalisation is baked in once here. -/
+/-- The reusable chunk for `a >> b` (heterogeneous: `a : u64`, `b : u32`): the
+mask-extend-shift sequence on stack operands, normalising the count via
+`shiftAmount_norm`. -/
 theorem shr_chunk :
-    HBinChunk (A := UInt64) (B := UInt32) (C := UInt64)
-      (shiftAmountFrag ++ [.shrUI64])
-      (fun a b => a >>> (b.toUInt64 % 64)) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64, toV_u32] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i32 b) := by
-    simpa [Locals.get] using hb
-  have hamt : a >>> (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a >>> (b.toUInt64 % 64) := by
-    simp; bv_decide
-  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, wp_localGet_cons,
-    ha, hb', wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shrUI64_cons, hamt]
+    BinChunk (A := UInt64) (B := UInt32) (C := UInt64)
+      (shiftAmountFrag ++ [.shrUI64]) (fun a b => a >>> (b.toUInt64 % 64)) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [shiftAmountFrag, List.cons_append, List.nil_append, toV_u64, toV_u32,
+    wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shrUI64_cons, shiftAmount_norm]
 
-/-- Stack convenience theorem for inlined proof sites that have already loaded operands. -/
+/-- Concrete restatement of `shr_chunk` for `rw`/`simp` at an inlined `a >> b`. -/
 theorem shr_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a : UInt64) (b : UInt32)
     (vs : List Value) :
     wp m (.const shiftMask :: .and :: .extendUI32 :: .shrUI64 :: rest) Q st
         ⟨P, L, .i32 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a >>> (b.toUInt64 % 64)) :: vs⟩ env := by
-  have hamt : a >>> (UInt64.ofNat (shiftMask &&& b).toNat % 64) = a >>> (b.toUInt64 % 64) := by
-    simp; bv_decide
-  simp only [wp_const_cons, wp_and_cons, wp_extendUI32_cons, wp_shrUI64_cons, hamt]
-
-/-- Fallthrough body theorem for `rust_u64::shr`, built by reusing `shr_chunk`. -/
-theorem shrBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a : UInt64) (b : UInt32) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (.i64 a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (.i32 b)) :
-    wp m ([.localGet i, .localGet j] ++ shiftAmountFrag ++ [.shrUI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, .i64 (a >>> (b.toUInt64 % 64)) :: vs⟩ ∧
-          framePost st st')
-      st ⟨P, L, vs⟩ env :=
-  hbinBodyWp shr_chunk st i j a b vs ha hb
+  simpa only [shiftAmountFrag, toV_u64, toV_u32, List.cons_append, List.nil_append]
+    using shr_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Sub.lean
+++ b/codelib/CodeLib/RustStd/U64/Sub.lean
@@ -1,23 +1,28 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::sub` — inlined to a single `i64.subI64`. Chunk fact + export body, reusing the trunk. -/
+/-! `u64::sub` — inlined to local reads plus a single `i64.subI64`. Chunk fact + body, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.subI64]` computes `-` on stack operands (reusable wherever
-`a - b` is inlined). -/
+/-- The inlined chunk `[.subI64]` computes `-` after operands are read from locals. -/
 theorem sub_chunk : BinChunk (T := UInt64) [.subI64] (· - ·) := by
-  intro α m env Q st P L rest a b vs
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_subI64_cons]
+  intro α m env Q st P L rest i j a b vs ha hb
+  simp only [toV_u64] at ha hb
+  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
+    simpa [Locals.get] using hb
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
+    wp_subI64_cons]
 
 set_option maxRecDepth 4096 in
-/-- Export-body theorem for `rust_u64::sub`, built by reusing `sub_chunk`. -/
+/-- Fallthrough body theorem for `rust_u64::sub`, built by reusing `sub_chunk`. -/
 theorem subBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
     (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.subI64] ++ [.ret])
-      (Returns (.i64 (a - b) :: vs) (framePost st)) st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp sub_chunk st a b vs
+    wp m ([.localGet 0, .localGet 1] ++ [.subI64])
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a - b) :: vs⟩ ∧ framePost st st')
+      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
+  binBodyWp sub_chunk st 0 1 a b vs rfl rfl
 
 /-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
 inlined `i64.sub`), reusing the polymorphic chunk. -/
@@ -25,6 +30,6 @@ theorem sub_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.subI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
       wp m rest Q st ⟨P, L, .i64 (a - b) :: vs⟩ env :=
-  sub_chunk a b vs
+  by simp only [wp_subI64_cons]
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/U64/Sub.lean
+++ b/codelib/CodeLib/RustStd/U64/Sub.lean
@@ -1,35 +1,22 @@
 import CodeLib.RustStd.U64.Basic
 
-/-! `u64::sub` — inlined to local reads plus a single `i64.subI64`. Chunk fact + body, reusing the trunk. -/
+/-! `u64::sub` — inlined to a single `i64.subI64`. Chunk fact + concrete
+restatement, reusing the trunk. -/
 
 namespace Wasm.RustStd.U64
 open Wasm Wasm.RustStd
 
-/-- The inlined chunk `[.subI64]` computes `-` after operands are read from locals. -/
-theorem sub_chunk : BinChunk (T := UInt64) [.subI64] (· - ·) := by
-  intro α m env Q st P L rest i j a b vs ha hb
-  simp only [toV_u64] at ha hb
-  have hb' : (⟨P, L, .i64 a :: vs⟩ : Locals).get j = some (.i64 b) := by
-    simpa [Locals.get] using hb
-  simp only [List.cons_append, List.nil_append, toV_u64, wp_localGet_cons, ha, hb',
-    wp_subI64_cons]
+/-- The reusable chunk: `[.subI64]` computes `-` on stack operands. -/
+theorem sub_chunk : BinChunk [.subI64] ((· - ·) : UInt64 → UInt64 → UInt64) := by
+  intro α m env Q st P L rest a b vs _
+  simp only [List.cons_append, List.nil_append, toV_u64, wp_subI64_cons]
 
-set_option maxRecDepth 4096 in
-/-- Fallthrough body theorem for `rust_u64::sub`, built by reusing `sub_chunk`. -/
-theorem subBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    (a b : UInt64) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ [.subI64])
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨[.i64 a, .i64 b], [], .i64 (a - b) :: vs⟩ ∧ framePost st st')
-      st ⟨[.i64 a, .i64 b], [], vs⟩ env :=
-  binBodyWp sub_chunk st 0 1 a b vs rfl rfl
-
-/-- Concrete `i64` restatement (matches emitted opcodes for `rw`/`simp` at an
-inlined `i64.sub`), reusing the polymorphic chunk. -/
+/-- Concrete `i64` restatement for `rw`/`simp` at an inlined `i64.sub`. -/
 theorem sub_seq {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α}
     {st : Store α} {P L : List Value} {rest : Program} (a b : UInt64) (vs : List Value) :
     wp m (.subI64 :: rest) Q st ⟨P, L, .i64 b :: .i64 a :: vs⟩ env ↔
-      wp m rest Q st ⟨P, L, .i64 (a - b) :: vs⟩ env :=
-  by simp only [wp_subI64_cons]
+      wp m rest Q st ⟨P, L, .i64 (a - b) :: vs⟩ env := by
+  simpa only [toV_u64, List.cons_append, List.nil_append]
+    using sub_chunk (rest := rest) a b vs trivial
 
 end Wasm.RustStd.U64

--- a/codelib/CodeLib/RustStd/UInt.lean
+++ b/codelib/CodeLib/RustStd/UInt.lean
@@ -19,9 +19,10 @@ general binary shape: if locals `i` and `j` contain encoded `a` and `b`, then
 `[localGet i, localGet j] ++ frag` followed by any `rest` is equivalent to
 running `rest` with the encoded result on top of the existing operand stack.
 `BinChunk` is the homogeneous specialization of that shape, and `UnChunk` is
-the unary variant. The body helpers produce `Continuation.Fallthrough`
-postconditions for reusable instruction sequences; they deliberately do not
-append or reason about `.ret`.
+the unary variant. `HBinChunkWhere` is the same binary shape with an explicit
+side condition for operations that can trap on some inputs. The body helpers
+produce `Continuation.Fallthrough` postconditions for reusable instruction
+sequences; they deliberately do not append or reason about `.ret`.
 -/
 
 namespace Wasm.RustStd
@@ -32,6 +33,13 @@ open Wasm
 class UIntWasm (T : Type) where
   /-- The wasm value carrying a `T`. -/
   toV : T → Value
+
+/-- `u32` is carried as `Value.i32`, including when it is a mixed-width operand
+to a `u64` operation such as shifts. -/
+instance instUIntWasmUInt32 : UIntWasm UInt32 where
+  toV a := .i32 a
+
+@[simp] theorem toV_u32 (a : UInt32) : (UIntWasm.toV a : Value) = .i32 a := rfl
 
 section
 variable {T : Type} [UIntWasm T]
@@ -53,6 +61,19 @@ abbrev HBinChunk {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
     wp m ([.localGet i, .localGet j] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a b) :: vs⟩ env
 
+/-- Heterogeneous binary chunk shape with an input side condition. Use this for
+instructions that trap on some operand values, such as unsigned division by
+zero. -/
+abbrev HBinChunkWhere {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    (frag : Program) (op : A → B → C) (pre : A → B → Prop) : Prop :=
+  ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
+    {P L : List Value} {rest : Program} (i j : Nat) (a : A) (b : B) (vs : List Value)
+    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (_hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
+    (_hpre : pre a b),
+    wp m ([.localGet i, .localGet j] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
+    wp m rest Q st ⟨P, L, toV (op a b) :: vs⟩ env
+
 /-- Homogeneous binary chunk shape, defined from the heterogeneous one. -/
 abbrev BinChunk (frag : Program) (op : T → T → T) : Prop :=
   HBinChunk frag op
@@ -65,10 +86,11 @@ abbrev UnChunk (frag : Program) (op : T → T) : Prop :=
     wp m ([.localGet i] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a) :: vs⟩ env
 
-/-- Turn a binary chunk into a fallthrough theorem for any local frame. -/
-theorem binBodyWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
+/-- Turn a heterogeneous binary chunk into a fallthrough theorem for any local frame. -/
+theorem hbinBodyWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag : Program} {op : A → B → C} (chunk : HBinChunk frag op)
     {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
+    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
     (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
     wp m ([.localGet i, .localGet j] ++ frag)
@@ -84,6 +106,85 @@ theorem binBodyWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag o
     unfold framePost
     simp
   simpa only [List.append_nil] using h
+
+/-- Turn a side-conditioned heterogeneous binary chunk into a fallthrough theorem
+for any local frame. -/
+theorem hbinBodyWpWhere {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag : Program} {op : A → B → C} {pre : A → B → Prop}
+    (chunk : HBinChunkWhere frag op pre)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
+    (hpre : pre a b) :
+    wp m ([.localGet i, .localGet j] ++ frag)
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
+      st ⟨P, L, vs⟩ env := by
+  have h :
+      wp m ([.localGet i, .localGet j] ++ frag ++ [])
+        (fun c => ∃ st',
+          c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
+        st ⟨P, L, vs⟩ env := by
+    rw [chunk i j a b vs ha hb hpre]
+    unfold framePost
+    simp
+  simpa only [List.append_nil] using h
+
+/-- Variant of `hbinBodyWp` for exported function bodies that immediately return
+after the reusable fragment. -/
+theorem hbinBodyReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag : Program} {op : A → B → C} (chunk : HBinChunk frag op)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
+    wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
+      (Returns (toV (op a b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env := by
+  rw [chunk i j a b vs ha hb]
+  unfold Returns framePost
+  simp
+
+/-- Variant of `hbinBodyWpWhere` for exported function bodies that immediately
+return after the reusable fragment. -/
+theorem hbinBodyWhereReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag : Program} {op : A → B → C} {pre : A → B → Prop}
+    (chunk : HBinChunkWhere frag op pre)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
+    (hpre : pre a b) :
+    wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
+      (Returns (toV (op a b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env := by
+  rw [chunk i j a b vs ha hb hpre]
+  unfold Returns framePost
+  simp
+
+/-- Turn a homogeneous binary chunk into a fallthrough theorem for any local frame. -/
+theorem binBodyWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
+    wp m ([.localGet i, .localGet j] ++ frag)
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
+      st ⟨P, L, vs⟩ env :=
+  hbinBodyWp chunk st i j a b vs ha hb
+
+/-- Homogeneous specialization of `hbinBodyReturnsWp`. -/
+theorem binBodyReturnsWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
+    wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
+      (Returns (toV (op a b) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env :=
+  hbinBodyReturnsWp chunk st i j a b vs ha hb
 
 /-- Turn a unary chunk into a fallthrough theorem for any local frame. -/
 theorem unBodyWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
@@ -103,6 +204,19 @@ theorem unBodyWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
     unfold framePost
     simp
   simpa only [List.append_nil] using h
+
+/-- Variant of `unBodyWp` for exported function bodies that immediately return
+after the reusable fragment. -/
+theorem unBodyReturnsWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i : Nat) (a : T) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)) :
+    wp m ([.localGet i] ++ frag ++ [.ret])
+      (Returns (toV (op a) :: vs) (framePost st))
+      st ⟨P, L, vs⟩ env := by
+  rw [chunk i a vs ha]
+  unfold Returns framePost
+  simp
 
 end
 

--- a/codelib/CodeLib/RustStd/UInt.lean
+++ b/codelib/CodeLib/RustStd/UInt.lean
@@ -6,38 +6,35 @@ import CodeLib.Entry
 /-!
 # `CodeLib.RustStd.UInt` — the type-agnostic trunk
 
-Common reasoning shared by every fixed-width unsigned integer type. A
-`UIntWasm T` instance just fixes how a `T` is carried as a wasm `Value`
-(`toV`); everything reusable is proven once here, over an arbitrary instance,
-and each per-type / per-function file (`U64/Add.lean`, `U32/Add.lean`, …) plugs
-in its concrete instruction fragment.
+Common reasoning shared by Rust-style integer operations compiled to Wasm. A
+`UIntWasm T` instance only fixes how a Lean type `T` is carried as a wasm
+`Value` (`toV`); algebraic structure stays with the concrete operation theorem.
+That keeps this trunk usable for homogeneous operations (`UInt64 → UInt64 →
+UInt64`) and heterogeneous ones (`A → B → C`) whose operands/results have
+different wasm encodings.
 
-The reusable unit is a **chunk theorem**: "this inlined instruction sequence,
-run on stack operands, computes this Lean operation". A `BinChunk` is stated
-with the operands on the value stack (`⟨P, L, toV b :: toV a :: vs⟩`) so it
-`rw`s directly onto an inlined occurrence — no `.call`, no shim, exactly what
-`opt-0`'s "same inlined sequence everywhere" buys us. The chunk for a given
-`(type, op)` lives in that op's file and is discharged by reusing the
-interpreter's atomic `wp_*` lemma; `binBodyWp`/`unBodyWp` here turn any chunk
-into the function-body theorem the per-crate `TerminatesWith` spec bridges via
-`of_returns_wp` (so the *same* chunk serves a called export and an inlined use).
+The reusable unit is a **chunk theorem**: "this instruction fragment, fed by
+operands read from locals, computes this Lean operation". `HBinChunk` is the
+general binary shape: if locals `i` and `j` contain encoded `a` and `b`, then
+`[localGet i, localGet j] ++ frag` followed by any `rest` is equivalent to
+running `rest` with the encoded result on top of the existing operand stack.
+`BinChunk` is the homogeneous specialization of that shape, and `UnChunk` is
+the unary variant. The body helpers produce `Continuation.Fallthrough`
+postconditions for reusable instruction sequences; they deliberately do not
+append or reason about `.ret`.
 -/
 
 namespace Wasm.RustStd
 
 open Wasm
 
-/-- A fixed-width unsigned integer type carried as a wasm `Value`. The algebraic
-operations come from `T`'s existing instances; only the wasm encoding is new. -/
-class UIntWasm (T : Type)
-    [Add T] [Sub T] [Mul T] [AndOp T] [OrOp T] [HXor T T T] [Complement T]
-    [Div T] [Mod T] [OfNat T 0] [DecidableEq T] where
+/-- A fixed-width unsigned integer type carried as a wasm `Value`. -/
+class UIntWasm (T : Type) where
   /-- The wasm value carrying a `T`. -/
   toV : T → Value
 
 section
-variable {T : Type} [Add T] [Sub T] [Mul T] [AndOp T] [OrOp T] [HXor T T T]
-  [Complement T] [Div T] [Mod T] [OfNat T 0] [DecidableEq T] [UIntWasm T]
+variable {T : Type} [UIntWasm T]
 
 open UIntWasm
 
@@ -45,51 +42,67 @@ open UIntWasm
 abbrev framePost {α} (st : Store α) : Store α → Prop :=
   fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages
 
-/-- Chunk shape for a binary op: with `toV b :: toV a :: vs` on the stack,
-running `frag` then `rest` equals running `rest` with `toV (op a b)` on the
-stack. The reusable inline-sequence theorem. -/
-abbrev BinChunk (frag : Program) (op : T → T → T) : Prop :=
+/-- Heterogeneous binary chunk shape. The operands are read from arbitrary
+locals `i` and `j`, not preloaded onto the operand stack. -/
+abbrev HBinChunk {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    (frag : Program) (op : A → B → C) : Prop :=
   ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
-    {P L : List Value} {rest : Program} (a b : T) (vs : List Value),
-    wp m (frag ++ rest) Q st ⟨P, L, toV b :: toV a :: vs⟩ env ↔
+    {P L : List Value} {rest : Program} (i j : Nat) (a : A) (b : B) (vs : List Value)
+    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (_hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)),
+    wp m ([.localGet i, .localGet j] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a b) :: vs⟩ env
 
-/-- Chunk shape for a unary op (`not`). -/
+/-- Homogeneous binary chunk shape, defined from the heterogeneous one. -/
+abbrev BinChunk (frag : Program) (op : T → T → T) : Prop :=
+  HBinChunk frag op
+
+/-- Chunk shape for a unary op (`not`), with the operand read from local `i`. -/
 abbrev UnChunk (frag : Program) (op : T → T) : Prop :=
   ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
-    {P L : List Value} {rest : Program} (a : T) (vs : List Value),
-    wp m (frag ++ rest) Q st ⟨P, L, toV a :: vs⟩ env ↔
+    {P L : List Value} {rest : Program} (i : Nat) (a : T) (vs : List Value)
+    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)),
+    wp m ([.localGet i] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a) :: vs⟩ env
 
-/-- Turn a binary chunk into the opt-0 export-body theorem
-`[localGet 0, localGet 1] ++ frag ++ [ret]` — by **reusing the chunk** (the
-opaque `frag` means `wp_run` can't bypass it). The per-crate spec feeds this to
-`of_returns_wp`. -/
+/-- Turn a binary chunk into a fallthrough theorem for any local frame. -/
 theorem binBodyWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α) (a b : T) (vs : List Value) :
-    wp m ([.localGet 0, .localGet 1] ++ frag ++ [.ret])
-      (Returns (toV (op a b) :: vs) (framePost st))
-      st ⟨[toV a, toV b], [], vs⟩ env := by
-  unfold Returns framePost
-  simp only [List.cons_append, List.nil_append]
-  wp_run
-  simp
-  rw [chunk a b vs]
-  simp
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
+    wp m ([.localGet i, .localGet j] ++ frag)
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
+      st ⟨P, L, vs⟩ env := by
+  have h :
+      wp m ([.localGet i, .localGet j] ++ frag ++ [])
+        (fun c => ∃ st',
+          c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
+        st ⟨P, L, vs⟩ env := by
+    rw [chunk i j a b vs ha hb]
+    unfold framePost
+    simp
+  simpa only [List.append_nil] using h
 
-/-- Turn a unary chunk into the opt-0 export-body theorem
-`[localGet 0] ++ frag ++ [ret]`. -/
+/-- Turn a unary chunk into a fallthrough theorem for any local frame. -/
 theorem unBodyWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α) (a : T) (vs : List Value) :
-    wp m ([.localGet 0] ++ frag ++ [.ret])
-      (Returns (toV (op a) :: vs) (framePost st))
-      st ⟨[toV a], [], vs⟩ env := by
-  unfold Returns framePost
-  simp only [List.cons_append, List.nil_append]
-  wp_run
-  simp
-  rw [chunk a vs]
-  simp
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i : Nat) (a : T) (vs : List Value)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)) :
+    wp m ([.localGet i] ++ frag)
+      (fun c => ∃ st',
+        c = .Fallthrough st' ⟨P, L, toV (op a) :: vs⟩ ∧ framePost st st')
+      st ⟨P, L, vs⟩ env := by
+  have h :
+      wp m ([.localGet i] ++ frag ++ [])
+        (fun c => ∃ st',
+          c = .Fallthrough st' ⟨P, L, toV (op a) :: vs⟩ ∧ framePost st st')
+        st ⟨P, L, vs⟩ env := by
+    rw [chunk i a vs ha]
+    unfold framePost
+    simp
+  simpa only [List.append_nil] using h
 
 end
 

--- a/codelib/CodeLib/RustStd/UInt.lean
+++ b/codelib/CodeLib/RustStd/UInt.lean
@@ -6,218 +6,181 @@ import CodeLib.Entry
 /-!
 # `CodeLib.RustStd.UInt` — the type-agnostic trunk
 
-Common reasoning shared by Rust-style integer operations compiled to Wasm. A
-`UIntWasm T` instance only fixes how a Lean type `T` is carried as a wasm
-`Value` (`toV`); algebraic structure stays with the concrete operation theorem.
-That keeps this trunk usable for homogeneous operations (`UInt64 → UInt64 →
-UInt64`) and heterogeneous ones (`A → B → C`) whose operands/results have
-different wasm encodings.
+Common reasoning shared by every fixed-width unsigned integer operation compiled
+to Wasm. The trunk is fully generic: it fixes *nothing* about a concrete width.
+A `UIntWasm T` instance (defined per width in `U8/Basic.lean`, `U32/Basic.lean`,
+`U64/Basic.lean`, …) only says how a Lean `T` is carried as a wasm `Value`
+(`toV`); all algebraic structure stays with the concrete operation theorem. The
+same trunk therefore serves homogeneous operations (`UInt64 → UInt64 → UInt64`)
+and heterogeneous ones (`A → B → C`, e.g. a `u64` shift by a `u32`).
 
-The reusable unit is a **chunk theorem**: "this instruction fragment, fed by
-operands read from locals, computes this Lean operation". `HBinChunk` is the
-general binary shape: if locals `i` and `j` contain encoded `a` and `b`, then
-`[localGet i, localGet j] ++ frag` followed by any `rest` is equivalent to
-running `rest` with the encoded result on top of the existing operand stack.
-`BinChunk` is the homogeneous specialization of that shape, and `UnChunk` is
-the unary variant. `HBinChunkWhere` is the same binary shape with an explicit
-side condition for operations that can trap on some inputs. The body helpers
-produce `Continuation.Fallthrough` postconditions for reusable instruction
-sequences; they deliberately do not append or reason about `.ret`.
+## The one reusable unit: a chunk
+
+A **chunk** is the fact "this instruction fragment computes this Lean operation,
+with the operands on the value stack". There is exactly one binary shape
+(`BinChunk`) and one unary shape (`UnChunk`); both are stated in *stack* form
+(operands already pushed), which is what you `rw` at an inlined occurrence. A
+chunk that can trap on some inputs carries a precondition `pre` (default `True`,
+so total ops never mention it).
+
+## From a chunk to an export body
+
+The compiler may instead emit the operation as a *called* function whose body
+reads its operands from parameter locals. The body helpers bridge the gap once:
+`wp_localGetPair` turns the two `localGet`s into the stack form, and
+`binBodyReturnsWp` / `unBodyReturnsWp` / `checkedBinBodyReturnsWp` package that
+plus the trailing `.ret` (and, for trapping ops, the guard `block`) into the
+`Returns` fact the per-crate `TerminatesWith` spec bridges via `of_returns_wp`.
+Because the body helpers consume the *same* chunk an inlined site uses, one chunk
+proof serves both "inlined" and "called" — and we never need to know in advance
+which the compiler chose.
+
+## Concrete widths
+
+The chunk algebra is width-generic; a `UIntWasm` instance supplies the carrier
+for each concrete width. `u32` (carried as `.i32`) is provided just below — it is
+the shift-count operand of a `u64` shift — and `u64` (carried as `.i64`) lives in
+`U64/Basic`. Width-specific algebraic facts (a `u64` shift count modulo 64, …) are
+ordinary Lean theorems proven in that width's files and fed to the chunk proof;
+the trunk never sees them.
+
+`UInt128` is intentionally absent: Lean core has no `UInt128`, and a wasm `Value`
+carries only `i32`/`i64` (no `i128`), so a `u128` is not a single value — it would
+need a `v128` or an `i64` pair, an encoding outside what `UIntWasm` models.
 -/
 
 namespace Wasm.RustStd
 
 open Wasm
 
-/-- A fixed-width unsigned integer type carried as a wasm `Value`. -/
+/-- A fixed-width unsigned integer type carried as a wasm `Value`. The chunk
+algebra below is generic over the instance; each concrete width provides one. -/
 class UIntWasm (T : Type) where
   /-- The wasm value carrying a `T`. -/
   toV : T → Value
 
-/-- `u32` is carried as `Value.i32`, including when it is a mixed-width operand
-to a `u64` operation such as shifts. -/
+open UIntWasm
+
+/-- `u32` is carried as `Value.i32`, including as a mixed-width operand to a wider
+operation such as a `u64` shift (whose count is a `u32`). -/
 instance instUIntWasmUInt32 : UIntWasm UInt32 where
   toV a := .i32 a
 
 @[simp] theorem toV_u32 (a : UInt32) : (UIntWasm.toV a : Value) = .i32 a := rfl
 
-section
-variable {T : Type} [UIntWasm T]
-
-open UIntWasm
-
 /-- Frame post shared by every export body: globals + page count preserved. -/
 abbrev framePost {α} (st : Store α) : Store α → Prop :=
   fun st' => st'.globals = st.globals ∧ st'.mem.pages = st.mem.pages
 
-/-- Heterogeneous binary chunk shape. The operands are read from arbitrary
-locals `i` and `j`, not preloaded onto the operand stack. -/
-abbrev HBinChunk {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    (frag : Program) (op : A → B → C) : Prop :=
-  ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
-    {P L : List Value} {rest : Program} (i j : Nat) (a : A) (b : B) (vs : List Value)
-    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (_hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)),
-    wp m ([.localGet i, .localGet j] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
-    wp m rest Q st ⟨P, L, toV (op a b) :: vs⟩ env
+/-! ## Chunks (the reusable stack-form facts) -/
 
-/-- Heterogeneous binary chunk shape with an input side condition. Use this for
-instructions that trap on some operand values, such as unsigned division by
-zero. -/
-abbrev HBinChunkWhere {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    (frag : Program) (op : A → B → C) (pre : A → B → Prop) : Prop :=
+/-- Binary chunk: with `toV b` on top of `toV a`, running `frag` then `rest`
+equals running `rest` with `toV (op a b)` on the stack, provided the operands
+satisfy `pre` (default `True`, dropped for total ops). Heterogeneous in the
+operand/result encodings, so it covers both `T → T → T` and `A → B → C`. -/
+abbrev BinChunk {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    (frag : Program) (op : A → B → C) (pre : A → B → Prop := fun _ _ => True) : Prop :=
   ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
-    {P L : List Value} {rest : Program} (i j : Nat) (a : A) (b : B) (vs : List Value)
-    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (_hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
+    {P L : List Value} {rest : Program} (a : A) (b : B) (vs : List Value)
     (_hpre : pre a b),
-    wp m ([.localGet i, .localGet j] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
+    wp m (frag ++ rest) Q st ⟨P, L, toV b :: toV a :: vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a b) :: vs⟩ env
 
-/-- Homogeneous binary chunk shape, defined from the heterogeneous one. -/
-abbrev BinChunk (frag : Program) (op : T → T → T) : Prop :=
-  HBinChunk frag op
-
-/-- Chunk shape for a unary op (`not`), with the operand read from local `i`. -/
-abbrev UnChunk (frag : Program) (op : T → T) : Prop :=
+/-- Unary chunk (`not`): with `toV a` on the stack, `frag` computes `toV (op a)`. -/
+abbrev UnChunk {T : Type} [UIntWasm T] (frag : Program) (op : T → T) : Prop :=
   ∀ {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
-    {P L : List Value} {rest : Program} (i : Nat) (a : T) (vs : List Value)
-    (_ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)),
-    wp m ([.localGet i] ++ frag ++ rest) Q st ⟨P, L, vs⟩ env ↔
+    {P L : List Value} {rest : Program} (a : T) (vs : List Value),
+    wp m (frag ++ rest) Q st ⟨P, L, toV a :: vs⟩ env ↔
     wp m rest Q st ⟨P, L, toV (op a) :: vs⟩ env
 
-/-- Turn a heterogeneous binary chunk into a fallthrough theorem for any local frame. -/
-theorem hbinBodyWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    {frag : Program} {op : A → B → C} (chunk : HBinChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
+/-! ## Reading operands from locals -/
+
+/-- Two `localGet`s push the operands read from locals `i`, `j` (`b` on top of
+`a`), turning a local-read body into the stack form a chunk consumes. The second
+read ignores the value the first pushed — `Locals.get` indexes only
+params/locals — which is why `hb` retypes to the pushed frame by `rfl`. This is
+the whole `localGet`/`Locals.get` plumbing, in one place. -/
+theorem wp_localGetPair {A B : Type} [UIntWasm A] [UIntWasm B]
+    {α : Type} {m : Module} {env : HostEnv α} {Q : Assertion α} {st : Store α}
+    {P L : List Value} {rest : Program} (i j : Nat) (a : A) (b : B) (vs : List Value)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
     (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
-    wp m ([.localGet i, .localGet j] ++ frag)
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
-      st ⟨P, L, vs⟩ env := by
-  have h :
-      wp m ([.localGet i, .localGet j] ++ frag ++ [])
-        (fun c => ∃ st',
-          c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
-        st ⟨P, L, vs⟩ env := by
-    rw [chunk i j a b vs ha hb]
-    unfold framePost
-    simp
-  simpa only [List.append_nil] using h
+    wp m (.localGet i :: .localGet j :: rest) Q st ⟨P, L, vs⟩ env ↔
+    wp m rest Q st ⟨P, L, toV b :: toV a :: vs⟩ env := by
+  have hb' : (⟨P, L, toV a :: vs⟩ : Locals).get j = some (toV b) := hb
+  simp only [wp_localGet_cons, ha, hb']
 
-/-- Turn a side-conditioned heterogeneous binary chunk into a fallthrough theorem
-for any local frame. -/
-theorem hbinBodyWpWhere {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    {frag : Program} {op : A → B → C} {pre : A → B → Prop}
-    (chunk : HBinChunkWhere frag op pre)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
-    (hpre : pre a b) :
-    wp m ([.localGet i, .localGet j] ++ frag)
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
-      st ⟨P, L, vs⟩ env := by
-  have h :
-      wp m ([.localGet i, .localGet j] ++ frag ++ [])
-        (fun c => ∃ st',
-          c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
-        st ⟨P, L, vs⟩ env := by
-    rw [chunk i j a b vs ha hb hpre]
-    unfold framePost
-    simp
-  simpa only [List.append_nil] using h
+/-! ## Export-body theorems
 
-/-- Variant of `hbinBodyWp` for exported function bodies that immediately return
-after the reusable fragment. -/
-theorem hbinBodyReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    {frag : Program} {op : A → B → C} (chunk : HBinChunk frag op)
+An opt-0 export body reads its operands from the parameter locals and returns:
+`[localGet i, localGet j] ++ frag ++ [.ret]` (binary), `[localGet i] ++ frag ++
+[.ret]` (unary), or that binary body wrapped in a trap-guard `block`. -/
+
+/-- Discharge a (total) binary export body by reusing the chunk. -/
+theorem binBodyReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag : Program} {op : A → B → C} (chunk : BinChunk frag op)
     {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
     {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
     (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
     wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
-      (Returns (toV (op a b) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env := by
-  rw [chunk i j a b vs ha hb]
+      (Returns (toV (op a b) :: vs) (framePost st)) st ⟨P, L, vs⟩ env := by
+  rw [show [.localGet i, .localGet j] ++ frag ++ [.ret]
+        = .localGet i :: .localGet j :: (frag ++ [.ret]) from by simp,
+      wp_localGetPair i j a b vs ha hb, chunk a b vs trivial]
   unfold Returns framePost
   simp
 
-/-- Variant of `hbinBodyWpWhere` for exported function bodies that immediately
-return after the reusable fragment. -/
-theorem hbinBodyWhereReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
-    {frag : Program} {op : A → B → C} {pre : A → B → Prop}
-    (chunk : HBinChunkWhere frag op pre)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
-    (hpre : pre a b) :
-    wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
-      (Returns (toV (op a b) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env := by
-  rw [chunk i j a b vs ha hb hpre]
-  unfold Returns framePost
-  simp
-
-/-- Turn a homogeneous binary chunk into a fallthrough theorem for any local frame. -/
-theorem binBodyWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
-    wp m ([.localGet i, .localGet j] ++ frag)
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, toV (op a b) :: vs⟩ ∧ framePost st st')
-      st ⟨P, L, vs⟩ env :=
-  hbinBodyWp chunk st i j a b vs ha hb
-
-/-- Homogeneous specialization of `hbinBodyReturnsWp`. -/
-theorem binBodyReturnsWp {frag : Program} {op : T → T → T} (chunk : BinChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i j : Nat) (a b : T) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
-    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b)) :
-    wp m ([.localGet i, .localGet j] ++ frag ++ [.ret])
-      (Returns (toV (op a b) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env :=
-  hbinBodyReturnsWp chunk st i j a b vs ha hb
-
-/-- Turn a unary chunk into a fallthrough theorem for any local frame. -/
-theorem unBodyWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
-    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i : Nat) (a : T) (vs : List Value)
-    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)) :
-    wp m ([.localGet i] ++ frag)
-      (fun c => ∃ st',
-        c = .Fallthrough st' ⟨P, L, toV (op a) :: vs⟩ ∧ framePost st st')
-      st ⟨P, L, vs⟩ env := by
-  have h :
-      wp m ([.localGet i] ++ frag ++ [])
-        (fun c => ∃ st',
-          c = .Fallthrough st' ⟨P, L, toV (op a) :: vs⟩ ∧ framePost st st')
-        st ⟨P, L, vs⟩ env := by
-    rw [chunk i a vs ha]
-    unfold framePost
-    simp
-  simpa only [List.append_nil] using h
-
-/-- Variant of `unBodyWp` for exported function bodies that immediately return
-after the reusable fragment. -/
-theorem unBodyReturnsWp {frag : Program} {op : T → T} (chunk : UnChunk frag op)
+/-- Discharge a unary export body by reusing the chunk. -/
+theorem unBodyReturnsWp {T : Type} [UIntWasm T]
+    {frag : Program} {op : T → T} (chunk : UnChunk frag op)
     {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
     {P L : List Value} (i : Nat) (a : T) (vs : List Value)
     (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a)) :
     wp m ([.localGet i] ++ frag ++ [.ret])
-      (Returns (toV (op a) :: vs) (framePost st))
-      st ⟨P, L, vs⟩ env := by
-  rw [chunk i a vs ha]
+      (Returns (toV (op a) :: vs) (framePost st)) st ⟨P, L, vs⟩ env := by
+  rw [show [.localGet i] ++ frag ++ [.ret] = .localGet i :: (frag ++ [.ret]) from by simp]
+  simp only [wp_localGet_cons, ha]
+  rw [chunk a vs]
   unfold Returns framePost
   simp
 
-end
+/-! ## Guarded (trapping) export bodies
+
+A trapping op compiles to its chunk wrapped in a zero-or-bounds-check `block`:
+the guard falls through when the side condition holds and otherwise breaks out of
+the block to a panic tail. One template covers them all — give it the chunk and a
+proof that the guard falls through; it discharges the whole body for an arbitrary
+panic `tail` (unreachable on the falling-through path, hence left to the call
+site). -/
+
+/-- Opt-0 guarded body: a `block` wrapping `guard ++ [localGet i, localGet j] ++
+frag ++ [.ret]`. -/
+abbrev checkedBinBody (guard frag : Program) (i j : Nat) : Program :=
+  [.block 0 0 (guard ++ [.localGet i, .localGet j] ++ frag ++ [.ret])]
+
+set_option maxRecDepth 4096 in
+/-- Discharge a guarded binary export body by reusing the chunk. `guardWp` is the
+guard's fall-through fact (e.g. `nonzeroGuardWp`), polymorphic in the block
+continuation; the panic `tail` is arbitrary because the guarded path returns
+before reaching it. -/
+theorem checkedBinBodyReturnsWp {A B C : Type} [UIntWasm A] [UIntWasm B] [UIntWasm C]
+    {frag guard : Program} {op : A → B → C} {pre : A → B → Prop}
+    (chunk : BinChunk frag op pre)
+    {α : Type} {m : Module} {env : HostEnv α} (st : Store α)
+    {P L : List Value} (i j : Nat) (a : A) (b : B) (vs : List Value) (tail : Program)
+    (guardWp : ∀ {Q : Assertion α} {rest : Program},
+        wp m (guard ++ rest) Q st ⟨P, L, vs⟩ env ↔ wp m rest Q st ⟨P, L, vs⟩ env)
+    (ha : (⟨P, L, vs⟩ : Locals).get i = some (toV a))
+    (hb : (⟨P, L, vs⟩ : Locals).get j = some (toV b))
+    (hpre : pre a b) :
+    wp m (checkedBinBody guard frag i j ++ tail)
+      (Returns (toV (op a b) :: vs) (framePost st)) st ⟨P, L, vs⟩ env := by
+  unfold checkedBinBody Returns framePost
+  apply wp_block_cons
+  rw [show guard ++ [.localGet i, .localGet j] ++ frag ++ [.ret]
+        = guard ++ (.localGet i :: .localGet j :: (frag ++ [.ret])) from by simp,
+      guardWp, wp_localGetPair i j a b vs ha hb, chunk a b vs hpre]
+  simp
 
 end Wasm.RustStd

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -3,16 +3,27 @@ import Project.RustU64.Program
 /-!
 # `rust_u64` per-crate specs (abs_diff + operators add .. shr)
 
-Each spec is discharged by reusing the per-function CodeLib theorem from
-`CodeLib/RustStd/U64/<Fn>.lean` (`addBodyWp`, …, `divBodyWp`, `shlBodyWp`, …),
-which is itself built on the type-agnostic trunk `CodeLib/RustStd/UInt.lean`.
-No operator body is re-proven here — `of_returns_wp` bridges the reusable `wp`
-fact to `TerminatesWith`.
+Each spec is discharged by reusing the per-function CodeLib chunk from
+`CodeLib/RustStd/U64/<Fn>.lean` (`add_chunk`, …, `shl_chunk`, …) through the
+trunk's body combinators (`binBodyReturnsWp`, `unBodyReturnsWp`, and
+`divBodyWp`/`remBodyWp` for the guarded ops), all built on the type-agnostic
+trunk `CodeLib/RustStd/UInt.lean`. No operator body is re-proven here —
+`of_returns_wp` bridges the reusable `wp` fact to `TerminatesWith`.
 -/
 
 namespace Project.RustU64.Spec
 
 open Wasm Wasm.RustStd Wasm.RustStd.U64
+
+/-! The panic tail emitted after a guarded op's `block`: push the panic message's
+data offset, `call` the imported panic handler, then `unreachable`. The reusable
+`divBodyWp`/`remBodyWp` deliberately quantify over this tail (it is unreachable
+when the divisor is nonzero), so the concrete literals — which are specific to
+*this* module's data layout and import table, not to CodeLib — are named here at
+the call site. Naming them keeps the `func*Def` body match legible: a regenerated
+module that shifts the offset or func index is a one-line edit here. -/
+def divPanicTail : Program := [.const 1048600, .call 66, .unreachable]
+def remPanicTail : Program := [.const 1048616, .call 67, .unreachable]
 
 @[spec_of "rust-internal" "core::num::abs_diff"]
 def AbsDiffSpec : Prop :=
@@ -70,7 +81,7 @@ def DivSpec : Prop :=
 theorem div_correct : DivSpec := by
   intro env a b hb
   exact (TerminatesWith.of_returns_wp (f := func6Def) (rs := [.i64 (a / b)]) rfl rfl
-      (divBodyWp «module».initialStore 0 1 a b [] [.const 1048600, .call 66, .unreachable]
+      (divBodyWp «module».initialStore 0 1 a b [] divPanicTail
         rfl rfl hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::rem"]
@@ -82,7 +93,7 @@ def RemSpec : Prop :=
 theorem rem_correct : RemSpec := by
   intro env a b hb
   exact (TerminatesWith.of_returns_wp (f := func10Def) (rs := [.i64 (a % b)]) rfl rfl
-      (remBodyWp «module».initialStore 0 1 a b [] [.const 1048616, .call 67, .unreachable]
+      (remBodyWp «module».initialStore 0 1 a b [] remPanicTail
         rfl rfl hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitand"]
@@ -138,7 +149,7 @@ def ShlSpec : Prop :=
 theorem shl_correct : ShlSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func12Def) (rs := [.i64 (a <<< (b.toUInt64 % 64))])
-      rfl rfl (hbinBodyReturnsWp shl_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
+      rfl rfl (binBodyReturnsWp shl_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
       (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::shr"]
@@ -150,7 +161,7 @@ def ShrSpec : Prop :=
 theorem shr_correct : ShrSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func13Def) (rs := [.i64 (a >>> (b.toUInt64 % 64))])
-      rfl rfl (hbinBodyReturnsWp shr_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
+      rfl rfl (binBodyReturnsWp shr_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
       (fun _ _ h => h.1)
 
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64/Spec.lean
+++ b/programs/lean/Project/RustU64/Spec.lean
@@ -37,7 +37,7 @@ def AddSpec : Prop :=
 theorem add_correct : AddSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func2Def) (rs := [.i64 (a + b)]) rfl rfl
-      (addBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp add_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::sub"]
 def SubSpec : Prop :=
@@ -48,7 +48,7 @@ def SubSpec : Prop :=
 theorem sub_correct : SubSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func8Def) (rs := [.i64 (a - b)]) rfl rfl
-      (subBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp sub_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::mul"]
 def MulSpec : Prop :=
@@ -59,7 +59,7 @@ def MulSpec : Prop :=
 theorem mul_correct : MulSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func9Def) (rs := [.i64 (a * b)]) rfl rfl
-      (mulBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp mul_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::div"]
 def DivSpec : Prop :=
@@ -70,7 +70,8 @@ def DivSpec : Prop :=
 theorem div_correct : DivSpec := by
   intro env a b hb
   exact (TerminatesWith.of_returns_wp (f := func6Def) (rs := [.i64 (a / b)]) rfl rfl
-      (divBodyWp «module».initialStore a b [] hb) rfl).mono (fun _ _ h => h.1)
+      (divBodyWp «module».initialStore 0 1 a b [] [.const 1048600, .call 66, .unreachable]
+        rfl rfl hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::rem"]
 def RemSpec : Prop :=
@@ -81,7 +82,8 @@ def RemSpec : Prop :=
 theorem rem_correct : RemSpec := by
   intro env a b hb
   exact (TerminatesWith.of_returns_wp (f := func10Def) (rs := [.i64 (a % b)]) rfl rfl
-      (remBodyWp «module».initialStore a b [] hb) rfl).mono (fun _ _ h => h.1)
+      (remBodyWp «module».initialStore 0 1 a b [] [.const 1048616, .call 67, .unreachable]
+        rfl rfl hb) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitand"]
 def BitAndSpec : Prop :=
@@ -92,7 +94,7 @@ def BitAndSpec : Prop :=
 theorem bitand_correct : BitAndSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func3Def) (rs := [.i64 (a &&& b)]) rfl rfl
-      (bitandBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp bitand_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitor"]
 def BitOrSpec : Prop :=
@@ -103,7 +105,7 @@ def BitOrSpec : Prop :=
 theorem bitor_correct : BitOrSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func4Def) (rs := [.i64 (a ||| b)]) rfl rfl
-      (bitorBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp bitor_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::bitxor"]
 def BitXorSpec : Prop :=
@@ -114,7 +116,7 @@ def BitXorSpec : Prop :=
 theorem bitxor_correct : BitXorSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func5Def) (rs := [.i64 (a ^^^ b)]) rfl rfl
-      (bitxorBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      (binBodyReturnsWp bitxor_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::not"]
 def NotSpec : Prop :=
@@ -125,7 +127,7 @@ def NotSpec : Prop :=
 theorem not_correct : NotSpec := by
   intro env a
   exact (TerminatesWith.of_returns_wp (f := func11Def) (rs := [.i64 (~~~a)]) rfl rfl
-      (notBodyWp «module».initialStore a []) rfl).mono (fun _ _ h => h.1)
+      (unBodyReturnsWp not_chunk «module».initialStore 0 a [] rfl) rfl).mono (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::shl"]
 def ShlSpec : Prop :=
@@ -136,7 +138,8 @@ def ShlSpec : Prop :=
 theorem shl_correct : ShlSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func12Def) (rs := [.i64 (a <<< (b.toUInt64 % 64))])
-      rfl rfl (shlBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      rfl rfl (hbinBodyReturnsWp shl_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
+      (fun _ _ h => h.1)
 
 @[spec_of "rust-exported" "rust_u64::shr"]
 def ShrSpec : Prop :=
@@ -147,6 +150,7 @@ def ShrSpec : Prop :=
 theorem shr_correct : ShrSpec := by
   intro env a b
   exact (TerminatesWith.of_returns_wp (f := func13Def) (rs := [.i64 (a >>> (b.toUInt64 % 64))])
-      rfl rfl (shrBodyWp «module».initialStore a b []) rfl).mono (fun _ _ h => h.1)
+      rfl rfl (hbinBodyReturnsWp shr_chunk «module».initialStore 0 1 a b [] rfl rfl) rfl).mono
+      (fun _ _ h => h.1)
 
 end Project.RustU64.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -16,7 +16,7 @@ is the whole point — the same theorem also serves the called export body.
 - `shl`/`shr`: `shl_seq`/`shr_seq` — the width-specific mask-extend-shift chunk
   (the `b % 64` normalisation is baked into the chunk, so no `bv_decide` here).
 - `div`/`rem`: peel the zero-divisor guard `block` (`wp_block_cons`), then reuse
-  `div_chunk`/`rem_chunk` for the divide/remainder (`divUI64`/`remUI64` atomics
+  `div_seq`/`rem_seq` for the divide/remainder (`divUI64`/`remUI64` atomics
   excluded). The trailing `+ c` / `* c` reuses `add_seq` / `mul_seq` too.
 -/
 
@@ -257,7 +257,7 @@ theorem not_then_xor_correct : NotThenXorSpec := by
     List.drop, not_seq, xor_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
     and_true, List.append_nil]
 
-/-! ## div (divisor nonzero) — peel the guard, then reuse `div_chunk` -/
+/-! ## div (divisor nonzero) — peel the guard, then reuse `div_seq` -/
 @[spec_of "rust-exported" "rust_u64_tests::div_then_add"]
 def DivThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a b c : UInt64), b ≠ 0 →
   TerminatesWith env «module» 4 «module».initialStore [.i64 c, .i64 b, .i64 a]
@@ -275,7 +275,7 @@ theorem div_then_add_correct : DivThenAddSpec := by
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
     wp_br_if_cons, h10]
-  rw [div_chunk a b _ hb]
+  rw [div_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, add_seq, wp_ret_cons]
@@ -298,7 +298,7 @@ theorem div_then_mul_correct : DivThenMulSpec := by
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
     wp_br_if_cons, h10]
-  rw [div_chunk a b _ hb]
+  rw [div_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, mul_seq, wp_ret_cons]
@@ -322,7 +322,7 @@ theorem rem_then_add_correct : RemThenAddSpec := by
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
     wp_br_if_cons, h10]
-  rw [rem_chunk a b _ hb]
+  rw [rem_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, add_seq, wp_ret_cons]
@@ -345,7 +345,7 @@ theorem rem_then_mul_correct : RemThenMulSpec := by
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
     wp_br_if_cons, h10]
-  rw [rem_chunk a b _ hb]
+  rw [rem_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, mul_seq, wp_ret_cons]
@@ -365,8 +365,8 @@ theorem shl_then_add_correct : ShlThenAddSpec := by
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, shl_seq, add_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
-    and_true, List.append_nil]
+    List.drop, shiftAmountFrag, shiftMask, shl_seq, add_seq, wp_ret_cons,
+    Continuation.Return.injEq, List.cons.injEq, and_true, List.append_nil]
 
 @[spec_of "rust-exported" "rust_u64_tests::shl_twice"]
 def ShlTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
@@ -381,8 +381,8 @@ theorem shl_twice_correct : ShlTwiceSpec := by
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, shl_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
-    and_true, List.append_nil]
+    List.drop, shiftAmountFrag, shiftMask, shl_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_then_sub"]
 def ShrThenSubSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
@@ -397,8 +397,8 @@ theorem shr_then_sub_correct : ShrThenSubSpec := by
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, shr_seq, sub_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
-    and_true, List.append_nil]
+    List.drop, shiftAmountFrag, shiftMask, shr_seq, sub_seq, wp_ret_cons,
+    Continuation.Return.injEq, List.cons.injEq, and_true, List.append_nil]
 
 @[spec_of "rust-exported" "rust_u64_tests::shr_twice"]
 def ShrTwiceSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n m : UInt32),
@@ -413,7 +413,7 @@ theorem shr_twice_correct : ShrTwiceSpec := by
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
     List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, shr_seq, wp_ret_cons, Continuation.Return.injEq, List.cons.injEq,
-    and_true, List.append_nil]
+    List.drop, shiftAmountFrag, shiftMask, shr_seq, wp_ret_cons, Continuation.Return.injEq,
+    List.cons.injEq, and_true, List.append_nil]
 
 end Project.RustU64Tests.Spec

--- a/programs/lean/Project/RustU64Tests/Spec.lean
+++ b/programs/lean/Project/RustU64Tests/Spec.lean
@@ -15,9 +15,10 @@ is the whole point — the same theorem also serves the called export body.
   `xor_seq`/`not_seq`.
 - `shl`/`shr`: `shl_seq`/`shr_seq` — the width-specific mask-extend-shift chunk
   (the `b % 64` normalisation is baked into the chunk, so no `bv_decide` here).
-- `div`/`rem`: peel the zero-divisor guard `block` (`wp_block_cons`), then reuse
-  `div_seq`/`rem_seq` for the divide/remainder (`divUI64`/`remUI64` atomics
-  excluded). The trailing `+ c` / `* c` reuses `add_seq` / `mul_seq` too.
+- `div`/`rem`: peel the `block` (`wp_block_cons`), reuse `nonzeroGuardSeq` for the
+  zero-divisor guard (no hand-rolled guard simp), then reuse `div_seq`/`rem_seq`
+  for the divide/remainder (`divUI64`/`remUI64` atomics excluded). The trailing
+  `+ c` / `* c` reuses `add_seq` / `mul_seq` too.
 -/
 
 set_option linter.unusedSimpArgs false
@@ -268,13 +269,14 @@ theorem div_then_add_correct : DivThenAddSpec := by
   intro env a b c hb
   apply TerminatesWith.of_wp_entry_for (f := func4Def) rfl
   unfold func4Def func4
-  apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
-    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.map, ValueType.zero, List.length_cons, List.length_nil]
+  apply wp_block_cons
+  have hget : (⟨[.i64 a, .i64 b, .i64 c], [], []⟩ : Locals).get 1 = some (.i64 b) := rfl
+  rw [nonzeroGuardSeq 1 b [] hget hb]
+  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
-    wp_br_if_cons, h10]
+    List.drop]
   rw [div_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -291,13 +293,14 @@ theorem div_then_mul_correct : DivThenMulSpec := by
   intro env a b c hb
   apply TerminatesWith.of_wp_entry_for (f := func5Def) rfl
   unfold func5Def func5
-  apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
-    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.map, ValueType.zero, List.length_cons, List.length_nil]
+  apply wp_block_cons
+  have hget : (⟨[.i64 a, .i64 b, .i64 c], [], []⟩ : Locals).get 1 = some (.i64 b) := rfl
+  rw [nonzeroGuardSeq 1 b [] hget hb]
+  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
-    wp_br_if_cons, h10]
+    List.drop]
   rw [div_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -315,13 +318,14 @@ theorem rem_then_add_correct : RemThenAddSpec := by
   intro env a b c hb
   apply TerminatesWith.of_wp_entry_for (f := func12Def) rfl
   unfold func12Def func12
-  apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
-    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.map, ValueType.zero, List.length_cons, List.length_nil]
+  apply wp_block_cons
+  have hget : (⟨[.i64 a, .i64 b, .i64 c], [], []⟩ : Locals).get 1 = some (.i64 b) := rfl
+  rw [nonzeroGuardSeq 1 b [] hget hb]
+  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
-    wp_br_if_cons, h10]
+    List.drop]
   rw [rem_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
@@ -338,20 +342,21 @@ theorem rem_then_mul_correct : RemThenMulSpec := by
   intro env a b c hb
   apply TerminatesWith.of_wp_entry_for (f := func13Def) rfl
   unfold func13Def func13
-  apply wp_block_cons
-  have h10 : (1 : UInt32) &&& 0 = 0 := by decide
   simp only [Function.toLocals, Function.numParams, List.take, List.reverse, List.reverseAux,
-    List.map, ValueType.zero, wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
+    List.map, ValueType.zero, List.length_cons, List.length_nil]
+  apply wp_block_cons
+  have hget : (⟨[.i64 a, .i64 b, .i64 c], [], []⟩ : Locals).get 1 = some (.i64 b) := rfl
+  rw [nonzeroGuardSeq 1 b [] hget hb]
+  simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
-    List.drop, wp_constI64_cons, wp_eqI64_cons, hb, ↓reduceIte, wp_const_cons, wp_and_cons,
-    wp_br_if_cons, h10]
+    List.drop]
   rw [rem_seq a b _ hb]
   simp only [wp_localGet_cons, Locals.get, List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, Nat.reduceAdd, Nat.reduceLT, reduceIte,
     List.drop, mul_seq, wp_ret_cons]
   simp [List.take]
 
-/-! ## shl / shr — width-specific mask-extend-shift (reusable theorem: `U64.shlBodyWp`) -/
+/-! ## shl / shr — width-specific mask-extend-shift (reusable theorem: `U64.shl_seq`) -/
 @[spec_of "rust-exported" "rust_u64_tests::shl_then_add"]
 def ShlThenAddSpec : Prop := ∀ (env : HostEnv Unit) (a : UInt64) (n : UInt32) (b : UInt64),
   TerminatesWith env «module» 14 «module».initialStore [.i64 b, .i32 n, .i64 a]


### PR DESCRIPTION
## Summary
- Generalize Rust integer chunk helpers to read operands from arbitrary locals, including heterogeneous and side-conditioned binary chunks.
- Refactor U64 div/rem/shift helpers to avoid hardcoded exported bodies and panic tails in CodeLib.
- Update RustU64 specs and reuse tests to compose the new chunk helpers.

## Test plan
- `cd codelib && lake build`
- `cd programs/lean && lake build`


Made with [Cursor](https://cursor.com)