### PR TITLE
decoder: remove dead stub-immediate path, fix stale docstrings

### DIFF
--- a/codelib/CodeLib/RustStd/Array/Basic.lean
+++ b/codelib/CodeLib/RustStd/Array/Basic.lean
@@ -15,10 +15,11 @@ exact shape the integer trunk `CodeLib/RustStd/UInt.lean` already abstracts as
 `UnChunk` (over any `UIntWasm` type; here `UInt32`, whose `toV` is `.i32`).
 So a length-only op needs *no new chunk shape*: its chunk is a `UnChunk` instance
 (`Len.len_chunk`, `IsEmpty.isEmpty_chunk`) and its called monomorphized body is
-discharged by the trunk's `unBodyReturnsWp` (`Len.lenBodyWp`,
-`IsEmpty.isEmptyBodyWp`) — the same `unBodyReturnsWp` reads the length from an
-**arbitrary** local `i` (slices carry the length in the second fat-pointer field,
-e.g. param local `1`), so nothing slice-specific is needed there.
+discharged by the shared `unSliceBodyTerminates` below (instantiated per op as
+`Len.lenBodyTerminates`, `IsEmpty.isEmptyBodyTerminates`), which feeds the chunk
+through the integer trunk's `unBodyReturnsWp`. That reads the length from the
+slice's second fat-pointer field (param local `1`), so nothing beyond the chunk
+is needed per op.
 
 The one genuinely new unit here is `fatPtrLoadWp`: unlike a scalar, a slice
 crosses the C ABI **spilled to linear memory**, so the export wrapper must read
@@ -105,5 +106,57 @@ macro_rules
       (simp only [Function.toLocals, Function.numParams, List.take, List.reverse,
           List.reverseAux, List.map, List.length_cons, List.length_nil]
        rw [fatPtrLoadWp 0 $p $dataPtr $len [] (by simp) $hfat]))
+
+/-- Open a memory-resident slice *export* proof: apply the entry lemma, unfold the
+wrapper `def`s, and marshal the fat pointer back from memory with `load_fat_ptr` —
+the uniform three-line head every slice export shares before it `call`s its body.
+`fdef`/`fbody` are the wrapper's `Function`/`Program` defs; the remaining operands
+match `load_fat_ptr`. Leaves the goal just past the fat-pointer read, with the
+per-export tail (`wp_call_tw`, result rewriting) still explicit since it varies. -/
+syntax "open_slice_export " ident ", " ident " at "
+  term ", " term ", " term " using " term : tactic
+
+macro_rules
+  | `(tactic| open_slice_export $fdef, $fbody at $p, $dataPtr, $len using $hfat) =>
+    `(tactic|
+      (apply TerminatesWith.of_wp_entry_for (f := $fdef) rfl
+       unfold $fdef $fbody
+       load_fat_ptr $p, $dataPtr, $len using $hfat))
+
+/-! ## Generic length-only slice callee
+
+A length-only slice primitive compiles at opt-0 to a two-param leaf body
+`[.localGet 1] ++ frag ++ [.ret]`: the fat pointer is passed as `(dataPtr, len)`
+(local `0`, local `1`), the body reads the length from local `1`, and `frag` is a
+`UnChunk` transforming it. `len` (`frag = []`, `op = id`) and `is_empty`
+(`frag = [.const 0, .eq, .const 1, .and]`, `op = isEmptyValue`) are both this
+shape, so one chunk-generic `TerminatesWith` bridge serves them — and any future
+unary slice primitive — instead of a per-op copy of the `of_returns_wp` glue. -/
+
+/-- Callee bridge for a length-only slice body: any module function `id` whose
+body is `[.localGet 1] ++ frag ++ [.ret]` for a `UnChunk frag op` terminates,
+when called with stack `(len, dataPtr, …rest)`, returning `op len` on top of
+`rest`. Instantiate at a concrete chunk (`len_chunk`, `isEmpty_chunk`) to obtain
+that primitive's leaf-call fact; the `of_returns_wp`/`unBodyReturnsWp` glue lives
+here once. -/
+theorem unSliceBodyTerminates {α} {env : HostEnv α} {m : Module} {id : Nat}
+    {f : Function} {frag : Program} {op : UInt32 → UInt32} (chunk : UnChunk frag op)
+    (st : Store α) (dataPtr len : UInt32) (rest : List Value)
+    (hf : m.funcs[id - m.imports.length]? = some f)
+    (hbody : f.body = [.localGet 1] ++ frag ++ [.ret])
+    (hnp : f.numParams = 2)
+    (hres : f.results.length = 1)
+    (hImp : m.imports[id]? = none := by rfl) :
+    TerminatesWith env m id st (.i32 len :: .i32 dataPtr :: rest)
+      (fun st' vs => vs = .i32 (op len) :: rest ∧ framePost st st') := by
+  refine (TerminatesWith.of_returns_wp (f := f) (rs := [.i32 (op len)])
+      (P := framePost st) hf hres.symm ?_ hImp).mono ?_
+  · rw [hbody]
+    simp only [Function.toLocals, hnp]
+    exact unBodyReturnsWp chunk st 1 len [] rfl
+  · intro st' vs h
+    refine ⟨?_, h.2⟩
+    rw [h.1, hnp]
+    simp
 
 end Wasm.RustStd.Array

