### PR TITLE
interpreter: evaluate const-expr data/elem segment offsets at instantiation

### DIFF
--- a/interpreter/Interpreter/Runner.lean
+++ b/interpreter/Interpreter/Runner.lean
@@ -256,6 +256,9 @@ def runOnce (a : Args) : IO UInt32 := do
   -- imported global is unreachable; the import pre-flight above
   -- rejects any module that would need one.
   let store0 := m.runConstGlobals a.fuel (m.initialStore (α := Unit)) {}
+  -- Data/elem segments whose offset is itself a const-expr are deferred
+  -- by `initialStore`; write them now that the globals are evaluated.
+  let store0 := m.runActiveSegments a.fuel store0 {}
   match Wasm.run a.fuel m idx store0 vs.reverse with
   | .Success results _ =>
     for v in results.reverse do

--- a/interpreter/Interpreter/Testsuite/Exec.lean
+++ b/interpreter/Interpreter/Testsuite/Exec.lean
@@ -723,6 +723,10 @@ def runCommand
         -- then GC element-segment item initializers into their tables.
         let store0 := m.runConstGlobals fuel store0 env
         let store0 := m.runConstElems fuel store0 env
+        -- Data/elem segments whose offset is itself a const-expr
+        -- (`global.get`, extended-const) are deferred by `initialStore`;
+        -- write them now that the globals hold their real values.
+        let store0 := m.runActiveSegments fuel store0 env
         match m.startFunc with
         | none => pure (ModuleSlot.ok m store0 env)
         | some idx =>

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -2331,8 +2331,9 @@ private def parseMemDecl (xs : List Sexpr) : Except Err Wasm.MemDecl := do
 
 /-- Parse a `(data ...)` body. Active segments produce `offset := some n`;
 passive segments (no offset expression) produce `offset := none`. -/
-private def parseDataSegment (memNames : Std.HashMap String Nat)
+private def parseDataSegment (ctx : Ctx)
     (xs : List Sexpr) : Except Err Wasm.DataSegment := do
+  let memNames := ctx.memNames
   -- Strip an optional segment id ($name).
   let xs := match xs with
     | .atom a :: r => if a.startsWith "$" then r else xs
@@ -2347,15 +2348,17 @@ private def parseDataSegment (memNames : Std.HashMap String Nat)
       pure ((← resolveNamed memNames "memory" mref), r)
     | r => pure ((0 : Nat), r)
   -- Extract the offset constant; passive segments have no offset form.
-  -- Non-`i32.const` offset expressions (e.g. `(global.get N)` pointing
-  -- at an imported global) are accepted with a 0 placeholder so the
-  -- module still decodes; tests that depend on the actual offset will
-  -- fail at runtime rather than at decode time.
+  -- Non-literal offset expressions (`global.get`, extended-const
+  -- arithmetic) cannot be folded at decode time — the value depends on
+  -- the store — so they are kept as a const-expr program in
+  -- `offsetExpr` (with a `some 0` active-marker placeholder in
+  -- `offset`) and evaluated at instantiation by
+  -- `Module.runActiveSegments`.
   let parsed ← match xs with
     | .list [.atom "offset", .list [.atom "i32.const", .atom n]] :: r =>
-      do .ok ((some (← parseU32 n) : Option UInt32), r)
+      do .ok ((some (← parseU32 n) : Option UInt32), ([] : Wasm.Program), r)
     | .list [.atom "i32.const", .atom n] :: r =>
-      do .ok ((some (← parseU32 n) : Option UInt32), r)
+      do .ok ((some (← parseU32 n) : Option UInt32), ([] : Wasm.Program), r)
     -- memory64: active offsets in a 64-bit memory are i64 constants. The
     -- segment offset field is 32 bits; active 64-bit segments in practice
     -- are tiny, so a genuinely huge offset is a decode error.
@@ -2363,23 +2366,31 @@ private def parseDataSegment (memNames : Std.HashMap String Nat)
       do
         let v ← parseI64 n
         if v.toNat ≥ 2 ^ 32 then .error "data offset out of range"
