### PR TITLE
examples: share one native_decide harness across the examples

### DIFF
--- a/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
+++ b/interpreter/Interpreter/Wasm/Examples/CallIndirectSubtype.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Semantics
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: `(return_)call_indirect` rejects a non-subtype (issue #95)
 
@@ -44,6 +45,8 @@ import Interpreter.Wasm.Semantics
 
 namespace Wasm
 
+open Wasm.Examples
+
 namespace CallIndirectSubtype
 
 /-- `$impl : $super` — the function the table holds. Its declared type is
@@ -83,20 +86,17 @@ require of the stored function's type (`$super`) against the call-site type
 (`$sub`); it fails, so the calls must trap. -/
 theorem super_not_subtype_sub : m.gcTypeSubtype 0 1 = false := by native_decide
 
-private def trapMsg (r : Result Unit) : Option String :=
-  match r with | .Trap _ msg => some msg | _ => none
-
 /-- `call_indirect (type $sub)` against `$impl : $super` traps: `$super` is
 not a subtype of `$sub` (`super_not_subtype_sub`). Before #95 this returned
 `7 + 1000 = 1007`. -/
 theorem call_indirect_traps :
-    trapMsg (run 20 m 1 (m.initialStore (α := Unit)) []) =
+    runTrapMsg 20 m 1 (m.initialStore (α := Unit)) [] =
       some "indirect call type mismatch" := by native_decide
 
 /-- `return_call_indirect (type $sub)` traps for the same reason — the
 issue's comment noted the bug was duplicated in the tail-call arms. -/
 theorem return_call_indirect_traps :
-    trapMsg (run 20 m 2 (m.initialStore (α := Unit)) []) =
+    runTrapMsg 20 m 2 (m.initialStore (α := Unit)) [] =
       some "indirect call type mismatch" := by native_decide
 
 end CallIndirectSubtype

--- a/interpreter/Interpreter/Wasm/Examples/ClzPopcnt.lean
+++ b/interpreter/Interpreter/Wasm/Examples/ClzPopcnt.lean
@@ -1,5 +1,6 @@
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: ClzPopcnt
 
@@ -18,6 +19,7 @@ import Interpreter.Wasm.Wp.Call
     Wasm defines `clz`/`ctz` of zero as 32; `popcnt` counts set bits. -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-! ### Function bodies -/
 
@@ -35,14 +37,6 @@ def clzPopcntModule : Module :=
       [ { params := [.i32], body := ClzBody,    results := [.i32] }
       , { params := [.i32], body := CtzBody,    results := [.i32] }
       , { params := [.i32], body := PopcntBody, results := [.i32] } ] }
-
-/-! ### Helpers -/
-
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 /-! ### Checks 1–3 — concrete `run` -/
 

--- a/interpreter/Interpreter/Wasm/Examples/DecoderImport.lean
+++ b/interpreter/Interpreter/Wasm/Examples/DecoderImport.lean
@@ -1,6 +1,7 @@
 import Interpreter.Wasm.Decoder.Wat
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: decoding a WAT module with imports (M9)
 
@@ -13,6 +14,7 @@ import Interpreter.Wasm.Wp.Call
        expected return value. -/
 
 namespace Wasm
+open Wasm.Examples
 namespace DecoderImport
 
 /-- A `.wat` module with a single host import (`env.inc : i32 → i32`)
@@ -30,10 +32,7 @@ def importWat : String := "
 shape of its `imports`, `funcs` body, and `exports`. We project each
 field rather than comparing whole `Module`s because `Module` has no
 `DecidableEq` instance. -/
-private def decoded : Wasm.Module :=
-  match Wasm.Decoder.Wat.decode importWat with
-  | .ok m    => m
-  | .error _ => default
+private def decoded : Wasm.Module := decodeOrDefault importWat
 
 /-- The single import is `env.inc : i32 → i32`. -/
 theorem importWat_imports :
@@ -68,16 +67,10 @@ def incHost : HostFn Unit :=
 
 def incEnv : HostEnv Unit := { funcs := [incHost] }
 
-private def runVals (m : Module) (env : HostEnv Unit) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run 10 m idx st args env with
-  | .Success vs _ => vs
-  | _ => []
-
 /-- Calling `caller(41)` against `incEnv` returns `[42]` — the import
 was resolved through `Module.imports[0]` → `HostEnv.funcs[0]`. -/
 theorem caller_against_incEnv :