--- a/codelib/CodeLib/RustStd/Array/IsEmpty.lean
+++ b/codelib/CodeLib/RustStd/Array/IsEmpty.lean
@@ -3,8 +3,8 @@ import CodeLib.RustStd.Array.Basic
 /-! `&[T]::is_empty` — a zero-length test masked to a Rust bool, computed from the
 slice length component. The reusable unit is the unary chunk (a `UnChunk` over
 `UInt32`) for the fragment `[.const 0, .eq, .const 1, .and]`; the called body
-(`isEmptyBodyWp`) derives from it through the integer trunk's `unBodyReturnsWp`,
-and an inlined occurrence reuses the chunk directly. -/
+(`isEmptyBodyTerminates`) derives from it through the trunk's
+`unSliceBodyTerminates`, and an inlined occurrence reuses the chunk directly. -/
 
 namespace Wasm.RustStd.Array
 
@@ -28,32 +28,21 @@ theorem isEmptyValue_and_one (len : UInt32) :
 /-- The reusable chunk: with the slice length on the stack, the fragment
 `[.const 0, .eq, .const 1, .and]` computes `isEmptyValue len`. The single
 stack-form unit for `is_empty` (a `UnChunk` over `UInt32`): it feeds the called
-body via the trunk's `unBodyReturnsWp`, and is `rw`-able directly at an inlined
-`is_empty` once the length is on the stack. -/
+body via the trunk's `unSliceBodyTerminates`, and is `rw`-able directly at an
+inlined `is_empty` once the length is on the stack. -/
 theorem isEmpty_chunk : UnChunk (T := UInt32) [.const 0, .eq, .const 1, .and] isEmptyValue := by
   intro α m env Q st P L rest len vs
   simp only [toV_u32, List.cons_append, List.nil_append, wp_const_cons, wp_eq_cons, wp_and_cons]
   unfold isEmptyValue
   by_cases h : len = 0 <;> simp [h]
 
-/-- Function-body theorem for the generated `&[T]::is_empty` primitive body
-`[localGet i, .const 0, .eq, .const 1, .and, .ret]`, reusing the integer trunk's
-`unBodyReturnsWp` with `isEmpty_chunk`. This is the *called* shape; an inlined
-`is_empty` reuses `isEmpty_chunk` directly (opt-0 only ever emits the call). -/
-theorem isEmptyBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i : Nat) (len : UInt32) (vs : List Value)
-    (hlen : (⟨P, L, vs⟩ : Locals).get i = some (.i32 len)) :
-    wp m [.localGet i, .const 0, .eq, .const 1, .and, .ret]
-      (Returns (.i32 (isEmptyValue len) :: vs) (framePost st)) st ⟨P, L, vs⟩ env :=
-  unBodyReturnsWp isEmpty_chunk st i len vs hlen
-
 /-- Reusable *callee* fact for a generated leaf `is_empty` body. Any module
 function `id` whose body is the canonical `[localGet 1, const 0, eq, const 1, and,
 ret]` (the slice length sits in param local `1`, the second fat-pointer field)
 terminates, when called with stack `(len, dataPtr, …rest)`, returning
-`isEmptyValue len` on top of `rest`. Each corpus' leaf `is_empty` call bridge is
-this lemma at its concrete `func…Def`, so the `of_returns_wp`/`isEmptyBodyWp` glue
-lives here once instead of being restated per corpus. -/
+`isEmptyValue len` on top of `rest`. This is the trunk's `unSliceBodyTerminates`
+at `isEmpty_chunk`; each corpus' leaf `is_empty` call bridge is this lemma at its
+concrete `func…Def`. -/
 theorem isEmptyBodyTerminates {α} {env : HostEnv α} {m : Module} {id : Nat}
     {f : Function} (st : Store α) (dataPtr len : UInt32) (rest : List Value)
     (hf : m.funcs[id - m.imports.length]? = some f)