-        else .ok ((some v.toUInt32 : Option UInt32), r)
+        else .ok ((some v.toUInt32 : Option UInt32), ([] : Wasm.Program), r)
     | .list [.atom "i64.const", .atom n] :: r =>
       do
         let v ← parseI64 n
         if v.toNat ≥ 2 ^ 32 then .error "data offset out of range"
-        else .ok ((some v.toUInt32 : Option UInt32), r)
-    | .list [.atom "offset", .list (.atom "global.get" :: _)] :: r
-    | .list (.atom "global.get" :: _) :: r =>
-      .ok ((some (0 : UInt32) : Option UInt32), r)
-    | _ => .ok ((none : Option UInt32), xs)
-  let (offset, rest) := parsed
+        else .ok ((some v.toUInt32 : Option UInt32), ([] : Wasm.Program), r)
+    -- Non-literal offset expressions (`global.get`, extended-const
+    -- arithmetic): keep the const-expr program for evaluation at
+    -- instantiation; `some 0` marks the segment active.
+    | .list (.atom "offset" :: es) :: r =>
+      do .ok ((some (0 : UInt32) : Option UInt32), (← parseInstrSeq ctx es), r)
+    -- Bare (unwrapped) non-literal offset expression, e.g.
+    -- `(data (global.get $o) "…")`.
+    | e :: r =>
+      if initExprNeedsEval e then
+        do .ok ((some (0 : UInt32) : Option UInt32), (← parseInstrSeq ctx [e]), r)
+      else .ok ((none : Option UInt32), ([] : Wasm.Program), xs)
+    | _ => .ok ((none : Option UInt32), ([] : Wasm.Program), xs)
+  let (offset, offsetExpr, rest) := parsed
   let mut bytes : List UInt8 := []
   for tok in rest do
     match tok with
     | .atom s => bytes := bytes ++ (← parseWatString s)
     | _ => .error "data segment: expected string literal(s)"
-  .ok { offset, bytes, memIdx }
+  .ok { offset, bytes, memIdx, offsetExpr }
 
 /-- Collect names declared by `(table $name ...)` forms in source order.
 Same pattern as `collectFuncNames` / `collectGlobalNames`. -/
@@ -2586,19 +2597,32 @@ private def parseElemSegment (ctx : Ctx)
     tableIdx := some idx; rest := r
   | _ => pure ()
   let mut offset : Option Nat := none
+  let mut offsetExpr : Wasm.Program := []
   match rest with
   | .list [.atom "offset", .list [.atom "i32.const", .atom n]] :: r =>
     let v ← parseNat n; offset := some v; rest := r
   | .list [.atom "offset", .list [.atom "i64.const", .atom n]] :: r =>
     -- table64: active offsets in a 64-bit table are i64 constants.
     let v ← parseI64 n; offset := some v.toNat; rest := r
-  | .list (.atom "offset" :: _) :: r =>
-    -- Other offset expressions (constant globals etc.) — not modelled.
-    offset := some 0; rest := r
+  | .list (.atom "offset" :: es) :: r =>
+    -- Non-literal offset expressions (`global.get`, extended-const
+    -- arithmetic): keep the const-expr program for evaluation at
+    -- instantiation by `Module.runActiveSegments`; `some 0` marks the
+    -- segment active.
+    offset := some 0; offsetExpr := (← parseInstrSeq ctx es); rest := r
   | .list [.atom "i32.const", .atom n] :: r =>
     let v ← parseNat n; offset := some v; rest := r
   | .list [.atom "i64.const", .atom n] :: r =>
     let v ← parseI64 n; offset := some v.toNat; rest := r
+  -- Bare (unwrapped) non-literal offset expression, e.g.
+  -- `(elem (global.get $o) $f)`. Guard against `(item …)` heads so a
+  -- passive segment's first const-expr item is never taken for an offset.
+  | e :: r =>
+    match e with
+    | .list (.atom "item" :: _) => pure ()
+    | _ =>
+      if initExprNeedsEval e then
+        offset := some 0; offsetExpr := (← parseInstrSeq ctx [e]); rest := r
   | _ => pure ()
   match rest with
   | .atom "func"      :: r => rest := r
@@ -2617,7 +2641,7 @@ private def parseElemSegment (ctx : Ctx)
     if elemRefIsGc inner then isGc := true
     rest := r
   | _ => pure ()