-    runVals decoded incEnv 1 (decoded.initialStore (α := Unit)) [.i32 41]
+    runValues 10 decoded 1 (decoded.initialStore (α := Unit)) [.i32 41] incEnv
       = [.i32 42] := by
   native_decide
 

--- a/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
+++ b/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
@@ -1,6 +1,7 @@
 import Interpreter.Wasm.Decoder.Wat
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: imported-global index offset in the WAT decoder
 
@@ -15,6 +16,7 @@ import Interpreter.Wasm.Wp.Call
     global end-to-end so a future miscount fails the build. -/
 
 namespace Wasm
+open Wasm.Examples
 namespace DecoderImportedGlobal
 
 /-- A `.wat` module with one imported global `spectest.ig : i32` (unified
@@ -28,10 +30,7 @@ def importedGlobalWat : String := "
     global.get $d))
 "
 
-private def decoded : Wasm.Module :=
-  match Wasm.Decoder.Wat.decode importedGlobalWat with
-  | .ok m    => m
-  | .error _ => default
+private def decoded : Wasm.Module := decodeOrDefault importedGlobalWat
 
 /-- One imported global at index `0`, one declared global at index `1`. -/
 theorem importedGlobalWat_global_layout :
@@ -56,16 +55,8 @@ theorem importedGlobalWat_getD_index :
 /-- End-to-end: running `getD` reads the declared global and returns `99`.
 A wrong index would read the import's zero slot (`0`) or trap out of
 bounds (empty result). -/
-private def emptyEnv : HostEnv Unit := { funcs := [] }
-
-private def runVals (m : Module) (env : HostEnv Unit) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run 10 m idx st args env with
-  | .Success vs _ => vs
-  | _ => []
-
 theorem importedGlobalWat_getD_returns_99 :
-    runVals decoded emptyEnv 0 (decoded.initialStore (α := Unit)) []
+    runValues 10 decoded 0 (decoded.initialStore (α := Unit)) []
       = [.i32 99] := by
   native_decide
 

--- a/interpreter/Interpreter/Wasm/Examples/EarlyBrInvalid.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EarlyBrInvalid.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: EarlyBrInvalid
 
@@ -9,19 +10,13 @@ import Interpreter.Wasm.Wp.Tactic
 
 namespace Wasm
 
+open Wasm.Examples
+
 def EarlyBrInvalid : Program := [.localGet 0, .br 1]
 
 def earlyBrInvalidModule : Module := {
   funcs := [{ params := [.i32], results := [.i32], body := EarlyBrInvalid }]
 }
-
-/-- Project the invalid message (if any) out of a `Result Unit`, so we can
-    `native_decide` against it without needing `DecidableEq Store Unit`. -/
-private def runInvalidMsg (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : Option String :=
-  match run fuel m idx st args with
-  | .Invalid msg => some msg
-  | _            => none
 
 theorem early_br_out_of_scope_is_invalid :
     runInvalidMsg 10 earlyBrInvalidModule 0

--- a/interpreter/Interpreter/Wasm/Examples/FloatOps.lean
+++ b/interpreter/Interpreter/Wasm/Examples/FloatOps.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Semantics
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: floating-point operations
 
@@ -13,6 +14,7 @@ Expected values are written as `Float`/`Float32` literals decoded to bits via
 `toBits`, so each theorem reads as the IEEE arithmetic it stands for. -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-- `(2.0 + 3.0) * 4.0` in `f64` ⇒ `20.0`. -/
 def f64Arith : Program :=
@@ -59,14 +61,6 @@ def floatModule : Module :=
       , { body := reinterpret,  results := [.f32] }
       , { body := memRoundtrip, results := [.f64] } ]
     memory := some { pagesMin := 1 } }
-
-/-- Project the value stack out of a `Result Unit`; `Store Unit` carries a
-    function-valued `Mem` and so has no decidable equality. -/
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 theorem f64_arith :
     runValues 10 floatModule 0 floatModule.initialStore [] = [.f64 (20.0 : Float).toBits] := by

--- a/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
@@ -1,5 +1,6 @@
 import Interpreter.Wasm.Decoder.Wat
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: constant-expression global initializers in the WAT decoder
 
