### PR TITLE
codelib: address review findings on MemRegion algebra (#138 follow-up)

### DIFF
--- a/codelib/CodeLib/RustStd/Frame.lean
+++ b/codelib/CodeLib/RustStd/Frame.lean
@@ -65,8 +65,24 @@ returns the stored value. -/
 /-! ## Byte-level write footprints
 
 A write only touches the bytes inside its footprint. These are the
-building blocks for the word-level disjointness lemmas below, and are
-occasionally useful on their own when a proof descends to `Mem.bytes`. -/
+building blocks for the word-level disjointness lemmas below (and for the
+store-commutation lemmas in `CodeLib.RustStd.Region`), and are
+occasionally useful on their own when a proof descends to `Mem.bytes`.
+
+Per width there are two facts: outside its footprint a store leaves the
+byte unchanged (`write*_bytes_of_disjoint`), and inside its footprint the
+byte depends only on the address and value, not the underlying memory
+(`write*_bytes_in`). Together with `Mem.ext_bytes` and page preservation,
+these are exactly the ingredients `Mem.write_write_comm_of_footprints`
+needs, so adding a new width to the commutation family costs only the two
+byte lemmas. -/
+
+/-- Two memories with equal page counts and pointwise-equal bytes are equal. -/
+theorem Mem.ext_bytes {m₁ m₂ : Mem} (hp : m₁.pages = m₂.pages)
+    (hb : ∀ i, m₁.bytes i = m₂.bytes i) : m₁ = m₂ := by
+  cases m₁; cases m₂
+  simp only [Mem.mk.injEq]
+  exact ⟨hp, funext hb⟩
 
 /-- A byte outside the 8-byte footprint of a `write64` is unchanged. -/
 theorem Mem.write64_bytes_of_disjoint (m : Mem) (a : UInt32) (v : UInt64) (i : Nat)
@@ -93,6 +109,48 @@ theorem Mem.write32_bytes_of_disjoint (m : Mem) (a v : UInt32) (i : Nat)
   have h2 : i ≠ a.toNat + 2 := by omega
   have h3 : i ≠ a.toNat + 3 := by omega
   simp [h0, h1, h2, h3]
+
+/-- Inside its 8-byte footprint, the byte written by a `write64` depends only
+on the address and value, not on the underlying memory. -/
+theorem Mem.write64_bytes_in (m m' : Mem) (a : UInt32) (v : UInt64) (i : Nat)
+    (hi : a.toNat ≤ i ∧ i < a.toNat + 8) :
+    (m.write64 a v).bytes i = (m'.write64 a v).bytes i := by
+  simp only [Mem.write64]
+  split_ifs <;> first | rfl | omega
+
+/-- Inside its 4-byte footprint, the byte written by a `write32` depends only
+on the address and value, not on the underlying memory. -/
+theorem Mem.write32_bytes_in (m m' : Mem) (a v : UInt32) (i : Nat)
+    (hi : a.toNat ≤ i ∧ i < a.toNat + 4) :
+    (m.write32 a v).bytes i = (m'.write32 a v).bytes i := by
+  simp only [Mem.write32]
+  split_ifs <;> first | rfl | omega
+
+/-- Skeleton for "disjoint stores commute", abstracted over the two stores.
+`f` writes an `na`-byte footprint at `a`, `g` an `nb`-byte footprint at `b`;
+each is described by page preservation plus its two byte-level facts
+(unchanged outside the footprint, memory-independent inside it). Every
+concrete width pair instantiates this with its `write*_bytes_of_disjoint` /
+`write*_bytes_in` lemmas — see `CodeLib.RustStd.Region`. -/
+theorem Mem.write_write_comm_of_footprints
+    (f g : Mem → Mem) (a b : UInt32) (na nb : Nat)
+    (hd : a.toNat + na ≤ b.toNat ∨ b.toNat + nb ≤ a.toNat)
+    (hfp : ∀ m, (f m).pages = m.pages)
+    (hgp : ∀ m, (g m).pages = m.pages)
+    (hfo : ∀ m i, (i < a.toNat ∨ a.toNat + na ≤ i) → (f m).bytes i = m.bytes i)
+    (hgo : ∀ m i, (i < b.toNat ∨ b.toNat + nb ≤ i) → (g m).bytes i = m.bytes i)
+    (hfi : ∀ m m' i, (a.toNat ≤ i ∧ i < a.toNat + na) → (f m).bytes i = (f m').bytes i)
+    (hgi : ∀ m m' i, (b.toNat ≤ i ∧ i < b.toNat + nb) → (g m).bytes i = (g m').bytes i)
+    (m : Mem) : g (f m) = f (g m) := by
+  refine Mem.ext_bytes (by rw [hgp, hfp, hfp, hgp]) fun i => ?_
+  by_cases hia : a.toNat ≤ i ∧ i < a.toNat + na
+  · rw [hgo (f m) i (by omega)]
+    exact hfi m (g m) i hia
+  · by_cases hib : b.toNat ≤ i ∧ i < b.toNat + nb
+    · rw [hfo (g m) i (by omega)]
+      exact hgi (f m) m i hib
+    · rw [hgo (f m) i (by omega), hfo m i (by omega),
+          hfo (g m) i (by omega), hgo m i (by omega)]
 
 /-! ## Disjoint read/write framing
 

--- a/codelib/CodeLib/RustStd/Region.lean
+++ b/codelib/CodeLib/RustStd/Region.lean
@@ -14,10 +14,13 @@ framing lemmas in `CodeLib.RustStd.Frame`.
   and symbolic array addresses alike.
 * Bridges from `Disjoint` facts to the `Frame` read/write lemmas
   (`Mem.read64_write64_of_region`, …): thin one-liners, so proofs can carry a
-  single region fact instead of re-shaping `Or`s at every call site.
+  single region fact instead of re-shaping `Or`s at every call site. All four
+  take the **written region first**; flip with `Disjoint.symm` if a fact
+  arrives in the other orientation.
 * **Disjoint stores commute** (`Mem.write64_write64_comm`, 32/32 and mixed
-  widths): requested in #68 and previously missing everywhere. Proved
-  byte-pointwise from the function-model `Mem`.
+  widths): requested in #68 and previously missing everywhere. Each width pair
+  is a one-line instance of `Mem.write_write_comm_of_footprints` (Frame), so a
+  new width costs only its two byte-level footprint lemmas there.
 * `slot64` — the `k`-th 8-byte element slot of a `u64` array region, with the
   no-wrap and pairwise-disjointness lemmas array proofs otherwise re-derive
   (first consumer: `Project.SwapElements.Spec`).
@@ -36,7 +39,12 @@ deriving Repr, DecidableEq
 
 namespace MemRegion
 
-/-- Two regions occupy disjoint integer byte ranges. -/
+/-- Ordered interval disjointness: one region's byte range ends at or before
+the other's begins. For non-empty regions this coincides with set-disjointness
+of the byte ranges; a zero-length region strictly *inside* another counts as
+overlapping here even though it occupies no bytes. That strictness is
+deliberate — it keeps the shape a plain two-case `omega` fact, and every
+consumer instantiates a positive `len` (4 or 8). -/
 def Disjoint (r₁ r₂ : MemRegion) : Prop :=
   r₁.base.toNat + r₁.len ≤ r₂.base.toNat ∨ r₂.base.toNat + r₂.len ≤ r₁.base.toNat
 
@@ -50,14 +58,16 @@ end MemRegion
 
 /-! ## Bridging `Disjoint` to the `Frame` read/write lemmas
 
-The `Frame` lemmas take the raw interval disjunction with the *write* address
-on the left; these wrappers take a `Disjoint` fact between the written region
-and the read region, in either order. -/
+The `Frame` lemmas each take a raw interval disjunction whose orientation is
+an artifact of their statements; these wrappers hide that behind one uniform
+convention: the `Disjoint` fact always names the **written** region first and
+the read region second. A fact oriented the other way flips with
+`Disjoint.symm`. -/
 
 theorem Mem.read64_write64_of_region (m : Mem) (a b : UInt32) (v : UInt64)
     (h : MemRegion.Disjoint ⟨a, 8⟩ ⟨b, 8⟩) :
     (m.write64 a v).read64 b = m.read64 b :=
-  Mem.read64_write64_disjoint m a b v (h.elim Or.inr Or.inl)
+  Mem.read64_write64_disjoint m a b v h.symm
 
 theorem Mem.read64_write32_of_region (m : Mem) (a b : UInt32) (v : UInt32)
     (h : MemRegion.Disjoint ⟨b, 4⟩ ⟨a, 8⟩) :
@@ -67,88 +77,50 @@ theorem Mem.read64_write32_of_region (m : Mem) (a b : UInt32) (v : UInt32)
 theorem Mem.read32_write32_of_region (m : Mem) (a b v : UInt32)
     (h : MemRegion.Disjoint ⟨a, 4⟩ ⟨b, 4⟩) :
     (m.write32 a v).read32 b = m.read32 b :=
-  Mem.read32_write32_disjoint m a b v (h.elim Or.inr Or.inl)
+  Mem.read32_write32_disjoint m a b v h.symm
 
 theorem Mem.read32_write64_of_region (m : Mem) (a b : UInt32) (v : UInt64)
-    (h : MemRegion.Disjoint ⟨a, 4⟩ ⟨b, 8⟩) :
+    (h : MemRegion.Disjoint ⟨b, 8⟩ ⟨a, 4⟩) :
     (m.write64 b v).read32 a = m.read32 a :=
-  Mem.read32_write64_disjoint m a b v h
+  Mem.read32_write64_disjoint m a b v h.symm
 
-/-! ## Disjoint stores commute -/
+/-! ## Disjoint stores commute
 
-/-- Two memories with equal page counts and pointwise-equal bytes are equal. -/
-theorem Mem.ext_bytes {m₁ m₂ : Mem} (hp : m₁.pages = m₂.pages)
-    (hb : ∀ i, m₁.bytes i = m₂.bytes i) : m₁ = m₂ := by
-  cases m₁; cases m₂
-  simp only [Mem.mk.injEq]
-  exact ⟨hp, funext hb⟩
-
-/-- Inside its 8-byte footprint, the byte written by a `write64` depends only
-on the address and value, not on the underlying memory. -/
-theorem Mem.write64_bytes_in (m m' : Mem) (a : UInt32) (v : UInt64) (i : Nat)
-    (hi : a.toNat ≤ i ∧ i < a.toNat + 8) :
-    (m.write64 a v).bytes i = (m'.write64 a v).bytes i := by
-  simp only [Mem.write64]
-  split_ifs <;> first | rfl | omega
-
-/-- Inside its 4-byte footprint, the byte written by a `write32` depends only
-on the address and value, not on the underlying memory. -/
-theorem Mem.write32_bytes_in (m m' : Mem) (a v : UInt32) (i : Nat)
-    (hi : a.toNat ≤ i ∧ i < a.toNat + 4) :
-    (m.write32 a v).bytes i = (m'.write32 a v).bytes i := by
-  simp only [Mem.write32]
-  split_ifs <;> first | rfl | omega
+One-line instances of `Mem.write_write_comm_of_footprints` (Frame): each
+width supplies page preservation plus its two byte-level footprint facts. -/
 
 /-- Two 64-bit stores to disjoint ranges commute. -/
 theorem Mem.write64_write64_comm (m : Mem) (a b : UInt32) (v w : UInt64)
     (h : MemRegion.Disjoint ⟨a, 8⟩ ⟨b, 8⟩) :
-    (m.write64 a v).write64 b w = (m.write64 b w).write64 a v := by
-  have hd : a.toNat + 8 ≤ b.toNat ∨ b.toNat + 8 ≤ a.toNat := h
-  refine Mem.ext_bytes (by simp) fun i => ?_
-  by_cases hia : a.toNat ≤ i ∧ i < a.toNat + 8
-  · rw [Mem.write64_bytes_of_disjoint _ b w i (by omega)]
-    exact Mem.write64_bytes_in m (m.write64 b w) a v i hia
-  · by_cases hib : b.toNat ≤ i ∧ i < b.toNat + 8
-    · rw [Mem.write64_bytes_of_disjoint (m.write64 b w) a v i (by omega)]
-      exact Mem.write64_bytes_in (m.write64 a v) m b w i hib
-    · rw [Mem.write64_bytes_of_disjoint _ b w i (by omega),
-          Mem.write64_bytes_of_disjoint _ a v i (by omega),
-          Mem.write64_bytes_of_disjoint _ a v i (by omega),
-          Mem.write64_bytes_of_disjoint _ b w i (by omega)]
+    (m.write64 a v).write64 b w = (m.write64 b w).write64 a v :=
+  Mem.write_write_comm_of_footprints (·.write64 a v) (·.write64 b w) a b 8 8 h
+    (fun _ => rfl) (fun _ => rfl)
+    (fun m i hi => Mem.write64_bytes_of_disjoint m a v i hi)
+    (fun m i hi => Mem.write64_bytes_of_disjoint m b w i hi)
+    (fun m m' i hi => Mem.write64_bytes_in m m' a v i hi)
+    (fun m m' i hi => Mem.write64_bytes_in m m' b w i hi) m
 
 /-- Two 32-bit stores to disjoint ranges commute. -/
 theorem Mem.write32_write32_comm (m : Mem) (a b : UInt32) (v w : UInt32)
     (h : MemRegion.Disjoint ⟨a, 4⟩ ⟨b, 4⟩) :
-    (m.write32 a v).write32 b w = (m.write32 b w).write32 a v := by
-  have hd : a.toNat + 4 ≤ b.toNat ∨ b.toNat + 4 ≤ a.toNat := h
-  refine Mem.ext_bytes (by simp) fun i => ?_
-  by_cases hia : a.toNat ≤ i ∧ i < a.toNat + 4
-  · rw [Mem.write32_bytes_of_disjoint _ b w i (by omega)]
-    exact Mem.write32_bytes_in m (m.write32 b w) a v i hia
-  · by_cases hib : b.toNat ≤ i ∧ i < b.toNat + 4
-    · rw [Mem.write32_bytes_of_disjoint (m.write32 b w) a v i (by omega)]
-      exact Mem.write32_bytes_in (m.write32 a v) m b w i hib
-    · rw [Mem.write32_bytes_of_disjoint _ b w i (by omega),
-          Mem.write32_bytes_of_disjoint _ a v i (by omega),
-          Mem.write32_bytes_of_disjoint _ a v i (by omega),
-          Mem.write32_bytes_of_disjoint _ b w i (by omega)]
+    (m.write32 a v).write32 b w = (m.write32 b w).write32 a v :=
+  Mem.write_write_comm_of_footprints (·.write32 a v) (·.write32 b w) a b 4 4 h
+    (fun _ => rfl) (fun _ => rfl)
+    (fun m i hi => Mem.write32_bytes_of_disjoint m a v i hi)
+    (fun m i hi => Mem.write32_bytes_of_disjoint m b w i hi)
+    (fun m m' i hi => Mem.write32_bytes_in m m' a v i hi)
+    (fun m m' i hi => Mem.write32_bytes_in m m' b w i hi) m
 
 /-- A 64-bit store and a 32-bit store to disjoint ranges commute. -/
 theorem Mem.write64_write32_comm (m : Mem) (a b : UInt32) (v : UInt64) (w : UInt32)
     (h : MemRegion.Disjoint ⟨a, 8⟩ ⟨b, 4⟩) :
-    (m.write64 a v).write32 b w = (m.write32 b w).write64 a v := by
-  have hd : a.toNat + 8 ≤ b.toNat ∨ b.toNat + 4 ≤ a.toNat := h
-  refine Mem.ext_bytes (by simp) fun i => ?_
-  by_cases hia : a.toNat ≤ i ∧ i < a.toNat + 8
-  · rw [Mem.write32_bytes_of_disjoint _ b w i (by omega)]
-    exact Mem.write64_bytes_in m (m.write32 b w) a v i hia
-  · by_cases hib : b.toNat ≤ i ∧ i < b.toNat + 4
-    · rw [Mem.write64_bytes_of_disjoint (m.write32 b w) a v i (by omega)]
-      exact Mem.write32_bytes_in (m.write64 a v) m b w i hib
-    · rw [Mem.write32_bytes_of_disjoint _ b w i (by omega),
-          Mem.write64_bytes_of_disjoint _ a v i (by omega),
-          Mem.write64_bytes_of_disjoint _ a v i (by omega),
-          Mem.write32_bytes_of_disjoint _ b w i (by omega)]
+    (m.write64 a v).write32 b w = (m.write32 b w).write64 a v :=
+  Mem.write_write_comm_of_footprints (·.write64 a v) (·.write32 b w) a b 8 4 h
+    (fun _ => rfl) (fun _ => rfl)
+    (fun m i hi => Mem.write64_bytes_of_disjoint m a v i hi)
+    (fun m i hi => Mem.write32_bytes_of_disjoint m b w i hi)
+    (fun m m' i hi => Mem.write64_bytes_in m m' a v i hi)
+    (fun m m' i hi => Mem.write32_bytes_in m m' b w i hi) m
 
 /-! ## Array element slots -/
 
@@ -160,13 +132,15 @@ array specs. -/
 def slot64 (base k : UInt32) : MemRegion := ⟨base + 8 * k, 8⟩
 
 /-- `x <<< 3 = 8 * x` on `UInt32`: bridges the `(const 3) shl` address
-computation LLVM emits to the `8 * k` slot offset. -/
+computation LLVM emits to the `8 * k` slot offset. The single `bv_decide`
+fact of the slot algebra — `slot64_of_shl` derives from it. -/
 theorem shl3_eq_mul8 (x : UInt32) : x <<< (3 % 32 : UInt32) = 8 * x := by bv_decide
 
 /-- The codegen's `(k <<< 3) + base` lands on the slot base address. -/
 theorem slot64_of_shl (base k : UInt32) :
     k <<< (3 % 32 : UInt32) + base = (slot64 base k).base := by
-  simp only [slot64]; bv_decide
+  simp only [slot64]
+  rw [shl3_eq_mul8, UInt32.add_comm]
 
 /-- No wraparound: if the slot's true byte offset stays below `2^32`, the wasm
 address of `slot64 base k` is the integer `base.toNat + 8 * k.toNat`. -/


### PR DESCRIPTION
## Overview

A post-merge review of #138 surfaced seven findings — no soundness issues (all proofs were correct), but several API-consistency, documentation, and structure problems in the new `Region.lean`. This PR addresses all of them. Rebased on current `main` (post-#139/#142).

## Changes

### Bridge lemmas (`Mem.*_of_region`)
- **Uniform orientation.** Three of the four bridges took the *written* region as the first `Disjoint` argument; `read32_write64_of_region` alone took the *read* region first, while the section docstring claimed callers could pass the fact "in either order" (false — `Disjoint` is not definitionally symmetric). All four now take the **written region first**, and the docstring states that convention explicitly. `read32_write64_of_region`'s hypothesis flips from `Disjoint ⟨a,4⟩ ⟨b,8⟩` to `Disjoint ⟨b,8⟩ ⟨a,4⟩`; grep confirmed zero external consumers, so this is non-breaking.
- **Corrected docstring.** The old section header also claimed the Frame lemmas take the disjunction "with the write address on the left" — actually false for three of the four (their orientations are historical artifacts). The docstring now says exactly that, instead of describing a uniformity that isn't there.
- Bridges that need to flip now use `Disjoint.symm` instead of inlining its body `(h.elim Or.inr Or.inl)` — the helper finally has consumers.

### Store commutation
- The three commutation proofs were token-identical 12-line case analyses differing only in width constants. They are now one-line instances of a new generic skeleton **`Mem.write_write_comm_of_footprints`** (in `Frame.lean`), parameterized by the two footprints and each store's byte-level facts. Since `Mem.write8`/`write16` already exist (store8/store16 are wired into the interpreter and WP layer), the width family will grow — each new pair now costs only its two byte lemmas, not another proof clone.

### Placement
- The general byte-level foundations — `Mem.ext_bytes`, `Mem.write64_bytes_in`, `Mem.write32_bytes_in` — moved from `Region.lean` to `Frame.lean`'s byte-footprint section, next to their `_bytes_of_disjoint` siblings. They are pure `Mem` facts with nothing region-specific, and `Frame` couldn't have used them where they were without an import cycle. Fully-qualified names are unchanged, so the move is non-breaking.

### Single `bv_decide` in the slot algebra
- `slot64_of_shl` is now derived from `shl3_eq_mul8` (`rw [shl3_eq_mul8, UInt32.add_comm]`) instead of running its own independent `bv_decide`, halving the SAT calls per build, in line with the one-`bv_decide`-per-fact convention documented in `U64/Shl.lean`. The review originally flagged `shl3_eq_mul8` as dead code, but #139's `MemFillLoop` (merged after the review branch was cut) now consumes it, so it stays — the first CI run caught exactly this.

### Documentation
- `MemRegion.Disjoint`'s docstring now states its actual semantics: *ordered interval disjointness*, which for zero-length regions is strictly stronger than set-disjointness (an empty region strictly inside another does not count as disjoint), and why that strictness is deliberate.

## Not addressed (deliberately)
One review suggestion — tagging `slot64_of_shl` `@[simp]` — was **refuted** during verification: Frame's simp policy is scoped to the `_same`/`_pages` families, and the lemma's LHS contains the literal `(3 % 32 : UInt32)`, which simp's own literal normalization can rewrite before the lemma matches, making it a fragile global rewrite.

## Verification
- `lake build` green in `codelib/` and `programs/lean/` on the rebased branch (including `MemFillLoop` and the #139 `words64` files).
- `SwapElementsSpec` statement unchanged; `Project.SwapElements.Spec` rebuilds cleanly against the reshaped lemmas.

Refs #68, follow-up to #138.

---

*Disclosure per CONTRIBUTING: AI tooling (Claude Code) was used to write and check these changes.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)