### PR TITLE
testsuite: fix stale help/docstring text, drop dead helper

### DIFF
--- a/interpreter/Interpreter/Testsuite.lean
+++ b/interpreter/Interpreter/Testsuite.lean
@@ -3,7 +3,7 @@ import Interpreter.Testsuite.Exec
 /-!
 # `testsuite` — run the W3C Wasm spec testsuite against this interpreter
 
-  lake exe testsuite [--fuel N] [-h|--help] [PATTERN]
+  lake exe testsuite [--fuel N] [--json|--report] [-h|--help] [PATTERN]
 
 If `PATTERN` is omitted, runs every top-level `.wast` file under
 `vendor/testsuite/`. Otherwise filters to files whose relative path
@@ -14,11 +14,17 @@ Per `.wast` file we shell out to `wasm-tools json-from-wast` to split the
 script into a JSON manifest plus per-module `.wasm` files, then walk the
 commands. Only `module`, `assert_return`, `assert_trap`, and `action` are
 executed — every other command type (`assert_invalid`, `assert_malformed`,
-`register`, `assert_unlinkable`, etc.) is reported as `Skipped(<kind>)`.
+`assert_unlinkable`, etc.) is reported as `Skipped(<kind>)`.
+
+Output is the human-readable per-file report by default. `--json` emits the
+results as a JSON array instead; `--report` emits the stable text coverage
+report (one sorted line per command, outcome tag only) that CI byte-compares
+to detect coverage drift. The two are mutually exclusive.
 
 Exit code: nonzero iff any `Fail`, `InterpreterError`, or `OutOfFuel`
 outcome was recorded. `DecodeError`/`ModuleUnavailable`/`Skipped` don't
 fail the run — they're "feature not implemented" signal, not regressions.
+`--report` always exits 0 (the report diff, not the exit code, is the gate).
 -/
 
 namespace Wasm.Testsuite
@@ -38,7 +44,7 @@ def usage : String :=
 
   PATTERN     If given, only run .wast files whose path contains this substring.
               If omitted, run every top-level .wast file under vendor/testsuite/.
-  --fuel N    Per-assertion reduction-step cap, default 1_000_000.
+  --fuel N    Per-assertion reduction-step cap, default 50_000_000.
   --json      Emit results as a JSON array instead of the human-readable report.
   --report    Emit the stable text coverage report (one line per command,
               sorted, outcome tag only — used by CI to detect coverage drift).
@@ -231,8 +237,9 @@ end
 report file is byte-compared in CI, so anything emitted here must not depend
 on incidental error wording. Free-form sources are:
   * `non-integer expected: <parser err>` — collapse to `non-integer-expected`.
-All other reasons are already constant strings (`register`, raw wast command
-names like `assert_invalid`/`assert_malformed`/etc.) and pass through. -/
+All other reasons are already stable strings (`assert_invalid`/`assert_malformed`
++ `: not rejected` when we accept an ill-formed module, and raw wast command
+names like `assert_unlinkable` from the fallthrough) and pass through. -/
 private def skippedBucket (r : String) : String :=
   if r.startsWith "non-integer expected" then "non-integer-expected"
   else r

--- a/interpreter/Interpreter/Testsuite/Exec.lean
+++ b/interpreter/Interpreter/Testsuite/Exec.lean
@@ -40,10 +40,6 @@ inductive Outcome where
   | moduleUnavailable
 deriving Repr, Inhabited
 
-def Outcome.isFail : Outcome → Bool
-  | .fail _ | .interpreterError _ | .outOfFuel => true
-  | _ => false
-
 /-- One executed command's recorded outcome, with its source `.wast` line. -/
 structure CmdResult where
   line    : Nat


### PR DESCRIPTION
testsuite: fix stale help/docstring text, drop dead helper

Tooling cleanup, behaviour unchanged:
- Remove `Outcome.isFail` — it has no callers (failure counting lives in
  `Counts.hasFailure`).
- Correct the `--fuel` help text: the default is `50_000_000` (the `defaultFuel`
  constant), not `1_000_000`.
- Document the `--json` / `--report` flags in the module docstring (and that
  `--report` always exits 0).
- Fix the `skippedBucket` comment, which listed `register` as a skip reason even
  though `register` is now executed.
