### PR TITLE
examples: extract shared UInt32 counter-step lemmas

### DIFF
--- a/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
@@ -1,6 +1,7 @@
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Block
 import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Examples.UIntLemmas
 
 /-! ## Example: IsEvenRec / IsOddRec
 
@@ -54,12 +55,7 @@ theorem evenOddSpec : ∀ n : UInt32,
       simp
       by_cases hn : n = 0
       · subst hn; simp
-      · have hn1 : (n - 1).toNat < n.toNat := by
-          have hnn : n.toNat ≠ 0 := fun h => hn (UInt32.toNat.inj h)
-          rw [UInt32.toNat_sub]
-          simp only [show (1 : UInt32).toNat = 1 from rfl]
-          have := n.toNat_lt
-          omega
+      · have hn1 : (n - 1).toNat < n.toNat := UInt32.toNat_sub_one_lt (fun h => hn (UInt32.toNat.inj h))
         have ihOdd := (ih' (n - 1) hn1).2
         simp [hn]
         apply wp_call_cons
@@ -71,11 +67,7 @@ theorem evenOddSpec : ∀ n : UInt32,
           wp_run
           simp
           have hnn : n.toNat ≠ 0 := fun h => hn (UInt32.toNat.inj h)
-          have hnsub : (n - 1).toNat = n.toNat - 1 := by
-            rw [UInt32.toNat_sub]
-            simp only [show (1 : UInt32).toNat = 1 from rfl]
-            have := n.toNat_lt
-            omega
+          have hnsub := UInt32.toNat_sub_one_eq hnn
           rw [hnsub]
           split_ifs <;> simp_all <;> omega
   · -- IsOddRec
@@ -89,12 +81,7 @@ theorem evenOddSpec : ∀ n : UInt32,
       simp
       by_cases hn : n = 0
       · subst hn; simp
-      · have hn1 : (n - 1).toNat < n.toNat := by
-          have hnn : n.toNat ≠ 0 := fun h => hn (UInt32.toNat.inj h)
-          rw [UInt32.toNat_sub]
-          simp only [show (1 : UInt32).toNat = 1 from rfl]
-          have := n.toNat_lt
-          omega
+      · have hn1 : (n - 1).toNat < n.toNat := UInt32.toNat_sub_one_lt (fun h => hn (UInt32.toNat.inj h))
         have ihEven := (ih' (n - 1) hn1).1
         simp [hn]
         apply wp_call_cons
@@ -106,11 +93,7 @@ theorem evenOddSpec : ∀ n : UInt32,
           wp_run
           simp
           have hnn : n.toNat ≠ 0 := fun h => hn (UInt32.toNat.inj h)
-          have hnsub : (n - 1).toNat = n.toNat - 1 := by
-            rw [UInt32.toNat_sub]
-            simp only [show (1 : UInt32).toNat = 1 from rfl]
-            have := n.toNat_lt
-            omega
+          have hnsub := UInt32.toNat_sub_one_eq hnn
           rw [hnsub]
           split_ifs <;> simp_all <;> omega
 

--- a/interpreter/Interpreter/Wasm/Examples/Factorial.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Factorial.lean
@@ -1,6 +1,7 @@
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Block
 import Interpreter.Wasm.Wp.Loop
+import Interpreter.Wasm.Examples.UIntLemmas
 
 /-! ## Example: Factorial
 
@@ -47,11 +48,7 @@ theorem factorialSpec (m : Module) (st : Store Unit) (n : UInt32) :
     · have hxn : x.toNat ≠ 0 := by
         intro h
         exact hx (UInt32.toNat.inj h)
-      have hxsub : (x - 1).toNat = x.toNat - 1 := by
-        rw [UInt32.toNat_sub]
-        simp only [show (1 : UInt32).toNat = 1 from rfl]
-        have := x.toNat_lt
-        omega
+      have hxsub := UInt32.toNat_sub_one_eq hxn
       simp [hx]
       refine ⟨?_, by omega⟩
       rw [← hacc]

--- a/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
@@ -1,12 +1,17 @@
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Block
 import Interpreter.Wasm.Wp.Loop
+import Interpreter.Wasm.Examples.UIntLemmas
 
 /-! ## Example: SimpleLoop
 
     Counts down `n` while accumulating into `locals[0]`. Uses:
-    - invariant `∃ x y, s = ⟨[.i32 y], [.i32 x], []⟩ ∧ x + y = n` (over UInt32)
-    - variant   `y.toNat` (the counter), strictly decreases each iteration. -/
+    - invariant `∃ x y, s = ⟨[.i32 x], [.i32 y], []⟩ ∧ x.toNat + y.toNat = n.toNat`,
+      where `x` is `params[0]` (the counter) and `y` is `locals[0]` (the accumulator).
+    - variant   `x.toNat` (the counter), strictly decreases each iteration.
+
+    The invariant is stated in `Nat` (via `toNat`) to avoid UInt32 wraparound, so
+    `omega` applies. -/
 
 namespace Wasm
 
@@ -48,11 +53,7 @@ theorem simpleLoopSpec (m : Module) (st : Store Unit) (n : UInt32) :
     · have hxn : x.toNat ≠ 0 := by
         intro h
         exact hx (UInt32.toNat.inj h)
-      have hxsub : (x - 1).toNat = x.toNat - 1 := by
-        rw [UInt32.toNat_sub]
-        simp only [show (1 : UInt32).toNat = 1 from rfl]
-        have := x.toNat_lt
-        omega
+      have hxsub := UInt32.toNat_sub_one_eq hxn
       simp
       have hy : y.toNat < 4294967295 := by
         have hn := n.toNat_lt

--- a/interpreter/Interpreter/Wasm/Examples/UIntLemmas.lean
+++ b/interpreter/Interpreter/Wasm/Examples/UIntLemmas.lean
@@ -1,4 +1,4 @@
-import Interpreter.Wasm.Semantics
+import Init
 
 /-!
 # `UInt32` counter-stepping lemmas for the examples

--- a/interpreter/Interpreter/Wasm/Examples/UIntLemmas.lean
+++ b/interpreter/Interpreter/Wasm/Examples/UIntLemmas.lean
@@ -1,0 +1,30 @@
+import Interpreter.Wasm.Semantics
+
+/-!
+# `UInt32` counter-stepping lemmas for the examples
+
+Shared by the loop / recursion examples (`SimpleLoop`, `Factorial`,
+`EvenOddRec`): their measures step a `UInt32` counter down by one, and both the
+decreasing-measure obligation and the invariant re-establishment need
+`(x - 1).toNat` in `Nat` terms. `x ≠ 0` rules out the `0 - 1` wraparound
+(`0 - 1 = 0xFFFFFFFF` on `UInt32`, but `0 - 1 = 0` on `Nat`). Previously this
+proof block was pasted in each of the three files.
+-/
+
+/-- On `UInt32`, when `x ≠ 0` the wrapping predecessor agrees with `Nat`
+subtraction: `(x - 1).toNat = x.toNat - 1`. -/
+theorem UInt32.toNat_sub_one_eq {x : UInt32} (hx : x.toNat ≠ 0) :
+    (x - 1).toNat = x.toNat - 1 := by
+  rw [UInt32.toNat_sub]
+  simp only [show (1 : UInt32).toNat = 1 from rfl]
+  have := x.toNat_lt
+  omega
+
+/-- On `UInt32`, when `x ≠ 0` the wrapping predecessor strictly decreases the
+`Nat` value — the standard loop / recursion variant step. -/
+theorem UInt32.toNat_sub_one_lt {x : UInt32} (hx : x.toNat ≠ 0) :
+    (x - 1).toNat < x.toNat := by
+  rw [UInt32.toNat_sub]
+  simp only [show (1 : UInt32).toNat = 1 from rfl]
+  have := x.toNat_lt
+  omega


### PR DESCRIPTION
examples: extract shared UInt32 counter-step lemmas

`SimpleLoop`, `Factorial` and `EvenOddRec` each pasted the same
`(x - 1).toNat = x.toNat - 1` / `(x - 1).toNat < x.toNat` proof block (the
`UInt32` counter step, valid for `x ≠ 0`). This lifts the two facts into a new
`Examples/UIntLemmas.lean` and has the three files use them. Also fixes
`SimpleLoop`'s module docstring, whose stated invariant/variant disagreed with
the proof (x/y swapped; the invariant is in `Nat` to avoid UInt32 wraparound).