-  if isDeclarative then offset := none
+  if isDeclarative then offset := none; offsetExpr := []
   if isGc then
     -- Each item is a `(item <const-expr>)` (or a bare const-expr) producing
     -- one reference value; keep the program for `runConstElems`.
@@ -2626,7 +2650,7 @@ private def parseElemSegment (ctx : Ctx)
       match it with
       | .list (.atom "item" :: inner) => exprs := exprs ++ [← parseInstrSeq ctx inner]
       | other                         => exprs := exprs ++ [← parseInstrSeq ctx [other]]
-    return { tableIdx, offset, exprs }
+    return { tableIdx, offset, exprs, offsetExpr }
   let mut funcs : List (Option Nat) := []
   for it in rest do
     match it with
@@ -2647,7 +2671,7 @@ private def parseElemSegment (ctx : Ctx)
       | [.list [.atom "ref.null", _]] => funcs := funcs ++ [none]
       | _ => .error "elem: unsupported (item ...) form"
     | _ => .error "elem: unsupported entry"
-  .ok { tableIdx, offset, funcs }
+  .ok { tableIdx, offset, funcs, offsetExpr }
 
 /-- Parse the `(param …)` / `(result …)` / `(type N)` forms inside the
 `(func …)` of an `(import …)` declaration, returning `(params, results)`.
@@ -2933,7 +2957,8 @@ def parseModule (xs : List Sexpr) : Except Err Wasm.Module := do
       | none   => memDecl := some (← parseMemDecl body)
       | some _ => extraMemDecls := extraMemDecls.push (← parseMemDecl body)
     | .list (.atom "data" :: body) =>
-      dataSegs := dataSegs.push (← parseDataSegment memNames body)
+      let dctx : Ctx := { Ctx.empty with funcIds := funcIds, globalIds := globalIds, types := types, tableNames := tableNames, elemNames := elemNames, memNames := memNames, tagNames := tagNames }
+      dataSegs := dataSegs.push (← parseDataSegment dctx body)
     | .list (.atom "table" :: body) =>
       for n in inlineExportsOf body do
         tableExports := tableExports.push (n, tblImps.length + tableDecls.size)

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -33,6 +33,7 @@ import Interpreter.Wasm.Examples.FloatOps
 import Interpreter.Wasm.Examples.Gcd
 import Interpreter.Wasm.Examples.SelectAbs
 import Interpreter.Wasm.Examples.GlobalInitExpr
+import Interpreter.Wasm.Examples.SegmentOffsetExpr
 import Interpreter.Wasm.Examples.CallIndirectSubtype
 
 /-! # Wasm.Examples.Basic

