### PR TITLE
interpreter: iso-recursive type equivalence; ref.test/cast against concrete function types

### DIFF
--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -441,6 +441,10 @@ private structure TypeEntry where
   fieldNames : List (Option String) := []
   /-- `false` when declared `(sub …)` without `final` (open for subtyping). -/
   isFinal : Bool := true
+  /-- Recursion-group marker for members of a multi-member `(rec …)` group
+  (the group's first type index); `none` for singleton groups. Threaded
+  into `GcTypeDef.recGroup` for iso-recursive type equivalence. -/
+  recGroup : Option Nat := none
 deriving Inhabited
 
 structure Ctx where
@@ -1798,15 +1802,21 @@ private structure FuncDecl where
   inlineExports : List String
   func          : Wasm.Function
 
-private def resolveTypeRef (types : Array TypeEntry) (s : String)
-    : Except Err (List Wasm.ValueType × List Wasm.ValueType) := do
-  let idx ← if s.startsWith "$" then
+/-- Resolve a `(type N)` / `(type $sig)` reference to its type-table
+index. -/
+private def resolveTypeIdxRef (types : Array TypeEntry) (s : String)
+    : Except Err Nat :=
+  if s.startsWith "$" then
     let name := (s.drop 1).toString
     match types.findIdx? (fun t => t.symId = some name) with
     | some i => .ok i
     | none => .error s!"unknown type id: {s}"
   else
     parseNat s
+
+private def resolveTypeRef (types : Array TypeEntry) (s : String)
+    : Except Err (List Wasm.ValueType × List Wasm.ValueType) := do
+  let idx ← resolveTypeIdxRef types s
   match types[idx]? with
   | some { sig := some sig, .. } => .ok sig
   | some { sig := none, .. } =>
@@ -1998,6 +2008,11 @@ private def parseFunc (funcIds : Std.HashMap String Nat)
   let mut inlineExports : List String := []
   let mut localIds : Std.HashMap String Nat := {}
   let mut typeApplied : Bool := false
+  -- Declared `(type N)` index, recorded on the function so the runtime
+  -- nominal type checks (`(return_)call_indirect`, `ref.test`/`ref.cast`
+  -- against a concrete function type) can consult the `rec`/`sub`
+  -- hierarchy (issues #95/#96).
+  let mut declaredTypeIdx : Option Nat := none
   let mut rest := xs
   match rest with
   | .atom a :: r =>
@@ -2083,6 +2098,7 @@ private def parseFunc (funcIds : Std.HashMap String Nat)
           paramTypes := ps
           resultTypes := rs
           typeApplied := true
+          declaredTypeIdx := some (← resolveTypeIdxRef types ref)
         | _ => throw "malformed (type ...) reference"
         rest := r
       | "export" =>
@@ -2109,6 +2125,7 @@ private def parseFunc (funcIds : Std.HashMap String Nat)
              locals  := localTypes
              body    := instrs
              results := resultTypes
+             typeIdx := declaredTypeIdx
            } }
 
 private def resolveFuncRef (idOf : Std.HashMap String Nat) (s : String)
@@ -2846,10 +2863,19 @@ def parseModule (xs : List Sexpr) : Except Err Wasm.Module := do
       types := types.push (parseTypeField body)
     -- Recursive type groups (`(rec (type …) …)`, GC proposal): the inner
     -- types occupy consecutive indices, flattened into the table here.