@@ -62,15 +51,7 @@ theorem isEmptyBodyTerminates {α} {env : HostEnv α} {m : Module} {id : Nat}
     (hres : f.results.length = 1)
     (hImp : m.imports[id]? = none := by rfl) :
     TerminatesWith env m id st (.i32 len :: .i32 dataPtr :: rest)
-      (fun st' vs => vs = .i32 (isEmptyValue len) :: rest ∧ framePost st st') := by
-  refine (TerminatesWith.of_returns_wp (f := f) (rs := [.i32 (isEmptyValue len)])
-      (P := framePost st) hf hres.symm ?_ hImp).mono ?_
-  · rw [hbody]
-    simp only [Function.toLocals, hnp]
-    exact isEmptyBodyWp st 1 len [] rfl
-  · intro st' vs h
-    refine ⟨?_, h.2⟩
-    rw [h.1, hnp]
-    simp
+      (fun st' vs => vs = .i32 (isEmptyValue len) :: rest ∧ framePost st st') :=
+  unSliceBodyTerminates isEmpty_chunk st dataPtr len rest hf hbody hnp hres hImp
 
 end Wasm.RustStd.Array

--- a/codelib/CodeLib/RustStd/Array/Len.lean
+++ b/codelib/CodeLib/RustStd/Array/Len.lean
@@ -3,8 +3,8 @@ import CodeLib.RustStd.Array.Basic
 /-! `&[T]::len` — the slice length is the `i32` length component of the fat
 pointer; the monomorphized primitive body just returns it. The reusable unit is
 the degenerate unary chunk (`frag = []`, `op = id`) over the length, which feeds
-the called body through the integer trunk's `unBodyReturnsWp`. The *inlined*
-read is just `wp_localGet_cons`, so it needs no slice-specific lemma. -/
+the called body through the trunk's `unSliceBodyTerminates`. The *inlined* read
+is just `wp_localGet_cons`, so it needs no slice-specific lemma. -/
 
 namespace Wasm.RustStd.Array
 
@@ -13,20 +13,26 @@ open Wasm Wasm.RustStd
 /-- The reusable chunk: with the length on the stack, the empty fragment leaves
 it unchanged — `len` is the identity length-only op. The `frag = []`, `op = id`
 case of the trunk's `UnChunk` (at `UInt32`, whose `toV` is `.i32`); feeds
-`lenBodyWp` via `unBodyReturnsWp`. -/
+`lenBodyTerminates` via `unSliceBodyTerminates`. -/
 theorem len_chunk : UnChunk (T := UInt32) [] (id : UInt32 → UInt32) := by
   intro α m env Q st P L rest len vs
   simp
 
-/-- Function-body theorem for the generated `&[T]::len` primitive body
-`[localGet i, .ret]`, reusing the integer trunk's `unBodyReturnsWp` with
-`len_chunk`. Serves the *called* shape; the *inlined* shape is just
-`wp_localGet_cons`. -/
-theorem lenBodyWp {α} {m : Module} {env : HostEnv α} (st : Store α)
-    {P L : List Value} (i : Nat) (len : UInt32) (vs : List Value)
-    (hlen : (⟨P, L, vs⟩ : Locals).get i = some (.i32 len)) :
-    wp m [.localGet i, .ret]
-      (Returns (.i32 len :: vs) (framePost st)) st ⟨P, L, vs⟩ env :=
-  unBodyReturnsWp len_chunk st i len vs hlen
+/-- Reusable *callee* fact for a generated leaf `len` body. Any module function
+`id` whose body is the canonical `[localGet 1, ret]` (the slice length sits in
+param local `1`, the second fat-pointer field) terminates, when called with stack
+`(len, dataPtr, …rest)`, returning `len` on top of `rest`. This is the trunk's
+`unSliceBodyTerminates` at `len_chunk` (`op = id`); each corpus' leaf `len` call
+bridge is this lemma at its concrete `func…Def`. -/
+theorem lenBodyTerminates {α} {env : HostEnv α} {m : Module} {id : Nat}
+    {f : Function} (st : Store α) (dataPtr len : UInt32) (rest : List Value)
+    (hf : m.funcs[id - m.imports.length]? = some f)
+    (hbody : f.body = [.localGet 1, .ret])
+    (hnp : f.numParams = 2)
+    (hres : f.results.length = 1)
+    (hImp : m.imports[id]? = none := by rfl) :
+    TerminatesWith env m id st (.i32 len :: .i32 dataPtr :: rest)
+      (fun st' vs => vs = .i32 len :: rest ∧ framePost st st') :=
+  unSliceBodyTerminates len_chunk st dataPtr len rest hf hbody hnp hres hImp
 
 end Wasm.RustStd.Array

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -9,10 +9,10 @@ A small parser for the WebAssembly text format, targeting Wasm's AST.
 Supported:
 * `(module ...)` with any number of `(func ...)` definitions.
 * `(type ...)`, `(export ...)`, `(import ...)`, `(table ...)`, `(memory ...)`,