@@ -15,6 +16,7 @@ import Interpreter.Wasm.Wp.Tactic
     placeholder zero leaking through — fails the build. -/
 
 namespace Wasm
+open Wasm.Examples
 namespace GlobalInitExpr
 
 /-- A module whose only global is initialised with an extended-const
@@ -26,10 +28,7 @@ def globalInitExprWat : String := "
     global.get $g))
 "
 
-private def decoded : Wasm.Module :=
-  match Wasm.Decoder.Wat.decode globalInitExprWat with
-  | .ok m    => m
-  | .error _ => default
+private def decoded : Wasm.Module := decodeOrDefault globalInitExprWat
 
 /-- The initializer is kept as a program rather than folded to a single
 literal: the global's `initExpr` is non-empty. -/
@@ -44,13 +43,9 @@ theorem runConstGlobals_evaluates_initExpr :
       = some (.i32 42) := by
   native_decide
 
-private def emptyEnv : HostEnv Unit := { funcs := [] }
-
 private def runVals (idx : Nat) (st : Store Unit) (args : List Value) :
     List Value :=
-  match run 64 decoded idx st args emptyEnv with
-  | .Success vs _ => vs
-  | _ => []
+  runValues 64 decoded idx st args
 
 /-- End-to-end: running `getG` after initialising the globals returns `42`.
 The old behaviour — placeholder `0` from `ValueType.zero`, or the first

--- a/interpreter/Interpreter/Wasm/Examples/Harness.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Harness.lean
@@ -1,0 +1,56 @@
+import Interpreter.Wasm.Semantics
+import Interpreter.Wasm.Decoder.Wat
+
+/-!
+# `Wasm.Examples` — shared harness for the worked examples
+
+The examples pin behaviour with `native_decide`, which needs a *decidable*
+target. `Store α` has no `DecidableEq`, so a check cannot compare whole
+`Result`s; it projects the piece it cares about (the returned stack, or a trap /
+invalid message) out of the `Result` first. Every example used to re-declare its
+own copy of that projection (under two spellings, `runValues` / `runVals`), plus
+a `decode`-or-`default` wrapper. Those live here once.
+
+* `runValues` / `runTrapMsg` / `runInvalidMsg` — run a function and project the
+  success stack / trap message / invalid message. `env` defaults to the empty
+  host env, so pure-wasm examples omit it.
+* `decodeOrDefault` — decode a WAT module, falling back to `default` on error
+  (each decoder example pins the success shape with a separate decidable check,
+  so the fallback is never actually hit).
+-/
+
+namespace Wasm.Examples
+
+/-- Run `m`'s function `idx` and keep the returned stack, or `[]` on any
+non-`Success` outcome. Total, so `native_decide` can evaluate it without
+`DecidableEq (Store Unit)`. -/
+def runValues (fuel : Nat) (m : Module) (idx : Nat) (st : Store Unit)
+    (args : List Value) (env : HostEnv Unit := {}) : List Value :=
+  match run fuel m idx st args env with
+  | .Success vs _ => vs
+  | _ => []
+
+/-- Project the trap message (if the run trapped) out of the `Result`. -/
+def runTrapMsg (fuel : Nat) (m : Module) (idx : Nat) (st : Store Unit)
+    (args : List Value) (env : HostEnv Unit := {}) : Option String :=
+  match run fuel m idx st args env with
+  | .Trap _ msg => some msg
+  | _ => none
+
+/-- Project the invalidation message (if the run was rejected as invalid) out of
+the `Result`. -/
+def runInvalidMsg (fuel : Nat) (m : Module) (idx : Nat) (st : Store Unit)
+    (args : List Value) (env : HostEnv Unit := {}) : Option String :=
+  match run fuel m idx st args env with
+  | .Invalid msg => some msg
+  | _ => none
+
+/-- Decode a WAT module, falling back to `default` on a decode error. Decoder
+examples check the decoded shape with a separate decidable projection, so the
+fallback is a placeholder that is never reached on a well-formed input. -/
+def decodeOrDefault (wat : String) : Wasm.Module :=
+  match Wasm.Decoder.Wat.decode wat with
+  | .ok m => m
+  | .error _ => default
+
+end Wasm.Examples

