### PR TITLE
wp: drop wp_call_of_terminates alias for wp_call_tw

### DIFF
--- a/interpreter/Interpreter/Wasm/Wp/Call.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Call.lean
@@ -61,14 +61,6 @@ theorem wp_call_tw {env : HostEnv α}
     wp m (.call id :: rest) Q st s env :=
   wp_call_at hRun hPost
 
-/-- Backwards-compatible descriptive alias for `wp_call_tw`. -/
-theorem wp_call_of_terminates {env : HostEnv α}
-    {id : Nat} {Post : Store α → List Value → Prop}
-    (hRun : TerminatesWith env m id st s.values Post)
-    (hPost : ∀ st' vs, Post st' vs → wp m rest Q st' { s with values := vs } env) :
-    wp m (.call id :: rest) Q st s env :=
-  wp_call_tw hRun hPost
-
 /-- Store-specific core of the indirect-call WP rule. Instead of a
 store-polymorphic `FuncSpec`, it consumes the resolved callee's success
 behaviour *at the current store* `st` — exactly a `TerminatesWith`
@@ -138,7 +130,10 @@ theorem wp_callIndirect_cons {α : Type} {env : HostEnv α}
   wp_callIndirect_at hStack hTbl hSlot hFn hTy hSig (spec vs0 hPre st) hPost
 
 /-- Indirect-call WP rule consuming the resolved target's public
-`TerminatesWith` theorem directly. -/
+`TerminatesWith` theorem directly — the indirect analogue of `wp_call_tw`.
+Staged ahead of its first consumer: the corpus reaches indirect calls once a
+Rust fn-pointer / trait-object / vtable dispatch target is verified, at which
+point this is the rule that composes the callee's `TerminatesWith` spec. -/
 theorem wp_callIndirect_tw {α : Type} {env : HostEnv α}
     {m : Module} {st : Store α} {s : Locals} {Q : Assertion α}
     {rest : Program} {ti tj : Nat}

--- a/programs/lean/Project/NumInteger/Spec.lean
+++ b/programs/lean/Project/NumInteger/Spec.lean
@@ -488,7 +488,7 @@ theorem func0_terminates (env : HostEnv Unit) (a b : UInt64) :
   simp [hp]
   -- At the call point: memory holds `a` at 1048560, `b` at 1048568, global0
   -- is 1048560.  Discharge `func1` via its `TerminatesWith`.
-  apply wp_call_of_terminates
+  apply wp_call_tw
     (func1_terminates env _ a b []
       (by rw [Mem.write64_pages, Mem.write64_pages]; exact hp)
       (by rfl)
@@ -526,7 +526,7 @@ theorem gcd_u64_correct : GcdU64Spec := by
   apply TerminatesWith.of_wp_entry_for (f := ⟨[.i64, .i64], [], func2, [.i64], none⟩) rfl
   unfold func2
   wp_run
-  apply wp_call_of_terminates (func0_terminates env a b)
+  apply wp_call_tw (func0_terminates env a b)
   rintro st' vs rfl
   wp_run
   rfl


### PR DESCRIPTION
wp: drop the `wp_call_of_terminates` alias in favour of `wp_call_tw`

`wp_call_of_terminates` and `wp_call_tw` are byte-identical direct-call rules;
the codebase has standardised on `wp_call_tw`. This removes the alias and points
its two remaining call sites (in `NumInteger/Spec.lean`) at `wp_call_tw`. Also
adds a one-line note to the (kept) indirect analogue `wp_callIndirect_tw`.