-  `(global ...)`, `(elem ...)`, `(data ...)`, `(start ...)` — recognized at the
-  module level. Only `func` and `export` contribute to the resulting
-  `Wasm.Module`; the rest are accepted to allow round-tripping the spec
-  testsuite, but their content is discarded.
+  `(global ...)`, `(elem ...)`, `(data ...)`, `(tag ...)`, `(start ...)` —
+  recognized at the module level and fully parsed into the resulting
+  `Wasm.Module`. (Non-func imports, i.e.
+  `(import … (memory|global|table …))`, are the one exception: dropped.)
 * Func headers may include `(type N)`, `(param ...)*`, `(result ...)*`,
   `(local ...)*` in any order, with grouped or singleton declarations.
 * Linear instruction stream and folded operand expressions
@@ -26,8 +26,10 @@ Supported:
 * Numeric indices and symbolic identifiers (`$L`).
 * `(;0;)` block comments and `;;` line comments are stripped during tokenization.
 
-Features Wasm does not model (memory loads/stores, `memory.*`, globals,
-`call_indirect`, tables) are accepted lexically but lowered to
+Memory loads/stores, `memory.*`, globals, `call_indirect`, tables,
+floats, and SIMD are all modelled and decode to real instructions.
+Instructions from proposals the interpreter still doesn't model (e.g.
+atomics/threads) are accepted lexically but lowered to
 `Wasm.Instruction.unreachable` so the surrounding function still
 type-checks. `local.tee i` is desugared to `[local.set i; local.get i]`. -/
 
@@ -672,13 +674,14 @@ private def parsePlainOp : String → Except Err Wasm.Instruction
   | "i31.get_u"    => .ok (.gc .i31GetU)
   | "ref.eq"       => .ok (.gc .refEq)
   | op          =>
-    -- Accept instructions from proposals the interpreter doesn't model
-    -- (floats, SIMD, reference types, tables, GC, exceptions, tail calls)
-    -- by lowering them to `unreachable`. This lets modules whose
-    -- *signatures* or unrelated functions touch these features still
-    -- decode; any function that actually executes such an instruction
-    -- traps with "unreachable" instead of failing to decode at all,
-    -- which would cascade to every assert in the file.
+    -- Fallback for mnemonics not matched above (and not caught by
+    -- `simdOp?`): still-unmodelled proposals such as atomics/threads and
+    -- relaxed SIMD, plus stray leftovers from partly-modelled proposals
+    -- (reference types, tables, GC, exceptions, tail calls). Lower them to
+    -- `unreachable` so modules whose *signatures* or unrelated functions
+    -- touch these features still decode; a function that actually executes
+    -- such an instruction traps with "unreachable" instead of failing to
+    -- decode at all, which would cascade to every assert in the file.
     if op.startsWith "f32." || op.startsWith "f64." || op.startsWith "v128."
        || op.startsWith "i8x16." || op.startsWith "i16x8." || op.startsWith "i32x4."
        || op.startsWith "i64x2." || op.startsWith "f32x4." || op.startsWith "f64x2."
@@ -695,9 +698,9 @@ private def parsePlainOp : String → Except Err Wasm.Instruction
     else
       .error s!"unsupported instruction: {op}"
 
-/-- Memory ops that take an offset immediate. We accept them lexically
-(`offset=`/`align=` attributes parsed and discarded) but emit
-`unreachable` for the instruction itself. -/
+/-- Memory ops that take an offset immediate, mapped to their natural
+alignment (byte width). `offset=`/`align=` attributes are parsed off the
+token stream; `memOpToInstruction` then emits the real load/store. -/
 private def isMemOp (op : String) : Option Nat :=
   match op with
   | "i32.load"     => some 4
@@ -714,10 +717,8 @@ private def isMemOp (op : String) : Option Nat :=
   | "i64.store8"   => some 1
   | "i64.store16"  => some 2
   | "i64.store32"  => some 4
-  -- Float and SIMD memory ops are lexically accepted (their offset=/
-  -- align= attributes parsed and discarded), but `memOpToInstruction`
-  -- lowers them to `unreachable` since the interpreter doesn't model
-  -- those value types.
+  -- Float and SIMD memory ops (their offset=/align= attributes parsed the
+  -- same way); `memOpToInstruction` emits the matching real load/store.
   | "f32.load" | "f32.store" => some 4
   | "f64.load" | "f64.store" => some 8
   | "v128.load" | "v128.store" => some 16