--- a/interpreter/Interpreter/Wasm/Examples/HostDispatch.lean
+++ b/interpreter/Interpreter/Wasm/Examples/HostDispatch.lean
@@ -1,5 +1,6 @@
 import Interpreter.Wasm.Wp.Tactic
 import Interpreter.Wasm.Wp.Call
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: host-function dispatch (M2)
 
@@ -15,6 +16,7 @@ import Interpreter.Wasm.Wp.Call
     `run`) sits at unified index `1` — that's the index passed to `run`. -/
 
 namespace Wasm
+open Wasm.Examples
 namespace HostDispatch
 
 /-! ### Demo 1 — `inc`: host returns a value
@@ -88,31 +90,19 @@ def memLoadModule : Module :=
 
 /-! ### `native_decide` checks
 
-    `runVals` / `runTrap` extract the success values or trap message so
+    `runValues` / `runTrapMsg` extract the success values or trap message so
     we don't need `DecidableEq` on `Store Unit`. -/
 
-private def runVals (m : Module) (env : HostEnv Unit) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run 10 m idx st args env with
-  | .Success vs _ => vs
-  | _ => []
-
-private def runTrap (m : Module) (env : HostEnv Unit) (idx : Nat)
-    (st : Store Unit) (args : List Value) : Option String :=
-  match run 10 m idx st args env with
-  | .Trap _ msg => some msg
-  | _ => none
-
 theorem inc_returns_plus_one :
-    runVals incModule incEnv 1 incModule.initialStore [.i32 41] = [.i32 42] := by
+    runValues 10 incModule 1 incModule.initialStore [.i32 41] incEnv = [.i32 42] := by
   native_decide
 
 theorem abort_propagates_trap :
-    runTrap abortModule abortEnv 1 abortModule.initialStore [] = some "host abort" := by
+    runTrapMsg 10 abortModule 1 abortModule.initialStore [] abortEnv = some "host abort" := by
   native_decide
 
 theorem memLoad_reads_caller_memory :
-    runVals memLoadModule memLoadEnv 1 memLoadModule.initialStore [.i32 0]
+    runValues 10 memLoadModule 1 memLoadModule.initialStore [.i32 0] memLoadEnv
       = [.i32 42] := by
   native_decide
 

--- a/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: memory.copy
 
@@ -9,6 +10,8 @@ import Interpreter.Wasm.Wp.Tactic
     either range escapes the legal byte span. -/
 
 namespace Wasm
+
+open Wasm.Examples
 
 private def initBytes : List UInt8 :=
   [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]
@@ -47,18 +50,6 @@ def copyModule : Module :=
       , { body := copyOverlapBody,  results := [.i64] }
       , { body := copyTrapBody } ]
     memory := some { pagesMin := 1, data := [{ offset := some 0, bytes := initBytes }] } }
-
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
-
-private def runTrapMsg (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : Option String :=
-  match run fuel m idx st args with
-  | .Trap _ msg => some msg
-  | _ => none
 
 theorem copy_disjoint_moves_bytes :
     runValues 10 copyModule 0 copyModule.initialStore [] = [.i32 0x44332211] := by

--- a/interpreter/Interpreter/Wasm/Examples/MemFill.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemFill.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: memory.fill
 
@@ -7,6 +8,8 @@ import Interpreter.Wasm.Wp.Tactic
     any write when the destination range escapes the legal byte span. -/
 
 namespace Wasm
+
+open Wasm.Examples
 
 /-- Fill the first 8 bytes with `0xAB`, then read them back as one i64.
     The expected payload is the byte `0xAB` repeated eight times. -/
@@ -27,20 +30,6 @@ def fillTrapBody : Program := [
 def fillModule : Module :=
   { funcs := [{ body := fillThenReadBody, results := [.i64] }, { body := fillTrapBody }]
     memory := some { pagesMin := 1 } }
-
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
-
-/-- Project the trap message (if any) out of a `Result Unit`, so we can
-    `native_decide` against it without needing `DecidableEq Store Unit`. -/
-private def runTrapMsg (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : Option String :=
-  match run fuel m idx st args with
-  | .Trap _ msg => some msg
-  | _ => none
 
 theorem fill_then_load_returns_repeated_byte :
     runValues 10 fillModule 0 fillModule.initialStore []

--- a/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: memory.size / memory.grow
 
@@ -11,6 +12,7 @@ import Interpreter.Wasm.Wp.Tactic
        untouched and pushes `-1` (`0xFFFFFFFF`). -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-- Push the current page count. -/
 def sizeBody : Program := [.memorySize]
@@ -39,12 +41,6 @@ def growModule : Module :=
       -- function returns two i32s under Wasm's standard convention.
       , { body := growFailBody,      results := [.i32, .i32] } ]
     memory := some { pagesMin := 1 } }
-
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 theorem memorySize_reads_pagesMin :
     runValues 10 growModule 0 growModule.initialStore [] = [.i32 1] := by

--- a/interpreter/Interpreter/Wasm/Examples/MemI64.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemI64.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: i64 memory loads/stores
 
@@ -13,6 +14,7 @@ import Interpreter.Wasm.Wp.Tactic
     constant, then read it back through the matching unsigned load. -/
 
 namespace Wasm
+open Wasm.Examples
 
 private def initBytes : List UInt8 :=
   [0x88, 0xFF, 0x66, 0x55, 0x44, 0x33, 0x22, 0xFF]
@@ -63,13 +65,6 @@ def i64MemModule : Module :=
       , { body := store64RoundtripBody,    results := [.i64] }  -- 10
       ]
     memory := some { pagesMin := 1, data := [{ offset := some 0, bytes := initBytes }] } }
