### PR TITLE
codelib: clarify UInt32/Option docstrings

### DIFF
--- a/codelib/CodeLib/RustStd/Option.lean
+++ b/codelib/CodeLib/RustStd/Option.lean
@@ -3,9 +3,13 @@ import Interpreter.Wasm
 /-!
 # `CodeLib.RustStd.Option`
 
-Shared helpers for reasoning about the C-ABI `Option<i64>` encoding used
-by `corpus/rust/rust_std/option` and any downstream crate that picks up
-the same convention.
+Shared helpers for reasoning about the C-ABI `Option<i64>` encoding.
+
+Staged ahead of its first consumer: no crate in `programs/rust` uses this yet.
+It is here because the corpus roadmap reaches `Option`-returning std methods
+(`unwrap_or`, `is_some`, `map`) and the `checked_*` arithmetic family, all of
+which return an `Option` across an `extern "C"` boundary and so hit exactly this
+sentinel encoding.
 
 The convention is:
 

--- a/codelib/CodeLib/UInt32.lean
+++ b/codelib/CodeLib/UInt32.lean
@@ -3,6 +3,13 @@
 
 Small bridge lemmas connecting `UInt32` bitwise operations to the
 `Nat` view that user-facing specifications prefer.
+
+`and_one_eq_zero_iff_toNat_mod_two` is consumed by the verifier's scaffolded
+starter proof (`verifier/template/project/lean/Project/IsEven/Spec.lean`), so
+the module is live even though nothing in `programs/lean` references it yet. It
+overlaps the width-generic parity bridge in `UInt64.lean`; both are candidates
+to fold into one shared low-bit lemma once that consolidation is done (keep this
+public name as a corollary — the template simp-references it).
 -/
 
 namespace Wasm


### PR DESCRIPTION
codelib: clarify `UInt32`/`Option` module docstrings

Two docstring-only fixes. `CodeLib.UInt32` now names its actual consumer (the
verifier's scaffolded starter proof) so it doesn't read as dead. `RustStd.Option`
drops a reference to a crate path that doesn't exist and states plainly that the
`Option<i64>` sentinel encoding is staged ahead of its first consumer.