@@ -765,24 +766,6 @@ private def consumeMemAttrs (natAlign : Nat) (toks : List Sexpr)
         | none => .ok (offset, .atom a :: r)
     | xs => .ok (offset, xs)
   loop 0 toks
-
-/-- Number of atom immediates a *lowered* (treated-as-`unreachable`) op
-consumes. Used to keep the linear/folded parsers in sync with the token
-stream when we accept-and-stub instructions from proposals the
-interpreter doesn't model. Returns `none` for ops we don't pretend to
-support. -/
-private def stubImmediateCount (_op : String) : Option Nat :=
-  -- `br_on_cast`/`br_on_cast_fail` take label + from_type + to_type and are
-  -- handled separately by `consumeBrOnCastImmediates`; all other GC ops are
-  -- now decoded to real instructions.
-  none
-
-/-- Drop the first `n` atom tokens from `toks`. Errors if a non-atom is
-encountered or the stream is too short. -/
-private partial def consumeStubAtoms (op : String) : Nat → List Sexpr → Except Err (List Sexpr)
-  | 0, ts => .ok ts
-  | k+1, .atom _ :: ts => consumeStubAtoms op k ts
-  | _+1, _ => .error s!"{op}: expected immediate atom"
 
 /-! ## SIMD mnemonic table
 
@@ -1379,9 +1362,7 @@ private partial def parseInstr (ctx : Ctx) (toks : List Sexpr)
           -- immediates so the token stream stays aligned.
           let rest' ← if op == "br_on_cast" || op == "br_on_cast_fail" then
             consumeBrOnCastImmediates op rest