-
-/-- Project the value stack out of a `Result Unit`; see `MemNarrowI32.lean`. -/
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 theorem load64_returns_word :
     runValues 10 i64MemModule 0 i64MemModule.initialStore [] = [.i64 0xFF2233445566FF88] := by

--- a/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
@@ -1,4 +1,5 @@
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: i32 narrow loads/stores
 
@@ -13,6 +14,7 @@ import Interpreter.Wasm.Wp.Tactic
     the matching unsigned load. -/
 
 namespace Wasm
+open Wasm.Examples
 
 private def initBytes : List UInt8 :=
   [0x42, 0xFF, 0xCD, 0xAB, 0xCD, 0xFF, 0, 0]
@@ -43,15 +45,6 @@ def narrowI32Module : Module :=
       , { body := store8RoundtripBody,  results := [.i32] }
       , { body := store16RoundtripBody, results := [.i32] } ]
     memory := some { pagesMin := 1, data := [{ offset := some 0, bytes := initBytes }] } }
-
-/-- Project the value stack out of a `Result Unit`. `Store Unit` carries a function-
-    valued `Mem`, so it has no decidable equality; comparing the values
-    alone keeps the `native_decide` checks below well-typed. -/
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 theorem load8U_returns_byte :
     runValues 10 narrowI32Module 0 narrowI32Module.initialStore [] = [.i32 0x42] := by

--- a/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
@@ -3,6 +3,7 @@ import Interpreter.Wasm.Wp.Block
 import Interpreter.Wasm.Wp.Call
 import Interpreter.Wasm.Spec.Termination
 import Interpreter.Wasm.Decoder.Wat
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: multi-value
 
@@ -56,6 +57,7 @@ import Interpreter.Wasm.Decoder.Wat
     set `local 0 = a`, `local 1 = b`. -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-! ### Function bodies -/
 
@@ -100,16 +102,6 @@ def multiValueModule : Module :=
         { params  := [],           body := CallsSwap, results := [.i32] } ] }
 
 /-! ### Check 1 — concrete `run` of a multi-value function -/
-
-/-- Helper: extract just the values list from a `Result`. `List Value` has
-    `DecidableEq` (so `native_decide` works on it), whereas `Result` carries
-    a `Store` field and `Store` doesn't. Returns `[]` on any non-success
-    outcome so the helper is total. Same idiom as `MemGrow.runValues`. -/
-private def runValues (fuel : Nat) (m : Module) (idx : Nat)
-    (st : Store Unit) (args : List Value) : List Value :=
-  match run fuel m idx st args with
-  | .Success vs _ => vs
-  | _ => []
 
 /-- Pushing `1` then `2` (so `2` is on top) and calling `swap` leaves
     `[1, 2]` (now `1` on top). Closed by `native_decide`, which compiles

--- a/interpreter/Interpreter/Wasm/Examples/RefIsNull.lean
+++ b/interpreter/Interpreter/Wasm/Examples/RefIsNull.lean
@@ -1,5 +1,6 @@
 import Interpreter.Wasm.Decoder.Wat
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: reference instructions (`ref.null`, `ref.func`, `ref.is_null`)
 
