### PR TITLE
ci: build the interpreter library so examples are checked

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -50,7 +50,12 @@ jobs:
       - uses: leanprover/lean-action@v1
         with:
           lake-package-directory: interpreter
-          build-args: runner
+          # Build the `Interpreter` library (not just the `runner` exe) so the
+          # worked examples under Interpreter/Wasm/Examples/ — which the main
+          # `programs/lean` build does not reach — are compiled and their
+          # `native_decide` checks run. This is what keeps an example from
+          # silently rotting or being left out of Examples/Basic.lean.
+          build-args: Interpreter runner
           use-mathlib-cache: true
       - name: Install just
         uses: taiki-e/install-action@just

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -53,8 +53,10 @@ jobs:
           # Build the `Interpreter` library (not just the `runner` exe) so the
           # worked examples under Interpreter/Wasm/Examples/ — which the main
           # `programs/lean` build does not reach — are compiled and their
-          # `native_decide` checks run. This is what keeps an example from
-          # silently rotting or being left out of Examples/Basic.lean.
+          # `native_decide` checks run, keeping an example from silently
+          # rotting. Coverage is only as complete as Examples/Basic.lean's
+          # umbrella import: this build reaches an example iff Basic.lean
+          # imports it, so every example file must be listed there.
           build-args: Interpreter runner
           use-mathlib-cache: true
       - name: Install just

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -30,7 +30,14 @@ import Interpreter.Wasm.Examples.Counter
 import Interpreter.Wasm.Examples.DecoderImport
 import Interpreter.Wasm.Examples.DecoderImportedGlobal
 import Interpreter.Wasm.Examples.FloatOps
+import Interpreter.Wasm.Examples.Gcd
+import Interpreter.Wasm.Examples.SelectAbs
+import Interpreter.Wasm.Examples.GlobalInitExpr
+import Interpreter.Wasm.Examples.CallIndirectSubtype
 
 /-! # Wasm.Examples.Basic
 
-Umbrella import for the bundled worked examples. -/
+Umbrella import for the bundled worked examples. Every example file under
+`Interpreter/Wasm/Examples/` must be imported here: this module is the only
+thing the CI `Interpreter` build reaches, so an example missing from this list
+is never compiled and its `native_decide` checks never run. -/

--- a/interpreter/Interpreter/Wasm/Examples/Gcd.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Gcd.lean
@@ -24,7 +24,7 @@ def Gcd : Program := [
   .localGet 0               -- return a
 ]
 
-theorem gcdSpec (m : Module) (st : Store) (n k : UInt32) :
+theorem gcdSpec (m : Module) (st : Store Unit) (n k : UInt32) :
     wp m Gcd
       (fun c => ∃ st' s',
         c = .Fallthrough st' s' ∧
@@ -34,15 +34,15 @@ theorem gcdSpec (m : Module) (st : Store) (n k : UInt32) :
   apply wp_loop_cons
     (Inv := fun st' s' =>
         st' = st ∧
-        ∃ a b : UInt32,
-          s' = { params := [.i32 a, .i32 b], locals := [.i32 0], values := [] } ∧
+        ∃ a b c : UInt32,
+          s' = { params := [.i32 a, .i32 b], locals := [.i32 c], values := [] } ∧
           Nat.gcd a.toNat b.toNat = Nat.gcd n.toNat k.toNat)
     (μ := fun _ s' =>
         match s'.params with
         | [_, .i32 b] => b.toNat
         | _           => 0)
-  · exact ⟨rfl, n, k, rfl, rfl⟩
-  · rintro st' s' ⟨rfl, a, b, rfl, hgcd⟩
+  · exact ⟨rfl, n, k, 0, rfl, rfl⟩
+  · rintro st' s' ⟨rfl, a, b, c, rfl, hgcd⟩
     apply wp_block_cons
     wp_run
     simp
@@ -50,13 +50,14 @@ theorem gcdSpec (m : Module) (st : Store) (n k : UInt32) :
     · subst hb
       simp [Nat.gcd_zero_right] at hgcd
       simp [← hgcd, UInt32.ofNat_toNat]
-    · have hbpos : 0 < b.toNat :=
-        Nat.pos_of_ne_zero (fun h => hb (UInt32.toNat_eq_zero.mp h))
-      refine ⟨rfl, b, a % b, rfl, ?_, ?_⟩
-      · rw [← hgcd]
-        simp [UInt32.toNat_mod]
-        exact (Nat.gcd_rec a.toNat b.toNat).symm
-      · simp [UInt32.toNat_mod]
-        exact Nat.mod_lt a.toNat hbpos
+    · simp only [hb, if_false]
+      have hbpos : 0 < b.toNat := by
+        rcases Nat.eq_zero_or_pos b.toNat with h | h
+        · exact absurd (UInt32.toNat.inj (h.trans UInt32.toNat_zero.symm)) hb
+        · exact h
+      refine ⟨not_false, ?_, ?_⟩
+      · rw [← hgcd, Nat.gcd_comm b.toNat (a.toNat % b.toNat),
+          Nat.gcd_comm a.toNat b.toNat, Nat.gcd_rec b.toNat a.toNat]
+      · exact Nat.mod_lt a.toNat hbpos
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/SelectAbs.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SelectAbs.lean
@@ -13,7 +13,7 @@ def SelectAbs : Program := [
   .select
 ]
 
-theorem selectAbsSpec (m : Module) (st : Store) (n : UInt32) :
+theorem selectAbsSpec (m : Module) (st : Store Unit) (n : UInt32) :
     wp m SelectAbs
       (fun c => ∃ st' s',
         c = .Fallthrough st' s' ∧
@@ -22,7 +22,9 @@ theorem selectAbsSpec (m : Module) (st : Store) (n : UInt32) :
   unfold SelectAbs
   -- wp_run fires all @[simp] lemmas including wp_select_cons
   wp_run
-  simp [Int32.lt_iff_toInt32_lt]
-  split <;> rfl
+  simp
+  by_cases hneg : n.toInt32 < 0
+  · simp [hneg]
+  · simp [hneg]
 
 end Wasm


### PR DESCRIPTION
ci: build the interpreter library so examples are checked

The main CI job builds only `programs/lean`, whose closure excludes the worked
examples under `Interpreter/Wasm/Examples/`, and the smoke job builds only the
`runner` executable — so nothing in CI compiles the examples or runs their
`native_decide` checks. This changes the smoke job's `build-args` from `runner`
to `Interpreter runner` so the example library is built in CI.
