### PR TITLE
docs: fix stale docstrings in the interpreter core

### DIFF
--- a/interpreter/Interpreter/Wasm/Mem.lean
+++ b/interpreter/Interpreter/Wasm/Mem.lean
@@ -6,10 +6,9 @@ page count (1 page = 64 KiB). The function is total: reads outside the
 (typically zero, since `Mem.empty` initialises with `fun _ => 0`), but
 well-formed programs never read those addresses.
 
-This is Step 1 of the linear-memory refactor: only the API and the
-field/structure are introduced. No proofs (frame lemmas, bounds, etc.)
-are added yet — those come later when instructions actually start
-consuming `Mem`.
+This is the live memory model backing every memory instruction:
+loads/stores, `memory.size`/`grow`/`fill`/`copy`/`init`, and the
+multi-memory and data-segment machinery all read and write a `Mem`.
 
 The simplicity-of-reasoning convention applies: writes update the
 underlying `bytes` function pointwise via `fun i => if i ∈ range then …

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -121,8 +121,9 @@ def readStorageLE (storage : StorageType) (bytes : List UInt8) (off : Nat) : Val
 
 /-- Evaluate a simple element-segment item constant expression to its
 reference value (GC proposal). Covers the forms element segments use:
-`ref.func`, `ref.null`, `ref.i31` of a constant, and scalar constants.
-Heap-allocating items (`struct.new`) are not handled here. -/
+`ref.func`; the null refs `ref.null func`/`extern`/`exn` and `ref.null`
+of a GC heap type; the `i32`/`i64` scalar constants; and `ref.i31` of an
+`i32.const`. Heap-allocating items (`struct.new`) are not handled here. -/
 def evalConstRef : Program → Option Value
   | [.refFunc f]                 => some (.funcref (some f))
   | [.refNull]                   => some (.funcref none)

--- a/interpreter/Interpreter/Wasm/Simd.lean
+++ b/interpreter/Interpreter/Wasm/Simd.lean
@@ -146,7 +146,9 @@ private def f32LaneBin (f : UInt32 → UInt32 → UInt32) (a b : Nat) : Nat :=
 private def f64LaneBin (f : UInt64 → UInt64 → UInt64) (a b : Nat) : Nat :=
   (f (UInt64.ofNat a) (UInt64.ofNat b)).toNat
 
-/-- `pmin`: `b < a ? b : a`, NaN-insensitive, operand returned unchanged. -/
+/-- The `pmin`/`pmax` family (f32 and f64): `pmin a b = b < a ? b : a` and
+`pmax a b = a < b ? b : a`, NaN-insensitive, returning the chosen operand
+unchanged rather than a canonicalised result. -/
 def f32Pmin (a b : UInt32) : UInt32 := if f32Lt b a then b else a
 def f32Pmax (a b : UInt32) : UInt32 := if f32Lt a b then b else a
 def f64Pmin (a b : UInt64) : UInt64 := if f64Lt b a then b else a

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -122,6 +122,8 @@ they report 0. -/
 def StorageType.byteSize : StorageType → Nat
   | .packed 8  => 1
   | .packed 16 => 2
+  -- Packed widths are only ever 8 or 16; this catch-all is unreachable for
+  -- well-formed inputs and just keeps the match total.
   | .packed _  => 1
   | .val .i32  => 4
   | .val .i64  => 8


### PR DESCRIPTION
docs: fix stale docstrings in the interpreter core

Documentation only, no code changes:
- `Mem.lean`: drop the stale "Step 1 of the refactor … nothing uses it yet"
  scaffolding sentence — `Mem` is the live memory model behind every memory
  instruction.
- `Semantics.lean`: `evalConstRef`'s docstring now lists all the forms it
  actually handles (the extern/exn/any null refs and the i64 constant were
  omitted).
- `Simd.lean`: the `pmin`/`pmax` header comment now covers the whole f32/f64
  family it heads, not just `pmin`.
- `Syntax.lean`: note that `StorageType.byteSize`'s `.packed _` catch-all is only
  reached for well-formed widths (8/16); it exists to keep the match total.