-          else match stubImmediateCount op with
-            | some n => consumeStubAtoms op n rest
-            | none   => .ok rest
+          else .ok rest
           .ok ([i], rest')
 
 private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
@@ -2849,14 +2830,13 @@ private def collectImports (types : Array TypeEntry) (fields : List Sexpr)
     | _ => pure ()
   return (imports, idOf)
 
-/-- Walk a `(module ...)` form. `(func …)`, `(export …)`, `(global …)`,
-`(memory …)`, `(data …)`, `(start …)`, and `(import "mod" "name"
-(func …))` all contribute to the resulting `Wasm.Module`. Function
-imports occupy the low end of the unified function index space (indices
-`0 … N-1`); in-module function indices are shifted up by
-`imports.length`. Other recognised fields (`type`, `table`, `elem`, non-
-func imports) are accepted lexically so the spec testsuite still loads,
-but their content is discarded. -/
+/-- Walk a `(module ...)` form. `(type …)`, `(func …)`, `(export …)`,
+`(global …)`, `(table …)`, `(memory …)`, `(elem …)`, `(data …)`,
+`(tag …)`, `(start …)`, and `(import "mod" "name" (func …))` all
+contribute to the resulting `Wasm.Module`. Function imports occupy the
+low end of the unified function index space (indices `0 … N-1`);
+in-module function indices are shifted up by `imports.length`. Only
+non-func imports (`(import … (memory|global|table …))`) are dropped. -/
 def parseModule (xs : List Sexpr) : Except Err Wasm.Module := do
   let mut rest := xs
   match rest with

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -11,8 +11,10 @@ Supported:
 * `(type ...)`, `(export ...)`, `(import ...)`, `(table ...)`, `(memory ...)`,
   `(global ...)`, `(elem ...)`, `(data ...)`, `(tag ...)`, `(start ...)` —
   recognized at the module level and fully parsed into the resulting
-  `Wasm.Module`. (Non-func imports, i.e.
-  `(import … (memory|global|table …))`, are the one exception: dropped.)
+  `Wasm.Module`. Non-func imports (`(import … (memory|global|table …))`)
+  are parsed too: each becomes a placeholder decl at the low end of its
+  index space and is recorded in `importedGlobals`/`importedTables`/
+  `importedMemories` for later host substitution.
 * Func headers may include `(type N)`, `(param ...)*`, `(result ...)*`,
   `(local ...)*` in any order, with grouped or singleton declarations.
 * Linear instruction stream and folded operand expressions
@@ -1005,17 +1007,6 @@ private def looksLikeLabel (s : String) : Bool :=
   else
     s.toList.all (fun c => c.isDigit || c = '_')
 
-/-- Consume the label immediate and the two type-immediates of a
-`br_on_cast` / `br_on_cast_fail`. The label is a single atom; each type
-is either an atom (e.g. `anyref`) or a `(ref …)` list. -/
-private def consumeBrOnCastImmediates (op : String)
-    : List Sexpr → Except Err (List Sexpr)
-  | .atom _ :: t1 :: t2 :: rest =>
-    match t1, t2 with
-    | .atom _, .atom _ | .atom _, .list _
-    | .list _, .atom _ | .list _, .list _ => .ok rest
-  | _ => .error s!"{op}: expected label + 2 type immediates"
-
 /-- Parse the *optional* table-index immediate carried by `table.get` /
 `table.size` in flat (post-`wasm-tools print`) form. The index is `$name`
 or a numeric literal when present and defaults to table `0` when omitted;
@@ -1357,13 +1348,12 @@ private partial def parseInstr (ctx : Ctx) (toks : List Sexpr)
         | none =>
         match parsePlainOp op with
         | .error e => .error e
-        | .ok i => do
-          -- For ops we lowered to `unreachable`, consume any textual
-          -- immediates so the token stream stays aligned.
-          let rest' ← if op == "br_on_cast" || op == "br_on_cast_fail" then
-            consumeBrOnCastImmediates op rest
-          else .ok rest
-          .ok ([i], rest')
+        -- Ops reaching this fallback are lowered to `unreachable` and carry
+        -- no immediates we track, so the token stream stays aligned with
+        -- `rest` untouched. (Ops that *do* carry immediates — including
+        -- `br_on_cast`/`br_on_cast_fail` — are handled by explicit arms above
+        -- and never fall through here.)
+        | .ok i => .ok ([i], rest)
 
 private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
     : Except Err (List Wasm.Instruction) :=
@@ -2832,11 +2822,14 @@ private def collectImports (types : Array TypeEntry) (fields : List Sexpr)
 
 /-- Walk a `(module ...)` form. `(type …)`, `(func …)`, `(export …)`,
 `(global …)`, `(table …)`, `(memory …)`, `(elem …)`, `(data …)`,
-`(tag …)`, `(start …)`, and `(import "mod" "name" (func …))` all
-contribute to the resulting `Wasm.Module`. Function imports occupy the
-low end of the unified function index space (indices `0 … N-1`);
-in-module function indices are shifted up by `imports.length`. Only
-non-func imports (`(import … (memory|global|table …))`) are dropped. -/
+`(tag …)`, `(start …)`, and `(import "mod" "name" (…))` — for func and
+non-func imports alike — all contribute to the resulting `Wasm.Module`.
+Function imports occupy the low end of the unified function index space
+(indices `0 … N-1`); in-module function indices are shifted up by
+`imports.length`. Non-func imports (`(import … (memory|global|table …))`)
+are collected by `collectEntityImports` into placeholder decls at the low
+end of the global/table/memory index spaces and recorded in
+`importedGlobals`/`importedTables`/`importedMemories`. -/
 def parseModule (xs : List Sexpr) : Except Err Wasm.Module := do
   let mut rest := xs
   match rest with

--- a/programs/lean/Project/RustArray/Spec.lean
+++ b/programs/lean/Project/RustArray/Spec.lean
@@ -7,7 +7,8 @@ import Interpreter.Wasm.Wp.Call
 Two layers, both discharged by reusing the `CodeLib/RustStd/Array` chunks:
 
 * the internal raw `(ptr, len)` bodies (`func0` = `len`, `func2` = `is_empty`),
-  reusing `lenBodyWp` / `isEmptyBodyWp`; and
+  reusing the CodeLib leaf bridges `lenBodyTerminates` / `isEmptyBodyTerminates`
+  (both instances of the trunk's `unSliceBodyTerminates`); and
 * the exported ABI wrappers (`func4` = `len`, `func5` = `is_empty`), which receive
   the slice as a fat pointer in linear memory: they `load32` the `(dataPtr, len)`
   fields back with `fatPtrLoadWp` and then `call` the bodies above (`is_empty`
@@ -24,42 +25,21 @@ namespace Project.RustArray.Spec
 
 open Wasm Wasm.RustStd Wasm.RustStd.Array
 
-/-! ## Internal `(ptr, len)` bodies -/
+/-! ## Call bridges
 
-@[spec_of "rust-internal" "rust_array::len"]
-def LenSpec : Prop := ∀ (env : HostEnv Unit) (ptr len : UInt32),
-  TerminatesWith env «module» 0 «module».initialStore [.i32 len, .i32 ptr]
-    (fun _ rs => rs = [.i32 len])
+Each bridge is the callee's behaviour at an *arbitrary* store (these bodies touch
+no memory), reusing the CodeLib `Array` chunks. They serve both layers: the
+internal specs below are each the matching bridge at `«module».initialStore`, and
+the exported wrappers `call` the same body after marshalling the fat pointer back
+from memory. -/
 
-@[proves Project.RustArray.Spec.LenSpec]
-theorem len_correct : LenSpec := by
-  intro env ptr len
-  exact (TerminatesWith.of_returns_wp (f := func0Def) (rs := [.i32 len]) rfl rfl
-      (lenBodyWp «module».initialStore 1 len [] rfl) rfl).mono (fun _ _ h => h.1)
-
-@[spec_of "rust-internal" "rust_array::is_empty"]
-def IsEmptySpec : Prop := ∀ (env : HostEnv Unit) (ptr len : UInt32),
-  TerminatesWith env «module» 2 «module».initialStore [.i32 len, .i32 ptr]
-    (fun _ rs => rs = [.i32 (isEmptyValue len)])
-
-@[proves Project.RustArray.Spec.IsEmptySpec]
-theorem is_empty_correct : IsEmptySpec := by
-  intro env ptr len
-  exact (TerminatesWith.of_returns_wp (f := func2Def) (rs := [.i32 (isEmptyValue len)]) rfl rfl
-      (isEmptyBodyWp «module».initialStore 1 len [] rfl) rfl).mono (fun _ _ h => h.1)
-
-/-! ## Call bridges for the exported wrappers
-
-Each bridge is the callee's behaviour at the export's store, reusing the body
-chunk above; `wp_call_tw` threads it through the `.call` in the wrapper. -/
-
-/-- `func0` (`len` body) as a callee: returns the length argument. -/
+/-- `func0` (`len` body) as a callee: returns the length argument, via the CodeLib
+leaf bridge `lenBodyTerminates`. -/
 private theorem len_call {env : HostEnv Unit} (st : Store Unit)
     (dataPtr len : UInt32) (rest : List Value) :
     TerminatesWith env «module» 0 st (.i32 len :: .i32 dataPtr :: rest)
       (fun st' vs => vs = .i32 len :: rest ∧ framePost st st') :=
-  TerminatesWith.of_returns_wp (f := func0Def) (rs := [.i32 len]) rfl rfl
-    (lenBodyWp st 1 len [] rfl) rfl
+  lenBodyTerminates st dataPtr len rest rfl rfl rfl rfl
 
 /-- `func2` (`is_empty` leaf body) as a callee: returns `isEmptyValue len`,
 reusing the CodeLib leaf bridge `isEmptyBodyTerminates`. -/
@@ -86,6 +66,31 @@ private theorem crateIsEmpty_call {env : HostEnv Unit} (st : Store Unit)
   rw [isEmptyValue_and_one]
   simp
 
+/-! ## Internal `(ptr, len)` body specs
+
+Each is the matching call bridge at `«module».initialStore` with an empty trailing
+stack (`.mono` drops the `framePost` frame the caller-facing spec doesn't need). -/
+
+@[spec_of "rust-internal" "rust_array::len"]
+def LenSpec : Prop := ∀ (env : HostEnv Unit) (ptr len : UInt32),
+  TerminatesWith env «module» 0 «module».initialStore [.i32 len, .i32 ptr]
+    (fun _ rs => rs = [.i32 len])
+
+@[proves Project.RustArray.Spec.LenSpec]
+theorem len_correct : LenSpec := by
+  intro env ptr len
+  exact (len_call «module».initialStore ptr len []).mono (fun _ _ h => h.1)
+
+@[spec_of "rust-internal" "rust_array::is_empty"]
+def IsEmptySpec : Prop := ∀ (env : HostEnv Unit) (ptr len : UInt32),
+  TerminatesWith env «module» 2 «module».initialStore [.i32 len, .i32 ptr]
+    (fun _ rs => rs = [.i32 (isEmptyValue len)])
+
+@[proves Project.RustArray.Spec.IsEmptySpec]
+theorem is_empty_correct : IsEmptySpec := by
+  intro env ptr len
+  exact (isEmptyLeaf_call «module».initialStore ptr len []).mono (fun _ _ h => h.1)
+
 /-! ## Exported ABI wrappers (fat pointer in memory) -/
 
 @[spec_of "rust-exported" "rust_array::len"]
@@ -97,9 +102,7 @@ def LenExportSpec : Prop := ∀ (env : HostEnv Unit) (st : Store Unit) (p dataPt
 @[proves Project.RustArray.Spec.LenExportSpec]
 theorem len_export_correct : LenExportSpec := by
   intro env st p dataPtr len hfat
-  apply TerminatesWith.of_wp_entry_for (f := func4Def) rfl
-  unfold func4Def func4
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func4Def, func4 at p, dataPtr, len using hfat
   apply wp_call_tw (len_call st dataPtr len [])
   intro st1 vs1 h1
   obtain ⟨hvs1, _⟩ := h1
@@ -116,9 +119,7 @@ def IsEmptyExportSpec : Prop := ∀ (env : HostEnv Unit) (st : Store Unit) (p da
 @[proves Project.RustArray.Spec.IsEmptyExportSpec]
 theorem is_empty_export_correct : IsEmptyExportSpec := by
   intro env st p dataPtr len hfat
-  apply TerminatesWith.of_wp_entry_for (f := func5Def) rfl
-  unfold func5Def func5
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func5Def, func5 at p, dataPtr, len using hfat
   apply wp_call_tw (crateIsEmpty_call st dataPtr len [])
   intro st1 vs1 h1
   subst h1

--- a/programs/lean/Project/RustArrayTests/Spec.lean
+++ b/programs/lean/Project/RustArrayTests/Spec.lean
@@ -140,9 +140,7 @@ def LenPlusOneExportSpec : Prop :=
 @[proves Project.RustArrayTests.Spec.LenPlusOneExportSpec]
 theorem len_plus_one_export_correct : LenPlusOneExportSpec := by
   intro env st p dataPtr len hfat
-  apply TerminatesWith.of_wp_entry_for (f := func8Def) rfl
-  unfold func8Def func8
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func8Def, func8 at p, dataPtr, len using hfat
   apply wp_call_tw (lenPlusOne_call st dataPtr len [])
   intro st1 vs1 h1
   subst h1
@@ -158,9 +156,7 @@ def LenPlusArgExportSpec : Prop :=
 @[proves Project.RustArrayTests.Spec.LenPlusArgExportSpec]
 theorem len_plus_arg_export_correct : LenPlusArgExportSpec := by
   intro env st p dataPtr len n hfat
-  apply TerminatesWith.of_wp_entry_for (f := func7Def) rfl
-  unfold func7Def func7
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func7Def, func7 at p, dataPtr, len using hfat
   wp_run
   apply wp_call_tw (lenPlusArg_call st dataPtr len n [])
   intro st1 vs1 h1
@@ -177,9 +173,7 @@ def EmptyPlusThreeExportSpec : Prop :=
 @[proves Project.RustArrayTests.Spec.EmptyPlusThreeExportSpec]
 theorem empty_plus_three_export_correct : EmptyPlusThreeExportSpec := by
   intro env st p dataPtr len hfat
-  apply TerminatesWith.of_wp_entry_for (f := func5Def) rfl
-  unfold func5Def func5
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func5Def, func5 at p, dataPtr, len using hfat
   apply wp_call_tw (emptyPlusThree_call st dataPtr len [])
   intro st1 vs1 h1
   subst h1
@@ -196,9 +190,7 @@ def EmptyXorFlagExportSpec : Prop :=
 @[proves Project.RustArrayTests.Spec.EmptyXorFlagExportSpec]
 theorem empty_xor_flag_export_correct : EmptyXorFlagExportSpec := by
   intro env st p dataPtr len flag hfat
-  apply TerminatesWith.of_wp_entry_for (f := func6Def) rfl
-  unfold func6Def func6
-  load_fat_ptr p, dataPtr, len using hfat
+  open_slice_export func6Def, func6 at p, dataPtr, len using hfat
   wp_run
   apply wp_call_tw (emptyXorFlag_call st dataPtr len flag [])
   intro st1 vs1 h1

--- a/programs/rust/rust_array_tests/src/exports.rs
+++ b/programs/rust/rust_array_tests/src/exports.rs
@@ -4,7 +4,7 @@
 //! a length read while `is_empty` lowers to a `call`, so the two shapes the chunk
 //! corpus targets are both exercised: the inlined-`len` read is stepped directly
 //! by `wp_run` (`wp_localGet_cons`/`wp_add_cons`), while the `is_empty` `call`
-//! reuses the CodeLib `isEmptyBodyWp` body theorem. The source helpers are generic
+//! reuses the CodeLib `isEmptyBodyTerminates` leaf bridge. The source helpers are generic
 //! over `T`; these wrappers only choose a concrete monomorphization so Rust emits
 //! wasm.
 


### PR DESCRIPTION
decoder: remove dead stub-immediate path, fix stale docstrings

`stubImmediateCount` unconditionally returns `none` (all GC ops are decoded for
real now), which makes the `some n => consumeStubAtoms …` branch that calls it
statically unreachable and `consumeStubAtoms` dead. This removes both and folds
the branch to its only reachable arm (`.ok rest`), keeping the live
`consumeBrOnCastImmediates` case untouched — behaviour is unchanged.

It also refreshes several comments that no longer match the decoder: the
top-of-file and `parseModule` docstrings (type/table/memory/global/elem/data/tag
content is fully parsed now, not discarded), the `parsePlainOp` catch-all
(floats and SIMD are modelled; the fallback only stubs still-unmodelled proposals
like atomics), and the `isMemOp` comments (memory ops emit real load/stores).
