### PR TITLE
testsuite: correct stale command-execution and exit-code docstrings

### DIFF
--- a/interpreter/Interpreter/Testsuite.lean
+++ b/interpreter/Interpreter/Testsuite.lean
@@ -12,19 +12,24 @@ contains `PATTERN` as a substring (case-sensitive). Subdirectories of
 
 Per `.wast` file we shell out to `wasm-tools json-from-wast` to split the
 script into a JSON manifest plus per-module `.wasm` files, then walk the
-commands. Only `module`, `assert_return`, `assert_trap`, and `action` are
-executed — every other command type (`assert_invalid`, `assert_malformed`,
-`assert_unlinkable`, etc.) is reported as `Skipped(<kind>)`.
+commands. `module`, `register`, `assert_return`, `assert_trap`,
+`assert_exception`, and `action` are executed against the interpreter.
+`assert_invalid`/`assert_malformed` are also run — we decode and statically
+validate the module, pass when it is rejected, and record
+`Skipped(<kind>: not rejected)` only if we wrongly accept it. Every remaining
+command type (`assert_unlinkable`, etc.) falls through to `Skipped(<kind>)`.
 
 Output is the human-readable per-file report by default. `--json` emits the
 results as a JSON array instead; `--report` emits the stable text coverage
 report (one sorted line per command, outcome tag only) that CI byte-compares
 to detect coverage drift. The two are mutually exclusive.
 
-Exit code: nonzero iff any `Fail`, `InterpreterError`, or `OutOfFuel`
-outcome was recorded. `DecodeError`/`ModuleUnavailable`/`Skipped` don't
-fail the run — they're "feature not implemented" signal, not regressions.
-`--report` always exits 0 (the report diff, not the exit code, is the gate).
+Exit code: `1` iff any `Fail`, `InterpreterError`, or `OutOfFuel` outcome was
+recorded, and `3` for a setup failure (bad arguments, an unreadable testsuite
+directory, no matching files, or temp-dir creation failure). `DecodeError`/
+`ModuleUnavailable`/`Skipped` don't fail the run — they're "feature not
+implemented" signal, not regressions. `--report` always exits 0 (the report
+diff, not the exit code, is the gate).
 -/
 
 namespace Wasm.Testsuite


### PR DESCRIPTION
Follow-up to #130. That PR set out to fix stale testsuite docstrings but left three inaccuracies in the `Interpreter/Testsuite.lean` module docstring (and, in one case, partially introduced an inconsistency by only half-updating a sentence). This is a **comment-only** change — no behaviour change.

## Fixes

1. **Incomplete "executed" list.** The docstring claimed *"Only `module`, `assert_return`, `assert_trap`, and `action` are executed"*. But `register` is executed (it records a binding — the #130 commit message itself says so; `Exec.lean:746`) and so is `assert_exception` (`Exec.lean:804`). Both are now listed.

2. **`assert_invalid`/`assert_malformed` mislabelled as skipped.** They were listed under *"reported as `Skipped(<kind>)`"*, but they are executed: we decode + statically validate the module, record `Pass` on correct rejection, and `Skipped(<kind>: not rejected)` only when we wrongly accept it (`Exec.lean:826-836`). This also aligns the top-of-file docstring with the `skippedBucket` comment that #130 added lower in the same file.

3. **Exit-code claim ignored the setup-failure path.** *"Exit code: nonzero iff any `Fail`, `InterpreterError`, or `OutOfFuel` outcome was recorded"* omitted the exit-code-`3` paths (bad arguments, unreadable testsuite dir, no matching files, temp-dir creation failure). Both codes are now spelled out.

## Verification

Comment-only edit confined to the existing `/-! … -/` docstring block; delimiters untouched. Local oleans are stale from the v4.32.0 toolchain bump (#144), so a full local rebuild would rebuild Mathlib — disproportionate for a docstring change; CI will build it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)