+    -- Multi-member groups are tagged with a shared recursion-group marker
+    -- (the first member's index) so iso-recursive type equivalence can
+    -- compare whole groups; singleton groups stay untagged.
     | .list (.atom "rec" :: inner) =>
+      let groupStart := types.size
+      let groupSize := inner.countP fun
+        | .list (.atom "type" :: _) => true
+        | _ => false
+      let marker := if groupSize > 1 then some groupStart else none
       for t in inner do
         match t with
-        | .list (.atom "type" :: body) => types := types.push (parseTypeField body)
+        | .list (.atom "type" :: body) =>
+          types := types.push { parseTypeField body with recGroup := marker }
         | _ => pure ()
     | _ => pure ()
   let (imports, importFuncIds) ← collectImports types rest
@@ -3006,7 +3032,8 @@ def parseModule (xs : List Sexpr) : Except Err Wasm.Module := do
       | none   => match te.sig with
         | some (ps, rs) => .func { params := ps, results := rs }
         | none          => .func {}
-    { comp, super := te.superRef.bind resolveSuper, «final» := te.isFinal }
+    { comp, super := te.superRef.bind resolveSuper, «final» := te.isFinal,
+      recGroup := te.recGroup }
   return { funcs    := decls.toList.map (·.func)
            exports  := exports.toList
            globals  := globImps.map (·.2) ++ globalDecls.toList

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -34,6 +34,7 @@ import Interpreter.Wasm.Examples.Gcd
 import Interpreter.Wasm.Examples.SelectAbs
 import Interpreter.Wasm.Examples.GlobalInitExpr
 import Interpreter.Wasm.Examples.CallIndirectSubtype
+import Interpreter.Wasm.Examples.RefCastFuncType
 
 /-! # Wasm.Examples.Basic
 

--- a/interpreter/Interpreter/Wasm/Examples/RefCastFuncType.lean
+++ b/interpreter/Interpreter/Wasm/Examples/RefCastFuncType.lean
@@ -1,0 +1,229 @@
+import Interpreter.Wasm.Examples.Harness
+
+/-! ## Example: `ref.test`/`ref.cast` against concrete (function) types
+
+    Issue #96: `ref.test`/`ref.cast` against a *concrete* function type
+    always failed — a non-null funcref only matched the abstract `func`
+    heap type — so "downcast a funcref, then `call_ref` it" trapped where
+    wasmtime/V8 succeed. The issue's follow-up comments add the struct
+    counterpart: two *separately declared but structurally identical*
+    types must be one type (the spec compares defined types up to
+    iso-recursive equivalence), yet `gcTypeSubtype` only walked the
+    declared `sub $super` chain by literal index, so `ref.test (ref $b)`
+    of a `struct.new $a` twin returned `0`.
+
+    The fix (this PR):
+
+    * `Module.gcTypeEquiv` — iso-recursive equivalence of type indices,
+      comparing whole recursion groups (composite types, finality, and
+      `sub` edges, with in-group supers compared by relative position);
+    * `Module.gcTypeSubtype` now tests each type on the `sub $super`
+      chain for *equivalence* with the target instead of index equality;
+    * the funcref arm of `gcRefMatches` handles `.concrete t` by checking
+      the function's declared type (`funcTypeIdx?`) against `t` with
+      `gcTypeSubtype` (falling back to the structural signature when the
+      declared type is unrecorded), and a null funcref matches every
+      *nullable* concrete function type;
+    * the WAT decoder records each function's declared `(type N)` in
+      `Function.typeIdx` and tags multi-member `(rec …)` groups so the
+      equivalence can see recursion-group boundaries.
+
+    The theorems below pin all of it down with `native_decide`, both on
+    hand-built modules and end-to-end through the decoder on the issue's
+    exact WAT. -/
+
+namespace Wasm
+
+open Wasm.Examples
+
+namespace RefCastFuncType
+
+/-! ### Hand-built module: concrete function types
+
+    Type table: index 0 = `$ft` (open for subtyping), index 1 = a
+    structurally identical twin of `$ft`, index 2 = `$sub` declaring
+    `$ft` as its supertype. Function 0 (`impl : $ft`) is `x ↦ x + 1`;
+    function 1 (`subImpl : $sub`) likewise. -/
+
+def Impl : Program := [.localGet 0, .const 1, .add]
+
+/-- `ref.test (ref $ft) (ref.func $impl)` — the issue's first module. -/
+def TestSame : Program := [.refFunc 0, .gc (.refTest false (.concrete 0))]
+
+/-- `ref.test` against the structurally identical *twin* declaration. -/
+def TestTwin : Program := [.refFunc 0, .gc (.refTest false (.concrete 1))]
+
+/-- `ref.test (ref $ft)` of a funcref whose type is `$sub <: $ft`. -/
+def TestSub : Program := [.refFunc 1, .gc (.refTest false (.concrete 0))]
+
+/-- `ref.test (ref $sub)` of a funcref of the *supertype* `$ft` — the one
+direction that must still fail. -/
+def TestSuper : Program := [.refFunc 0, .gc (.refTest false (.concrete 2))]
+
+/-- The issue's second module: `(call_ref $ft (i32.const 5)
+(ref.cast (ref $ft) (ref.func $impl)))`. -/
+def CastCall : Program :=
+  [.const 5, .refFunc 0, .gc (.refCast false (.concrete 0)), .callRef 0]
+
+/-- `ref.cast (ref $sub)` of a funcref of the supertype `$ft` — traps. -/
+def CastSuper : Program := [.refFunc 0, .gc (.refCast false (.concrete 2))]
+
+/-- Null funcref against a nullable / non-nullable concrete func type. -/
+def TestNullOk  : Program := [.refNull, .gc (.refTest true  (.concrete 0))]
+def TestNullNot : Program := [.refNull, .gc (.refTest false (.concrete 0))]
+
+def m : Module :=
+  { types   := [{ params := [.i32], results := [.i32] },
+                { params := [.i32], results := [.i32] },
+                { params := [.i32], results := [.i32] }]
+    gcTypes := [{ comp := .func { params := [.i32], results := [.i32] }, «final» := false },  -- 0: $ft
+                { comp := .func { params := [.i32], results := [.i32] }, «final» := false },  -- 1: twin of $ft
+                { comp := .func { params := [.i32], results := [.i32] }, super := some 0 }]   -- 2: $sub <: $ft
+    funcs   := [{ params := [.i32], body := Impl, results := [.i32], typeIdx := some 0 },  -- 0: impl : $ft
+                { params := [.i32], body := Impl, results := [.i32], typeIdx := some 2 },  -- 1: subImpl : $sub
+                { body := TestSame,    results := [.i32] },   -- 2
+                { body := TestTwin,    results := [.i32] },   -- 3
+                { body := TestSub,     results := [.i32] },   -- 4
+                { body := TestSuper,   results := [.i32] },   -- 5
+                { body := CastCall,    results := [.i32] },   -- 6
+                { body := CastSuper,   results := [.funcref] },  -- 7
+                { body := TestNullOk,  results := [.i32] },   -- 8
+                { body := TestNullNot, results := [.i32] }] } -- 9
+
+/-- The twin declarations of `$ft` are one defined type. -/
+theorem twin_equiv : m.gcTypeEquiv 0 1 = true := by native_decide
+
+/-- Equivalence sees through the `sub` chain too: `$sub <: twin-of-$ft`. -/
+theorem sub_subtype_twin : m.gcTypeSubtype 2 1 = true := by native_decide
+
+/-- …but a supertype is still not a subtype of its subtype. -/
+theorem super_not_subtype_sub : m.gcTypeSubtype 0 2 = false := by native_decide
+
+/-- `ref.test (ref $ft) (ref.func $impl)` is `1` (the issue's first
+module; previously `0`). -/
+theorem test_same :
+    runValues 20 m 2 (m.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+/-- The structurally identical twin target also tests `1`. -/
+theorem test_twin :
+    runValues 20 m 3 (m.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+/-- A funcref of type `$sub` tests `1` against the supertype `$ft`. -/
+theorem test_sub :
+    runValues 20 m 4 (m.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+/-- A funcref of type `$ft` tests `0` against the subtype `$sub`. -/
+theorem test_super :
+    runValues 20 m 5 (m.initialStore (α := Unit)) [] = [.i32 0] := by native_decide
+
+/-- The issue's second module: cast-then-`call_ref` returns `5 + 1 = 6`
+(previously trapped with a cast failure). -/
+theorem cast_call :
+    runValues 20 m 6 (m.initialStore (α := Unit)) [] = [.i32 6] := by native_decide
+
+/-- Casting a `$ft` funcref *down* to `$sub` still traps. -/
+theorem cast_super_traps :
+    runTrapMsg 20 m 7 (m.initialStore (α := Unit)) [] = some "cast failure" := by
+  native_decide
+
+/-- The null funcref inhabits the nullable concrete type `(ref null $ft)`… -/
+theorem test_null_nullable :
+    runValues 20 m 8 (m.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+/-- …but not the non-nullable `(ref $ft)`. -/
+theorem test_null_nonnullable :
+    runValues 20 m 9 (m.initialStore (α := Unit)) [] = [.i32 0] := by native_decide
+
+/-! ### Hand-built module: struct twins and recursion groups -/
+
+/-- `ref.test (ref $b) (struct.new $a (i32.const 7))` with `$a`/`$b`
+separately declared but structurally identical. -/
+def StructTwin : Program :=
+  [.const 7, .gc (.structNew 0), .gc (.refTest false (.concrete 1))]
+
+/-- Same test against a struct type with a *different* field type — must
+stay `0`. -/
+def StructOther : Program :=
+  [.const 7, .gc (.structNew 0), .gc (.refTest false (.concrete 2))]
+
+def structM : Module :=
+  { gcTypes := [{ comp := .struct [{ storage := .val .i32 }] },              -- 0: $a
+                { comp := .struct [{ storage := .val .i32 }] },              -- 1: $b, twin of $a
+                { comp := .struct [{ storage := .val .i64 }] },              -- 2: different shape
+                -- 3–4: a two-member `(rec …)` group of the same shape as 0
+                { comp := .struct [{ storage := .val .i32 }], recGroup := some 3 },
+                { comp := .struct [{ storage := .val .i32 }], recGroup := some 3 }]
+    funcs   := [{ body := StructTwin,  results := [.i32] },   -- 0
+                { body := StructOther, results := [.i32] }] } -- 1
+
+/-- The comment's struct-twin case: a `$a` value tests `1` against `$b`. -/
+theorem struct_twin :
+    runValues 20 structM 0 (structM.initialStore (α := Unit)) [] = [.i32 1] := by
+  native_decide
+
+/-- A structurally *different* struct type still tests `0`. -/
+theorem struct_other :
+    runValues 20 structM 1 (structM.initialStore (α := Unit)) [] = [.i32 0] := by
+  native_decide
+
+/-- Iso-recursive equivalence respects recursion-group boundaries: a
+member of a two-member `(rec …)` group is *not* equivalent to the same
+shape declared as a singleton group. -/
+theorem rec_group_not_equiv : structM.gcTypeEquiv 0 3 = false := by native_decide
+
+/-- Distinct members of one recursion group stay distinct types even when
+they share a shape, while separately declared singleton groups of the same
+shape are one type. -/
+theorem rec_group_members_distinct : structM.gcTypeEquiv 3 4 = false ∧
+    structM.gcTypeEquiv 0 1 = true := by native_decide
+
+/-! ### End-to-end through the decoder, on the issue's exact WAT -/
+
+def refTestWat : String :=
+  "(module
+     (type $ft (func (param i32) (result i32)))
+     (func $impl (type $ft) (local.get 0))
+     (elem declare func $impl)
+     (func (export \"f\") (result i32)
+       (ref.test (ref $ft) (ref.func $impl))))"
+
+def castCallWat : String :=
+  "(module
+     (type $ft (func (param i32) (result i32)))
+     (func $impl (type $ft) (i32.add (local.get 0) (i32.const 1)))
+     (elem declare func $impl)
+     (func (export \"f\") (result i32)
+       (call_ref $ft (i32.const 5) (ref.cast (ref $ft) (ref.func $impl)))))"
+
+def structTwinWat : String :=
+  "(module
+     (type $a (struct (field i32)))
+     (type $b (struct (field i32)))
+     (func (export \"f\") (result i32)
+       (ref.test (ref $b) (struct.new $a (i32.const 7)))))"
+
+private def refTestM    : Module := decodeOrDefault refTestWat
+private def castCallM   : Module := decodeOrDefault castCallWat
+private def structTwinM : Module := decodeOrDefault structTwinWat
+
+/-- The decoder records `$impl`'s declared `(type $ft)`. -/
+theorem decoded_typeIdx : refTestM.funcs.map (·.typeIdx) = [some 0, none] := by
+  native_decide
+
+/-- wasmtime/V8 return `1`; Talos previously returned `0`. -/
+theorem decoded_ref_test :
+    runValues 20 refTestM ((refTestM.findExport "f").getD 99)
+      (refTestM.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+/-- wasmtime/V8 return `6`; Talos previously trapped on the cast. -/
+theorem decoded_cast_call :
+    runValues 20 castCallM ((castCallM.findExport "f").getD 99)
+      (castCallM.initialStore (α := Unit)) [] = [.i32 6] := by native_decide
+
+/-- The comment's struct-twin module returns `1` end-to-end. -/
+theorem decoded_struct_twin :
+    runValues 20 structTwinM ((structTwinM.findExport "f").getD 99)
+      (structTwinM.initialStore (α := Unit)) [] = [.i32 1] := by native_decide
+
+end RefCastFuncType
+end Wasm

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -75,13 +75,37 @@ def AnyRef.matchesHeap (m : Module) (st : Store α) (ht : GcHeapType) : AnyRef �
 /-- Whether reference value `v` matches the target reference type
 `(ref null?ₙ ht)` used by `ref.test`/`ref.cast`/`br_on_cast`. The null
 reference matches exactly when the target is nullable and `ht` is in the
-same (any vs func vs extern) bottom family. -/
+same (any vs func vs extern) bottom family.
+
+A non-null funcref matches the abstract `func` heap type always, and a
+concrete target `(ref $ft)` when the function's declared type is a
+subtype of `$ft` (issue #96). When the declared type is unrecorded
+(`funcTypeIdx? = none`, hand-built modules) the check degrades to
+structural equality of the function's signature against the target's
+composite type, mirroring `Module.indirectCallTypeOk`. -/
 def gcRefMatches (m : Module) (st : Store α) (nullable : Bool)
     (ht : GcHeapType) : Value → Bool
   | .anyref none      => nullable && ht.inAnyHierarchy
   | .anyref (some r)  => r.matchesHeap m st ht
-  | .funcref none     => nullable && (ht == .func || ht == .noFunc)
-  | .funcref (some _) => ht == .func
+  | .funcref none     =>
+    nullable &&
+    (ht == .func || ht == .noFunc ||
+     -- Null also inhabits every nullable *concrete* function type: the
+     -- null funcref has type `nofunc`, the bottom of the func family.
+     (match ht with
+      | .concrete t => match m.gcComposite? t with
+        | some (.func _) => true
+        | _ => false
+      | _ => false))
+  | .funcref (some f) => match ht with
+    | .func       => true
+    | .concrete t =>
+      (match m.funcTypeIdx? f with
+       | some src => m.gcTypeSubtype src t
+       | none     => match m.funcSig? f, m.gcComposite? t with
+         | some fn, some (.func ty) => fn == ty
+         | _, _ => false)
+    | _ => false
   | .externref none   => nullable && (ht == .extern || ht == .noExtern)
   | .externref (some _) => ht == .extern
   | _                 => false

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -640,7 +640,7 @@ inductive CompositeType where
   | func   (sig : FuncType)
   | struct (fields : List FieldType)
   | array  (elem : FieldType)
-deriving Repr, Inhabited
+deriving Repr, Inhabited, DecidableEq, BEq
 
 /-- One entry of the module's GC type table: the composite type plus the
 declared immediate supertype index (`sub $super …`), if any. Indexed by
@@ -652,6 +652,14 @@ structure GcTypeDef where
   without `final`). A supertype named by another type's `sub` clause must
   be non-final. -/
   «final» : Bool := true
+  /-- Recursion-group id for members of a multi-member `(rec …)` group:
+  every member carries `some g` with the same `g` (the decoder uses the
+  group's first type index). `none` means the type forms a singleton
+  recursion group — the common case, and the default for hand-built
+  modules. Iso-recursive type equivalence (`Module.gcTypeEquiv`) compares
+  whole recursion groups, so this matters exactly when a `(rec …)` has
+  more than one member. -/
+  recGroup : Option Nat := none
 deriving Repr, Inhabited
 
 /-- Declaration of a single table. The interpreter only models
@@ -936,12 +944,75 @@ def Module.funcTypeIdx? (m : Module) (i : Nat) : Option Nat :=
   | some _ => none
   | none   => (m.funcs[i - m.imports.length]?).bind (·.typeIdx)
 
-/-- Whether GC type index `a` is a (reflexive, transitive) subtype of `b`,
-following the declared `sub $super` chain. Bounded by the type-table size
-so a malformed cyclic chain still terminates. -/
+/-- The member indices of the recursion group containing GC type `x`, in
+index order. A type with `recGroup := none` (or out of range) is its own
+singleton group; members of a multi-member `(rec …)` group share a
+`recGroup := some g` marker. -/
+def Module.gcRecGroup (m : Module) (x : Nat) : List Nat :=
+  match m.gcTypes[x]? with
+  | some { recGroup := some g, .. } =>
+    (List.range m.gcTypes.length).filter fun i =>
+      match m.gcTypes[i]? with
+      | some d => d.recGroup == some g
+      | none   => false
+  | _ => [x]
+
+/-- Iso-recursive equivalence of GC type indices `a` and `b` (issue #96):
+whether they denote the *same* defined type, per the spec's canonical
+(rec-group-wise) reading, rather than merely being the same table index.
+Two separately declared but structurally identical types — e.g. twin
+`(struct (field i32))` declarations — are one type and must compare equal.
+
+Two indices are equivalent when their recursion groups have the same
+shape and they sit at the same position within them: pairwise, the
+members' composite types and finality match, and their declared
+supertypes are either the same relative member of their own group (a
+recursive reference) or, when they point outside the group, equivalent
+defined types in turn. Composite types here contain no nested type
+indices (our reduced value-type lattice collapses reference types), so
+only the `super` edges recurse; the recursion is fuel-bounded by the
+type-table size so malformed cyclic chains still terminate.
+
+Known precision limit, inherited from the value-type lattice: two types
+that differ *only* in a field's or signature's concrete reference type
+(e.g. `(struct (field (ref $f1)))` vs `(struct (field (ref $f2)))` with
+`$f1 ≢ $f2`) canonicalize to the same composite here and are
+conservatively identified as equivalent, where the spec keeps them
+apart. Distinguishing them needs concrete heap types in `ValueType`. -/
+def Module.gcTypeEquiv (m : Module) (a b : Nat) : Bool :=
+  let rec go (fuel : Nat) (a b : Nat) : Bool :=
+    a == b ||
+    (let ga := m.gcRecGroup a
+     let gb := m.gcRecGroup b
+     ga.length == gb.length &&
+     ga.idxOf a == gb.idxOf b &&
+     (ga.zip gb).all fun (x, y) =>
+       match m.gcTypes[x]?, m.gcTypes[y]? with
+       | some dx, some dy =>
+         dx.final == dy.final &&
+         dx.comp == dy.comp &&
+         (match dx.super, dy.super with
+          | none, none => true
+          | some px, some py =>
+            (match ga.idxOf? px, gb.idxOf? py with
+             | some i, some j => i == j
+             | none, none =>
+               (match fuel with
+                | 0     => false
+                | f + 1 => go f px py)
+             | _, _ => false)
+          | _, _ => false)
+       | _, _ => false)
+  go m.gcTypes.length a b
+
+/-- Whether GC type index `a` is a (reflexive, transitive) subtype of `b`:
+some type on `a`'s declared `sub $super` chain is *equivalent* to `b`
+(`gcTypeEquiv`, not index equality — a structurally identical twin
+declaration of `b` counts). Bounded by the type-table size so a malformed
+cyclic chain still terminates. -/
 def Module.gcTypeSubtype (m : Module) (a b : Nat) : Bool :=
   let rec go (fuel x : Nat) : Bool :=
-    if x == b then true
+    if m.gcTypeEquiv x b then true
     else match fuel with
       | 0      => false
       | f + 1  => match m.gcTypes[x]? with

--- a/testsuite_report.txt
+++ b/testsuite_report.txt
@@ -2106,7 +2106,7 @@ br_on_cast_fail.wast:98 assert_return pass
 br_on_cast_fail.wast:99 assert_return fail
 br_on_cast_fail.wast:104 module pass
 br_on_cast_fail.wast:220 action pass
-br_on_cast_fail.wast:221 action fail
+br_on_cast_fail.wast:221 action pass
 br_on_cast_fail.wast:226 module pass
 br_on_cast_fail.wast:241 assert_invalid skipped:assert_invalid: not rejected
 br_on_cast_fail.wast:250 assert_invalid skipped:assert_invalid: not rejected
@@ -31318,7 +31318,7 @@ ref_cast.wast:93 assert_trap pass
 ref_cast.wast:94 assert_trap pass
 ref_cast.wast:99 module pass
 ref_cast.wast:185 action pass
-ref_cast.wast:186 action fail
+ref_cast.wast:186 action pass
 ref_eq.wast:1 module pass
 ref_eq.wast:29 action pass
 ref_eq.wast:31 assert_return pass
@@ -31551,7 +31551,7 @@ ref_test.wast:176 assert_return fail
 ref_test.wast:177 assert_return pass
 ref_test.wast:182 module pass
 ref_test.wast:329 assert_return pass
-ref_test.wast:330 assert_return fail
+ref_test.wast:330 assert_return pass
 relaxed_dot_product.wast:3 module pass
 relaxed_dot_product.wast:18 assert_return pass
 relaxed_dot_product.wast:24 assert_return pass
@@ -64049,9 +64049,9 @@ type-rec.wast:157 assert_unlinkable skipped:assert_unlinkable
 type-rec.wast:167 module pass
 type-rec.wast:174 assert_return pass
 type-rec.wast:176 module pass
-type-rec.wast:183 assert_trap fail
+type-rec.wast:183 assert_trap pass
 type-rec.wast:185 module pass
-type-rec.wast:192 assert_trap fail
+type-rec.wast:192 assert_trap pass
 type-rec.wast:197 module pass
 type-rec.wast:205 assert_invalid skipped:assert_invalid: not rejected
 type-rec.wast:217 assert_invalid skipped:assert_invalid: not rejected
@@ -64088,33 +64088,33 @@ type-subtyping.wast:283 module pass
 type-subtyping.wast:336 assert_return fail
 type-subtyping.wast:337 assert_trap pass
 type-subtyping.wast:338 assert_trap pass
-type-subtyping.wast:339 assert_trap fail
+type-subtyping.wast:339 assert_trap pass
 type-subtyping.wast:340 assert_trap pass
 type-subtyping.wast:341 assert_trap pass
 type-subtyping.wast:342 assert_trap pass
 type-subtyping.wast:344 module pass
-type-subtyping.wast:368 assert_trap fail
-type-subtyping.wast:369 assert_trap fail
+type-subtyping.wast:368 assert_trap pass
+type-subtyping.wast:369 assert_trap pass
 type-subtyping.wast:370 assert_trap pass
 type-subtyping.wast:371 assert_trap pass
 type-subtyping.wast:373 module pass
 type-subtyping.wast:398 assert_return pass
-type-subtyping.wast:399 assert_trap fail
-type-subtyping.wast:400 assert_trap fail
+type-subtyping.wast:399 assert_trap pass
+type-subtyping.wast:400 assert_trap pass
 type-subtyping.wast:402 module pass
-type-subtyping.wast:412 assert_return fail
+type-subtyping.wast:412 assert_return pass
 type-subtyping.wast:414 module pass
-type-subtyping.wast:430 assert_return fail
+type-subtyping.wast:430 assert_return pass
 type-subtyping.wast:432 module pass
-type-subtyping.wast:442 assert_return pass
+type-subtyping.wast:442 assert_return fail
 type-subtyping.wast:444 module pass
-type-subtyping.wast:453 assert_return fail
+type-subtyping.wast:453 assert_return pass
 type-subtyping.wast:455 module pass
-type-subtyping.wast:473 assert_return fail
+type-subtyping.wast:473 assert_return pass
 type-subtyping.wast:476 module pass
-type-subtyping.wast:488 assert_return fail
+type-subtyping.wast:488 assert_return pass
 type-subtyping.wast:492 module pass
-type-subtyping.wast:510 assert_return fail
+type-subtyping.wast:510 assert_return pass
 type-subtyping.wast:515 module pass
 type-subtyping.wast:523 assert_return pass
 type-subtyping.wast:525 module pass


### PR DESCRIPTION
Fixes #96.

## What

Three related defects, one root (as diagnosed in the issue and its comments):

1. `ref.test`/`ref.cast`/`br_on_cast` against a **concrete function type** always failed — a non-null funcref only matched the abstract `func` heap type — so "downcast a funcref, then `call_ref` it" trapped where wasmtime/V8 succeed.
2. `Module.gcTypeSubtype` compared types by **literal table index**, so two separately declared but structurally identical types (the struct-twin cases from the follow-up comments) never compared equal, even though the spec identifies defined types up to iso-recursive equivalence.
3. The runtime had no access to a function's declared `(type N)` for decoded modules — `Function.typeIdx` existed since #103 but the WAT decoder never set it.

## How

- **`Module.gcTypeEquiv`** (new): iso-recursive equivalence of type indices, comparing whole recursion groups — pairwise composite types, finality, and `sub` edges, with in-group supertypes compared by relative member position and cross-group supertypes compared recursively (fuel-bounded by the type-table size).
- **`Module.gcTypeSubtype`** now tests each type on the declared `sub $super` chain for *equivalence* with the target instead of index equality. `AnyRef.matchesHeap` (struct/array casts) and `Module.indirectCallTypeOk` (#95) pick this up for free — the struct-twin and rec-group testsuite cases now pass.
- **`gcRefMatches` funcref arm** handles `.concrete t`: the function's declared type (`funcTypeIdx?`) must be a subtype of `t`, degrading to a structural `funcSig?` comparison when the declared type is unrecorded (hand-built modules), mirroring `indirectCallTypeOk`. A **null** funcref now also matches every *nullable* concrete function type (`nofunc` is the bottom of the func family).
- **WAT decoder**: records each function's declared `(type N)` into `Function.typeIdx`, and tags multi-member `(rec …)` groups with a shared `GcTypeDef.recGroup` marker so equivalence can see recursion-group boundaries (distinct members of one group stay distinct; separately declared singleton groups of the same shape are one type).

## Test

`Examples/RefCastFuncType.lean` pins everything with `native_decide`, both on hand-built modules and **end-to-end through the decoder on the issue's exact WAT**:

- `ref.test (ref $ft) (ref.func $impl)` = 1 (issue module 1; was 0), and the cast-then-`call_ref` module returns 6 (was a trap);
- subtyping: `$sub` funcref vs `$super` target = 1, the reverse = 0, downcast still traps;
- struct twins: `ref.test (ref $b) (struct.new $a …)` = 1 (comment's case), non-equivalent shape stays 0;
- rec groups: 2-member group member ≢ same-shape singleton; distinct members of one group ≢ each other;
- null funcref: matches `(ref null $ft)`, not `(ref $ft)`.

**Spec testsuite: 62195 → 62210 pass, 138 → 123 fail** (report regenerated). 16 fail→pass across `ref_test`, `ref_cast`, `br_on_cast_fail`, `type-rec` (now 0 fail), `type-subtyping` (12 → 2 fail); `type-equivalence`, `call_indirect`, `call_ref`, `return_call*` unchanged at 0 fail. The single pass→fail flip (`type-subtyping.wast:442`) is a documented precision limit: two rec groups differing *only* in a struct field's concrete ref type are identified, because the reduced `ValueType` lattice erases concrete heap types from composites — it previously "passed" only because every concrete-func test returned 0. Fixing it requires concrete heap types in `ValueType` (noted in the `gcTypeEquiv` docstring).

`interpreter`, `codelib`, and `programs` all build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)