@@ -17,6 +18,7 @@ import Interpreter.Wasm.Wp.Tactic
       parser path the AST proof can't see. -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-- `RefReflect` pushes the null reference and tests it (`ref.is_null` ⇒ 1),
 then pushes a reference to function 0 and tests that (`ref.is_null` ⇒ 0),
@@ -65,10 +67,7 @@ def refWat : String := "
     ref.is_null))
 "
 
-private def decoded : Wasm.Module :=
-  match Wasm.Decoder.Wat.decode refWat with
-  | .ok m    => m
-  | .error _ => default
+private def decoded : Wasm.Module := decodeOrDefault refWat
 
 /-- Decoding succeeds with all six functions (rules out the `default`
 fallback above; `Instruction` has no `DecidableEq`, so we check a
@@ -76,9 +75,7 @@ decidable projection rather than the bodies directly). -/
 theorem decodes_six_funcs : decoded.funcs.length = 6 := by native_decide
 
 private def runVals (idx : Nat) : List Value :=
-  match run 10 decoded idx (decoded.initialStore (α := Unit)) [] with
-  | .Success vs _ => vs
-  | _ => []
+  runValues 10 decoded idx (decoded.initialStore (α := Unit)) []
 
 /-- End-to-end (decode → run): the null reference is null, so
 `null_is_null` returns `[1]`. A mis-decoded `ref.null`/`ref.is_null`

--- a/interpreter/Interpreter/Wasm/Examples/TableDispatch.lean
+++ b/interpreter/Interpreter/Wasm/Examples/TableDispatch.lean
@@ -1,5 +1,6 @@
 import Interpreter.Wasm.Decoder.Wat
 import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
 
 /-! ## Example: table instructions (`table.get`, `table.size`)
 
@@ -29,6 +30,7 @@ import Interpreter.Wasm.Wp.Tactic
       reads. -/
 
 namespace Wasm
+open Wasm.Examples
 
 /-- `TableProbe` reads table 0 three ways: it asks whether slot 2 is null
 (`table.get` then `ref.is_null`) and then pushes the table's size. Run
@@ -79,10 +81,7 @@ def dispatchWat : String := "
     call_indirect (type $sig)))
 "
 
-private def decoded : Wasm.Module :=
-  match Wasm.Decoder.Wat.decode dispatchWat with
-  | .ok m    => m
-  | .error _ => default
+private def decoded : Wasm.Module := decodeOrDefault dispatchWat
 
 /-- Decoding succeeds with all five functions (rules out the `default`
 fallback above; `Instruction` has no `DecidableEq`, so we check a
@@ -97,9 +96,7 @@ theorem table_populated :
   native_decide
 
 private def runVals (idx : Nat) (args : List Value) : List Value :=
-  match run 20 decoded idx (decoded.initialStore (α := Unit)) args with
-  | .Success vs _ => vs
-  | _ => []
+  runValues 20 decoded idx (decoded.initialStore (α := Unit)) args
 
 /-- End-to-end (decode → run): `table.size` reports the declared length 3. -/
 theorem sz_runs : runVals 2 [] = [.i32 3] := by native_decide


### PR DESCRIPTION
examples: share one native_decide harness across the worked examples

Each worked example pins its behaviour with `native_decide`, which needs a
decidable target. Since `Store α` has no `DecidableEq`, a check can't compare
whole `Result`s — it first projects out the piece it cares about (the returned
stack, or a trap / invalid message). Every example re-declared its own copy of
that projection (under two spellings, `runValues` and `runVals`), and the decoder
examples each re-declared a `decode`-or-`default` wrapper.

This adds one `Examples/Harness.lean` with those shared helpers —
`runValues` / `runTrapMsg` / `runInvalidMsg` (with `env` defaulting to the empty
host env) and `decodeOrDefault` — and rewrites the examples to use them. Where a
file had a per-module shorthand (e.g. `runVals idx`), it's kept as a one-line
wrapper delegating to the shared helper, so the call sites are unchanged.

This is a single mechanical refactor: every touched file gets the same edit
(delete the local helper, use the shared one), so the diff is large but uniform.
Behaviour is identical — the theorem statements and their `native_decide` checks
are unchanged.