--- a/interpreter/Interpreter/Wasm/Examples/SegmentOffsetExpr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SegmentOffsetExpr.lean
@@ -1,0 +1,81 @@
+import Interpreter.Wasm.Decoder.Wat
+import Interpreter.Wasm.Wp.Tactic
+import Interpreter.Wasm.Examples.Harness
+
+/-! ## Example: const-expr data/elem segment offsets
+
+    An active data or element segment's offset is a constant expression,
+    not just a literal: wasm 1.0 permits `global.get`, and the
+    extended-const proposal adds `i32.add`/`i32.sub`/`i32.mul` (i64
+    ditto). Talos keeps such offsets as a program in
+    `DataSegment.offsetExpr` / `ElementSegment.offsetExpr`; the segment
+    is skipped by `Module.initialStore` and written at instantiation by
+    `Module.runActiveSegments`, once `Module.runConstGlobals` has put
+    the globals in place.
+
+    This module is the regression test for issue #101, where such
+    segments landed at offset 0: the data below must end up at byte 4,
+    and the table entry at slot 2, or the theorems fail the build. -/
+
+namespace Wasm
+open Wasm.Examples
+namespace SegmentOffsetExpr
+
+/-- A module whose data segment lands at `global.get $o = 4` and whose
+element segment lands at `global.get $t = 2`. `readByte4` observes the
+data placement; `callAt2` observes the element placement (it traps if
+the funcref landed at slot 0 instead). -/
+def segmentOffsetWat : String := "
+(module
+  (global $o i32 (i32.const 4))
+  (global $t i32 (i32.const 2))
+  (memory 1)
+  (data (offset (global.get $o)) \"ABCD\")
+  (table 4 funcref)
+  (elem (offset (global.get $t)) $f42)
+  (type $ri (func (result i32)))
+  (func $f42 (type $ri) (i32.const 42))
+  (func $readByte4 (export \"readByte4\") (result i32)
+    (i32.load8_u (i32.const 4)))
+  (func $callAt2 (export \"callAt2\") (result i32)
+    (call_indirect (type $ri) (i32.const 2))))
+"
+
+private def decoded : Wasm.Module := decodeOrDefault segmentOffsetWat
+
+/-- The non-literal offsets are kept as programs rather than collapsed
+to a `0` placeholder: both segments carry a non-empty `offsetExpr`. -/
+theorem decoded_segments_keep_offsetExpr :
+    ((decoded.memory.bind (·.data[0]?)).map (·.offsetExpr.isEmpty)).getD true = false
+    ∧ (decoded.elements[0]?.map (·.offsetExpr.isEmpty)).getD true = false := by
+  constructor <;> native_decide
+
+/-- The instantiated store used by the theorems below: base store, then
+global initializers, then the deferred const-expr-offset segments. -/
+private def store0 : Store Unit :=
+  let m := decoded
+  m.runActiveSegments 64 (m.runConstGlobals 64 (m.initialStore (α := Unit)) {}) {}
+
+/-- `runActiveSegments` writes the data segment at the evaluated offset:
+byte 4 holds `'A' = 65`. The issue-#101 behaviour — the segment landing
+at offset 0 — would leave byte 4 zero. -/
+theorem readByte4_returns_65 :
+    runValues 64 decoded ((decoded.findExport "readByte4").getD 0) store0 []
+      = [.i32 65] := by
+  native_decide
+
+/-- Likewise the element segment: the funcref lands in table slot 2, so
+`call_indirect` at index 2 reaches `$f42`. With the segment at slot 0
+this call trapped on a null table entry. -/
+theorem callAt2_returns_42 :
+    runValues 64 decoded ((decoded.findExport "callAt2").getD 0) store0 []
+      = [.i32 42] := by
+  native_decide
+
+/-- And nothing leaked to the old placeholder location: byte 0 of the
+memory is still zero (the segment was *moved*, not duplicated). -/
+theorem byte0_still_zero : store0.mem.read8 0 = 0 := by
+  native_decide
+
+end SegmentOffsetExpr
+end Wasm

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -2277,7 +2277,9 @@ def Module.runConstElems (fuel : Nat) (m : Module) (st : Store α)
   for seg in m.elements do
     match seg.tableIdx, seg.offset with
     | some ti, some off =>
-      if !seg.exprs.isEmpty then
+      -- Segments whose offset is itself a pending const-expr are written
+      -- by `runActiveSegments` (which knows the real offset) instead.
+      if !seg.exprs.isEmpty && seg.offsetExpr.isEmpty then
         let mut i := 0
         for e in seg.exprs do
           match exec fuel m st {} e env with
@@ -2289,6 +2291,73 @@ def Module.runConstElems (fuel : Nat) (m : Module) (st : Store α)
             | _, _ => pure ()
           | _ => pure ()
           i := i + 1
+    | _, _ => pure ()
+  return st
+
+/-- Write the active data/element segments whose offset is a constant
+expression that could not be folded at decode time (`global.get` of an
+imported global, extended-const arithmetic). `Module.initialStore` skips
+these segments (their offset depends on the store); this pass evaluates
+each `offsetExpr` against the current store and writes the segment at
+the computed offset. Runs after `runConstGlobals` so the offsets see the
+evaluated (and imported) globals. -/
+def Module.runActiveSegments (fuel : Nat) (m : Module) (st : Store α)
+    (env : HostEnv α := {}) : Store α := Id.run do
+  let mut st := st
+  -- Evaluate one offset const-expr to a byte/element offset. `i64`
+  -- results come from memory64/table64 modules.
+  let evalOffset (st : Store α) (prog : Program) : Option Nat :=
+    match exec fuel m st {} prog env with
+    | .Fallthrough _ s' =>
+      match s'.values with
+      | .i32 v :: _ => some v.toNat
+      | .i64 v :: _ => some v.toNat
+      | _           => none
+    | _ => none
+  -- Active data segments with a pending offset expression. Segments live
+  -- in one global, source-ordered list (memory 0's `data`), routed to
+  -- their memory by `DataSegment.memIdx`.
+  let segs := match m.memory with
+    | some decl => decl.data
+    | none      => []
+  for seg in segs do
+    if seg.offset.isSome && !seg.offsetExpr.isEmpty then
+      match evalOffset st seg.offsetExpr with
+      | some off =>
+        if seg.memIdx = 0 then
+          st := { st with mem := st.mem.writeBytes off seg.bytes }
+        else
+          match st.extraMems[seg.memIdx - 1]? with
+          | some mem0 =>
+            let mems := st.extraMems.set (seg.memIdx - 1) (mem0.writeBytes off seg.bytes)
+            st := { st with extraMems := mems }
+          | none => pure ()
+      | none => pure ()
+  -- Active element segments with a pending offset expression.
+  for seg in m.elements do
+    match seg.tableIdx, seg.offset with
+    | some ti, some _ =>
+      if !seg.offsetExpr.isEmpty then
+        match evalOffset st seg.offsetExpr, st.tables[ti]? with
+        | some off, some tbl =>
+          if seg.exprs.isEmpty then
+            let tbls := st.tables.set ti (listWriteAt tbl off (seg.funcs.map Value.funcref))
+            st := { st with tables := tbls }
+          else
+            -- GC const-expr items, as in `runConstElems`, but at the
+            -- evaluated offset.
+            let mut i := 0
+            for e in seg.exprs do
+              match exec fuel m st {} e env with
+              | .Fallthrough st' s' =>
+                st := st'
+                match s'.values, st'.tables[ti]? with
+                | v :: _, some tbl' =>
+                  st := { st' with tables := st'.tables.set ti (tbl'.set (off + i) v) }
+                | _, _ => pure ()
+              | _ => pure ()
+              i := i + 1
+        | _, _ => pure ()
     | _, _ => pure ()
   return st
 

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -601,6 +601,14 @@ structure DataSegment where
   /-- Target memory index (multi-memory): 0 is the default memory, k ≥ 1
   the k-th extra memory (`Module.extraMemories[k-1]`). -/
   memIdx : Nat := 0
+  /-- For active segments whose offset is a constant expression that cannot
+  be folded to a literal at decode time (`global.get`, extended-const
+  arithmetic), the parsed const-expr program. When non-empty, `offset`
+  holds a `some 0` placeholder (the segment is still *active*) and the
+  segment is written by `Module.runActiveSegments` at instantiation —
+  after `Module.runConstGlobals` has put the globals in place — instead
+  of by `Module.initialStore`. -/
+  offsetExpr : Program := []
 deriving Repr, Inhabited
 
 /-- Declaration of a single linear memory. Wasm allows at most one
@@ -696,6 +704,13 @@ structure ElementSegment where
   `Module.runConstElems`, which writes the resulting values into the table.
   Empty for plain funcref segments (which use `funcs`). -/
   exprs    : List Program := []
+  /-- For active segments whose offset is a constant expression that cannot
+  be folded to a literal at decode time (`global.get`, extended-const
+  arithmetic), the parsed const-expr program. When non-empty, `offset`
+  holds a `some 0` placeholder (the segment is still *active*) and the
+  segment is written by `Module.runActiveSegments` at instantiation
+  instead of by `Module.initialStore`. -/
+  offsetExpr : Program := []
 deriving Repr, Inhabited
 
 structure Module where
@@ -830,11 +845,16 @@ def Module.initialStore [Inhabited α] (m : Module) : Store α :=
   -- Apply the active data segments targeting memory `idx` to `m0`.
   -- Segments live in one global, source-ordered list (memory 0's
   -- `data`); `DataSegment.memIdx` routes each to its memory.
+  -- Segments with a pending `offsetExpr` are skipped here: their offset
+  -- depends on the store (imported globals), so `Module.runActiveSegments`
+  -- writes them at instantiation after the globals are in place.
   let applySegs (segs : List DataSegment) (idx : Nat) (m0 : Mem) : Mem :=
     segs.foldl
       (fun acc seg => match seg.offset with
         | some off =>
-          if seg.memIdx = idx then acc.writeBytes off.toNat seg.bytes else acc
+          if seg.memIdx = idx && seg.offsetExpr.isEmpty then
+            acc.writeBytes off.toNat seg.bytes
+          else acc
         | none     => acc)
       m0
   let allSegs : List DataSegment := match m.memory with
@@ -860,13 +880,17 @@ def Module.initialStore [Inhabited α] (m : Module) : Store α :=
   -- Apply active element segments. Passive/declarative segments leave the
   -- table untouched and are tracked in `elementSegments` so `table.init`
   -- can consume them later.
+  -- As with data segments, elements with a pending `offsetExpr` are
+  -- deferred to `Module.runActiveSegments`.
   let tables : List TableInst := m.elements.foldl
     (fun acc seg =>
       match seg.tableIdx, seg.offset with
       | some t, some off =>
-        match acc[t]? with
-        | some tbl => listSetAt acc t (listWriteAt tbl off (seg.funcs.map Value.funcref))
-        | none     => acc
+        if seg.offsetExpr.isEmpty then
+          match acc[t]? with
+          | some tbl => listSetAt acc t (listWriteAt tbl off (seg.funcs.map Value.funcref))
+          | none     => acc
+        else acc
       | _, _ => acc)
     baseTables
   let elementSegments : List (Option (List (Option Nat))) :=

--- a/testsuite_report.txt
+++ b/testsuite_report.txt
@@ -4252,10 +4252,10 @@ data.wast:154 module pass
 data.wast:160 module pass
 data.wast:166 module pass
 data.wast:171 module pass
-data.wast:178 module decode_error
-data.wast:183 module decode_error
-data.wast:188 module decode_error
-data.wast:195 module decode_error
+data.wast:178 module pass
+data.wast:183 module pass
+data.wast:188 module pass
+data.wast:195 module pass
 data.wast:211 assert_uninstantiable skipped:assert_uninstantiable
 data.wast:219 assert_uninstantiable skipped:assert_uninstantiable
 data.wast:227 assert_uninstantiable skipped:assert_uninstantiable
@@ -4278,14 +4278,14 @@ data.wast:374 assert_invalid skipped:assert_invalid: not rejected
 data.wast:396 assert_invalid skipped:assert_invalid: not rejected
 data.wast:415 assert_invalid skipped:assert_invalid: not rejected
 data.wast:423 assert_invalid pass
-data.wast:431 assert_invalid pass
-data.wast:439 assert_invalid pass
-data.wast:447 assert_invalid pass
-data.wast:456 assert_invalid pass
-data.wast:465 assert_invalid pass
+data.wast:431 assert_invalid skipped:assert_invalid: not rejected
+data.wast:439 assert_invalid skipped:assert_invalid: not rejected
+data.wast:447 assert_invalid skipped:assert_invalid: not rejected
+data.wast:456 assert_invalid skipped:assert_invalid: not rejected
+data.wast:465 assert_invalid skipped:assert_invalid: not rejected
 data.wast:473 assert_invalid pass
-data.wast:481 assert_invalid pass
-data.wast:489 assert_invalid pass
+data.wast:481 assert_invalid skipped:assert_invalid: not rejected
+data.wast:489 assert_invalid skipped:assert_invalid: not rejected
 data.wast:497 assert_invalid skipped:assert_invalid: not rejected
 data.wast:506 assert_invalid skipped:assert_invalid: not rejected
 data.wast:514 assert_invalid skipped:assert_invalid: not rejected
@@ -4329,16 +4329,16 @@ elem.wast:98 module pass
 elem.wast:103 module pass
 elem.wast:109 module pass
 elem.wast:118 module pass
-elem.wast:128 module decode_error
-elem.wast:135 module decode_error
+elem.wast:128 module pass
+elem.wast:135 module pass
 elem.wast:142 module pass
 elem.wast:156 assert_return pass
 elem.wast:157 assert_return pass
 elem.wast:161 module pass
 elem.wast:175 assert_return pass
 elem.wast:176 assert_return pass
-elem.wast:178 module decode_error
-elem.wast:182 module decode_error
+elem.wast:178 module pass
+elem.wast:182 module pass
 elem.wast:190 module pass
 elem.wast:195 module pass
 elem.wast:201 module pass
@@ -4416,10 +4416,10 @@ elem.wast:784 assert_invalid skipped:assert_invalid: not rejected
 elem.wast:792 assert_invalid pass
 elem.wast:800 assert_invalid skipped:assert_invalid: not rejected
 elem.wast:808 assert_invalid skipped:assert_invalid: not rejected
-elem.wast:816 assert_invalid pass
-elem.wast:825 assert_invalid pass
-elem.wast:833 assert_invalid pass
-elem.wast:842 assert_invalid pass
+elem.wast:816 assert_invalid skipped:assert_invalid: not rejected
+elem.wast:825 assert_invalid skipped:assert_invalid: not rejected
+elem.wast:833 assert_invalid skipped:assert_invalid: not rejected
+elem.wast:842 assert_invalid skipped:assert_invalid: not rejected
 elem.wast:854 assert_invalid skipped:assert_invalid: not rejected
 elem.wast:862 assert_invalid pass
 elem.wast:870 assert_invalid pass
@@ -4462,16 +4462,16 @@ elem.wast:1041 register pass
 elem.wast:1043 module decode_error
 elem.wast:1053 assert_return module_unavailable
 elem.wast:1057 module pass
-elem.wast:1065 assert_return fail
+elem.wast:1065 assert_return pass
 elem.wast:1066 assert_trap fail
 elem.wast:1068 module pass
-elem.wast:1076 assert_return fail
+elem.wast:1076 assert_return pass
 elem.wast:1077 assert_trap fail
 elem.wast:1079 module pass
-elem.wast:1087 assert_return fail
+elem.wast:1087 assert_return pass
 elem.wast:1088 assert_trap fail
 elem.wast:1092 module pass
-elem.wast:1109 assert_return fail
+elem.wast:1109 assert_return pass
 elem.wast:1110 assert_trap fail
 endianness.wast:1 module pass
 endianness.wast:133 assert_return pass


### PR DESCRIPTION
Fixes #101.

A data or element segment whose offset is a `global.get` (or extended-const arithmetic) const-expr was placed at offset `0`: the decoder folded non-literal offset expressions to a `0` placeholder, so the offset was never evaluated at instantiation.

## Change

- **`Wasm.DataSegment` / `Wasm.ElementSegment`** gain an `offsetExpr : Program := []` field, mirroring `GlobalDecl.initExpr`. The WAT decoder keeps the parsed const-expr program (wrapped `(offset …)` and bare abbreviated forms) instead of collapsing it to `0`; `offset := some 0` remains as the active-segment marker.
- **`Module.initialStore`** skips segments with a pending `offsetExpr` — their offset depends on the store (imported globals), so they cannot be written there.
- **New `Module.runActiveSegments`** (Semantics.lean) evaluates each pending `offsetExpr` against the current store and writes the segment at the computed offset — data bytes into the right (multi-)memory, funcref/GC-item elements into the right table slot. It runs after `Module.runConstGlobals`, so offsets see the evaluated and imported globals; `runConstElems` skips these segments to avoid double-writing.
- Wired into both instantiation pipelines: the testsuite driver (`Testsuite/Exec.lean`) and the runner (`Runner.lean`).
- New example `Examples/SegmentOffsetExpr.lean` is the regression test: the issue's exact scenario (data at `global.get $o = 4`, elem at `global.get $t = 2`) proven end-to-end via `native_decide`, including that byte 0 stays zero (segment moved, not duplicated).

## Testsuite report

`testsuite_report.txt` regenerated (all three packages `lake build` cleanly):

- 8 × `module decode_error` → `pass` (data.wast 178/183/188/195, elem.wast 128/135/178/182)
- 4 × `assert_return fail` → `pass` (elem.wast 1065/1076/1087/1109 — `call_indirect` through a global-offset elem segment)
- 11 × `assert_invalid pass` → `skipped: not rejected`: ill-typed offset const-exprs (e.g. `(offset (nop) …)`, two-value offsets) were previously rejected only because the decoder couldn't parse non-literal offsets at all; they now decode and join the existing not-validated skip bucket (data.wast already carried 25 such skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)