### PR TITLE
Add `just differential`: differential-test the runner against V8 via miscast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ verifier-report/
 
 extracted/
 out/
+
+# differential-testing scratch (pinned miscast clone + run output)
+.differential-cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,17 @@ The recipe requires the pinned `wasm-tools` version (see `WASM_TOOLS_VERSION` in
 
 Bumping `WASM_TOOLS_VERSION` or the `vendor/testsuite` submodule will also change the report — those bumps and the regenerated report belong in the same commit.
 
+## Differential testing
+
+Beyond the spec testsuite, `just differential` keeps the runner in parity with a trusted engine (V8) by running the same modules on both and flagging divergences — above all **soundness** divergences, where the runner accepts or runs a module the oracle rejects or traps on.
+
+```bash
+just differential                          # recgroup soundness mode, V8 oracle
+just differential --mode recgroup -n 300   # reproduce the full #108 cluster
+```
+
+It drives the runner as the custom system-under-test for [miscast](https://github.com/jasisz/miscast) (pinned as an external dependency). Requires `wasm-tools` and `node` ≥ 22. See [`differential/README.md`](differential/README.md) for details.
+
 ## Contributing code
 
 Pull requests are welcome. A few guidelines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ just differential                          # recgroup soundness mode, V8 oracle
 just differential --mode recgroup -n 300   # reproduce the full #108 cluster
 ```
 
-It drives the runner as the custom system-under-test for [miscast](https://github.com/jasisz/miscast) (pinned as an external dependency). Requires `wasm-tools` and `node` ≥ 22. See [`differential/README.md`](differential/README.md) for details.
+It drives the runner as the custom system-under-test for [miscast](https://github.com/jasisz/miscast) (pinned as an external dependency). Requires `wasm-tools`, `python3`, `git`, and `node` ≥ 22 (on `PATH` or under `~/.nvm`). See [`differential/README.md`](differential/README.md) for details.
 
 ## Contributing code
 

--- a/differential/README.md
+++ b/differential/README.md
@@ -19,8 +19,9 @@ the runner, points miscast's custom system-under-test at it, and runs it against
 No adapter is needed: miscast invokes a custom SUT as `CUSTOM_CMD='<cmd> {wat} {export}'`
 and reads a value from stdout / a trap from a `trap:` line, which is exactly the
 runner's CLI and output contract — including uncaught exceptions (reported as a
-`trap:` line, matching V8's classification) and float arguments (the WAT literal
-grammar, the same values V8 sees). Out-of-fuel (exit 2, empty stdout) reads as
+`trap:` line, matching V8's classification). Invoke arguments are i32/i64 only —
+miscast skips float- and ref-arg actions upstream — and the runner reads them as
+plain integers, exactly as V8 does. Out-of-fuel (exit 2, empty stdout) reads as
 unsupported, so it never shows up as a false divergence.
 
 (miscast also ships `tools/talos_run.py`, an adapter written before the runner

--- a/differential/README.md
+++ b/differential/README.md
@@ -27,6 +27,14 @@ unsupported, so it never shows up as a false divergence.
 spoke this contract natively; driving the runner directly keeps the verdict
 mapping in one place instead of two.)
 
+The contract is enforced, not assumed: every run starts with **canaries** that
+probe the runner's actual output against miscast's own classification regexes —
+an arg-count complaint must not read as validator rejection (that would record
+false REJECT agreement on invalid modules), an uncaught exception must read as
+a trap, and a garbage float argument must fail the run rather than parse as
+`0.0`. A reworded runner error message that breaks the coupling fails the run
+immediately instead of silently skewing verdicts.
+
 miscast is pinned as an external dependency (a rev in `scripts/differential.sh`),
 not vendored. The first run clones it into `.differential-cache/` (gitignored);
 set `MISCAST_DIR=/path/to/miscast` to use a local checkout instead.
@@ -44,8 +52,9 @@ set `MISCAST_DIR=/path/to/miscast` to use a local checkout instead.
 `replay`). Each is one soundness corner, and a regression guard. **Every seed
 must export its entry point as `f`** — miscast drives a bare `.wat` through the
 export named `f` (the convention its own seed corpus follows); any other name
-makes the seed-driven modes silently skip the module. Seeds are also runnable
-directly:
+makes the seed-driven modes silently skip the module. `scripts/differential.sh`
+lints the corpus for this on every run, so a wrongly named seed fails loudly.
+Seeds are also runnable directly:
 
 ```bash
 cd interpreter && lake exe runner ../differential/seeds/recgroup_callindirect.wat f
@@ -56,7 +65,11 @@ which the runner now handles correctly. It must keep trapping.
 
 ## Known noise
 
-The runner's Lean float formatting differs from V8's, so some `f64` results show up
-as *value* (not soundness) divergences. Those are formatting noise, not bugs; the
-follow-up CI gate baselines them (and the #108 recgroup cluster) so it only trips on
-new divergences.
+The runner's Lean float formatting differs from V8's, so `f64` results *can* show
+up as *value* (not soundness) divergences in modes that compare results as text.
+Note that earlier sweeps predate two fixes on this branch — float CLI args used to
+be read as raw bit patterns, and garbage float literals used to parse as `0.0` —
+both of which manufactured exactly this kind of value divergence. The follow-up CI
+gate must therefore derive its baseline from a **fresh** full sweep on this branch
+(plus the #108 recgroup cluster), not from the earlier runs, so genuinely fixed
+noise is not baselined over real future divergences.

--- a/differential/README.md
+++ b/differential/README.md
@@ -18,8 +18,14 @@ the runner, points miscast's custom system-under-test at it, and runs it against
 
 No adapter is needed: miscast invokes a custom SUT as `CUSTOM_CMD='<cmd> {wat} {export}'`
 and reads a value from stdout / a trap from a `trap:` line, which is exactly the
-runner's CLI and output contract. Out-of-fuel (exit 2, empty stdout) reads as
+runner's CLI and output contract — including uncaught exceptions (reported as a
+`trap:` line, matching V8's classification) and float arguments (the WAT literal
+grammar, the same values V8 sees). Out-of-fuel (exit 2, empty stdout) reads as
 unsupported, so it never shows up as a false divergence.
+
+(miscast also ships `tools/talos_run.py`, an adapter written before the runner
+spoke this contract natively; driving the runner directly keeps the verdict
+mapping in one place instead of two.)
 
 miscast is pinned as an external dependency (a rev in `scripts/differential.sh`),
 not vendored. The first run clones it into `.differential-cache/` (gitignored);
@@ -28,16 +34,21 @@ set `MISCAST_DIR=/path/to/miscast` to use a local checkout instead.
 ## Requirements
 
 - `wasm-tools`
-- `node` ≥ 22 (the V8 / WasmGC oracle)
+- `python3` and `git` (fetching and driving miscast)
+- `node` ≥ 22 (the V8 / WasmGC oracle) — found on `PATH` or under `~/.nvm`;
+  override with `NODE=/path/to/node`
 
 ## Seeds
 
 `seeds/` holds hand-checked `.wat` probes for the seed-driven modes (`mutate`,
-`replay`). Each is one soundness corner, and a regression guard. They are also
-runnable directly:
+`replay`). Each is one soundness corner, and a regression guard. **Every seed
+must export its entry point as `f`** — miscast drives a bare `.wat` through the
+export named `f` (the convention its own seed corpus follows); any other name
+makes the seed-driven modes silently skip the module. Seeds are also runnable
+directly:
 
 ```bash
-lake exe runner differential/seeds/recgroup_callindirect.wat go
+cd interpreter && lake exe runner ../differential/seeds/recgroup_callindirect.wat f
 ```
 
 traps with `indirect call type mismatch`, agreeing with V8 — the minimal form of #108,

--- a/differential/README.md
+++ b/differential/README.md
@@ -1,0 +1,51 @@
+# Differential testing
+
+Keeps the runner in parity with a trusted engine by running the same modules on
+both and flagging divergences — above all **soundness** divergences, where the
+runner accepts or runs a module the oracle rejects or traps on.
+
+```bash
+just differential                          # recgroup soundness mode, V8 oracle
+just differential --mode recgroup -n 300   # reproduce the full #108 cluster
+just differential --mode mutate --seeds differential/seeds
+```
+
+## How it works
+
+The engine is [miscast](https://github.com/jasisz/miscast) (@jasisz), a differential
+and self-checking WebAssembly GC soundness tester. `scripts/differential.sh` builds
+the runner, points miscast's custom system-under-test at it, and runs it against V8.
+
+No adapter is needed: miscast invokes a custom SUT as `CUSTOM_CMD='<cmd> {wat} {export}'`
+and reads a value from stdout / a trap from a `trap:` line, which is exactly the
+runner's CLI and output contract. Out-of-fuel (exit 2, empty stdout) reads as
+unsupported, so it never shows up as a false divergence.
+
+miscast is pinned as an external dependency (a rev in `scripts/differential.sh`),
+not vendored. The first run clones it into `.differential-cache/` (gitignored);
+set `MISCAST_DIR=/path/to/miscast` to use a local checkout instead.
+
+## Requirements
+
+- `wasm-tools`
+- `node` ≥ 22 (the V8 / WasmGC oracle)
+
+## Seeds
+
+`seeds/` holds hand-checked `.wat` probes for the seed-driven modes (`mutate`,
+`replay`). Each is one soundness corner, and a regression guard. They are also
+runnable directly:
+
+```bash
+lake exe runner differential/seeds/recgroup_callindirect.wat go
+```
+
+traps with `indirect call type mismatch`, agreeing with V8 — the minimal form of #108,
+which the runner now handles correctly. It must keep trapping.
+
+## Known noise
+
+The runner's Lean float formatting differs from V8's, so some `f64` results show up
+as *value* (not soundness) divergences. Those are formatting noise, not bugs; the
+follow-up CI gate baselines them (and the #108 recgroup cluster) so it only trips on
+new divergences.

--- a/differential/seeds/recgroup_callindirect.wat
+++ b/differential/seeds/recgroup_callindirect.wat
@@ -1,0 +1,21 @@
+;; Rec-group canonicalization soundness probe (the #108 class).
+;;
+;; $A1 and $A2 are function types in *different* rec groups. Because each rec group
+;; also contains a struct that back-references the func type, the two groups are not
+;; structurally equal, so $A1 and $A2 are DISTINCT types. A `call_indirect (type $A2)`
+;; against a table slot holding a `$A1` function must therefore fail the type check
+;; and trap.
+;;
+;; V8 (and the spec) trap here. A runner that canonicalizes the two rec groups to the
+;; same type would accept the call and return 40 instead -- a value where the oracle
+;; traps, i.e. a SOUNDNESS divergence. That was #108.
+;;
+;; The runner traps correctly today (`trap: indirect call type mismatch`), so this is
+;; kept as a regression guard: it must keep trapping. `recgroup` mode generates many
+;; more of the same class on the fly.
+(module
+  (rec (type $A1 (func (param (ref null $B1)) (result i32))) (type $B1 (struct (field (ref null $A1)))))
+  (rec (type $B2 (struct (field (ref null $A2)))) (type $A2 (func (param (ref null $B2)) (result i32))))
+  (func $f (type $A1) i32.const 40)
+  (table 1 funcref) (elem (i32.const 0) $f)
+  (func (export "go") (result i32) (call_indirect (type $A2) (ref.null $B2) (i32.const 0))))

--- a/differential/seeds/recgroup_callindirect.wat
+++ b/differential/seeds/recgroup_callindirect.wat
@@ -13,9 +13,13 @@
 ;; The runner traps correctly today (`trap: indirect call type mismatch`), so this is
 ;; kept as a regression guard: it must keep trapping. `recgroup` mode generates many
 ;; more of the same class on the fly.
+;;
+;; The entry point is exported as "f": miscast's seed-corpus loader drives a bare
+;; `.wat` through the export named `f` (its upstream seeds all follow this), so any
+;; other name would make the seed-driven modes silently skip the module.
 (module
   (rec (type $A1 (func (param (ref null $B1)) (result i32))) (type $B1 (struct (field (ref null $A1)))))
   (rec (type $B2 (struct (field (ref null $A2)))) (type $A2 (func (param (ref null $B2)) (result i32))))
-  (func $f (type $A1) i32.const 40)
-  (table 1 funcref) (elem (i32.const 0) $f)
-  (func (export "go") (result i32) (call_indirect (type $A2) (ref.null $B2) (i32.const 0))))
+  (func $callee (type $A1) i32.const 40)
+  (table 1 funcref) (elem (i32.const 0) $callee)
+  (func (export "f") (result i32) (call_indirect (type $A2) (ref.null $B2) (i32.const 0))))

--- a/interpreter/Interpreter/Runner.lean
+++ b/interpreter/Interpreter/Runner.lean
@@ -32,9 +32,10 @@ def usage : String :=
   <method>  Export name, or a non-negative integer interpreted as a
             function index. The integer rule always wins — an export
             literally named \"0\" is unreachable.
-  [args...] One numeric literal per declared parameter. Decimal (`42`,
-            `-1`) and hex (`0xff`) accepted. The declared parameter
-            type drives the width/signedness coercion.
+  [args...] One numeric literal per declared parameter. Integers take
+            decimal (`42`, `-1`) or hex (`0xff`); floats take the WAT
+            literal grammar (`1.5`, `-0x1.8p+2`, `inf`, `nan`). The
+            declared parameter type drives the coercion.
   --fuel N  Reduction-step cap, default 1_000_000.
   -h, --help  Print this message and exit 0."
 
@@ -125,15 +126,16 @@ def parseArgForType (t : ValueType) (s : String) : Except String Value :=
     | .ok v  => .ok (.i64 v)
     | .error _ => .error s!"argument out of range for i64: `{s}`"
   | .f32 =>
-    -- No decimal float parser in core; a float CLI arg is its raw 32-bit
-    -- IEEE-754 encoding (e.g. `0x3f800000` for `1.0`).
-    match parseI32 s with
+    -- WAT float literal (decimal, hex-float, `inf`, `nan[:0x…]`) — the same
+    -- grammar `f32.const` accepts, via the decoder's parser. This is what a
+    -- differential harness replaying `.wast` invokes hands us verbatim.
+    match parseF32Lit s with
     | .ok v  => .ok (.f32 v)
-    | .error _ => .error s!"f32 argument must be a 32-bit IEEE-754 bit pattern: `{s}`"
+    | .error _ => .error s!"bad f32 literal: `{s}`"
   | .f64 =>
-    match parseI64 s with
+    match parseF64Lit s with
     | .ok v  => .ok (.f64 v)
-    | .error _ => .error s!"f64 argument must be a 64-bit IEEE-754 bit pattern: `{s}`"
+    | .error _ => .error s!"bad f64 literal: `{s}`"
   | .funcref =>
     -- No CLI surface for funcref args yet — pass `null` if the user
     -- writes "null", otherwise refuse.
@@ -153,8 +155,12 @@ def parseArgForType (t : ValueType) (s : String) : Except String Value :=
 
 def parseArgs?
     (params : List ValueType) (args : List String) : Except String (List Value) :=
+  -- Wording matters downstream: a differential harness (miscast) greps
+  -- stderr for validator-rejection vocabulary ("mismatch", "expected",
+  -- "arity", …) — a CLI arg-count complaint must not read as the module
+  -- being rejected, so keep those words out of this message.
   if params.length ≠ args.length then
-    .error s!"arg-count mismatch: function expects {params.length}, got {args.length}"
+    .error s!"wrong number of arguments: function takes {params.length}, got {args.length}"
   else
     let rec go : List ValueType → List String → Except String (List Value)
       | [], [] => .ok []
@@ -272,7 +278,10 @@ def runOnce (a : Args) : IO UInt32 := do
     IO.eprintln "out of fuel"
     return EXIT_OUT_OF_FUEL
   | .Thrown tag _ _ =>
-    IO.eprintln s!"uncaught exception (tag {tag})"
+    -- The `trap:` prefix keeps the CLI surface uniform (exit code already
+    -- says trap) and lets trap-line consumers (miscast) classify an escaped
+    -- exception the way V8 does, instead of dropping the case as unsupported.
+    IO.eprintln s!"trap: uncaught exception (tag {tag})"
     return EXIT_TRAP
   | .Invalid msg =>
     IO.eprintln s!"error: {msg}"

--- a/interpreter/Interpreter/Runner.lean
+++ b/interpreter/Interpreter/Runner.lean
@@ -127,8 +127,10 @@ def parseArgForType (t : ValueType) (s : String) : Except String Value :=
     | .error _ => .error s!"argument out of range for i64: `{s}`"
   | .f32 =>
     -- WAT float literal (decimal, hex-float, `inf`, `nan[:0x…]`) — the same
-    -- grammar `f32.const` accepts, via the decoder's parser. This is what a
-    -- differential harness replaying `.wast` invokes hands us verbatim.
+    -- grammar `f32.const` accepts, via the decoder's parser. The CLI is a
+    -- human surface: a literal means its value, never a raw bit pattern.
+    -- (miscast never passes float args — it skips float-arg invokes
+    -- upstream — so this is for people, and guarded by a harness canary.)
     match parseF32Lit s with
     | .ok v  => .ok (.f32 v)
     | .error _ => .error s!"bad f32 literal: `{s}`"

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -229,7 +229,11 @@ private def parseHexFloatMag (body : String) : Except Err Float := do
     | [i]          => (i, "")
     | i :: f :: _  => (i, f)
     | []           => ("", "")
-  let m := (fromHexString? (intH ++ fracH)).getD 0
+  -- A mantissa that fails to lex must be an error, not 0: this parser also
+  -- backs the runner's CLI float args, where a garbage literal silently
+  -- running as 0.0 would mask typos (and fake agreement in differential runs).
+  let some m := fromHexString? (intH ++ fracH)
+    | .error s!"bad hex float literal: 0x{body}"
   let e ← parseDecExp expS
   .ok (floatScalePow2 (Float.ofNat m) (e - 4 * Int.ofNat fracH.length))
 
@@ -243,7 +247,9 @@ private def parseDecFloatMag (body : String) : Except Err Float := do
     | [i]          => (i, "")
     | i :: f :: _  => (i, f)
     | []           => ("", "")
-  let m := ((intP ++ fracP).toNat?).getD 0
+  -- Same strictness rationale as `parseHexFloatMag`: garbage must not be 0.
+  let some m := (intP ++ fracP).toNat?
+    | .error s!"bad float literal: {body}"
   let de ← parseDecExp expS
   let exp := de - Int.ofNat fracP.length
   .ok (Float.ofScientific m (exp < 0) exp.natAbs)

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -208,49 +208,57 @@ private def floatDivPow2 : Float → Nat → Float
 private def floatScalePow2 (x : Float) (e : Int) : Float :=
   if e ≥ 0 then floatMulPow2 x e.toNat else floatDivPow2 x (-e).toNat
 
+/-- Exponent after an explicit `p`/`e` separator; empty is malformed (`1e`). -/
 private def parseDecExp (s : String) : Except Err Int :=
-  if s.isEmpty then .ok 0
-  else
-    let (neg, body) :=
-      if s.startsWith "-" then (true, (s.drop 1).toString)
-      else if s.startsWith "+" then (false, (s.drop 1).toString)
-      else (false, s)
-    match body.toNat? with
-    | some n => .ok (if neg then -(Int.ofNat n) else Int.ofNat n)
-    | none   => .error s!"bad float exponent: {s}"
+  let (neg, body) :=
+    if s.startsWith "-" then (true, (s.drop 1).toString)
+    else if s.startsWith "+" then (false, (s.drop 1).toString)
+    else (false, s)
+  match body.toNat? with
+  | some n => .ok (if neg then -(Int.ofNat n) else Int.ofNat n)
+  | none   => .error s!"bad float exponent: {s}"
 
-/-- Magnitude of a hex float `INT[.FRAC][p±EXP]` (no `0x`, no sign). -/
+/-- Magnitude of a hex float `INT[.FRAC][p±EXP]` (no `0x`, no sign).
+
+A literal that fails to lex must be an error, not a plausible value: this
+parser also backs the runner's CLI float args, where garbage silently
+running as *some* float would mask typos (and fake agreement in
+differential runs). Hence one dot and one exponent at most — extra
+segments (`1.2.3`, `0x1p2p9`) are malformed, not silently dropped —
+an explicit exponent must be non-empty, and an unlexable mantissa is
+an error rather than 0. -/
 private def parseHexFloatMag (body : String) : Except Err Float := do
-  let (mant, expS) := match (body.replace "P" "p").splitOn "p" with
-    | [m]          => (m, "")
-    | m :: e :: _  => (m, e)
-    | []           => ("", "")
-  let (intH, fracH) := match mant.splitOn "." with
-    | [i]          => (i, "")
-    | i :: f :: _  => (i, f)
-    | []           => ("", "")
-  -- A mantissa that fails to lex must be an error, not 0: this parser also
-  -- backs the runner's CLI float args, where a garbage literal silently
-  -- running as 0.0 would mask typos (and fake agreement in differential runs).
+  let (mant, expS?) ← match (body.replace "P" "p").splitOn "p" with
+    | [m]     => .ok (m, none)
+    | [m, e]  => .ok (m, some e)
+    | _       => .error s!"bad hex float literal: 0x{body}"
+  let (intH, fracH) ← match mant.splitOn "." with
+    | [i]     => .ok (i, "")
+    | [i, f]  => .ok (i, f)
+    | _       => .error s!"bad hex float literal: 0x{body}"
   let some m := fromHexString? (intH ++ fracH)
     | .error s!"bad hex float literal: 0x{body}"
-  let e ← parseDecExp expS
+  let e ← match expS? with
+    | none      => pure 0
+    | some expS => parseDecExp expS
   .ok (floatScalePow2 (Float.ofNat m) (e - 4 * Int.ofNat fracH.length))
 
-/-- Magnitude of a decimal float `INT[.FRAC][e±EXP]` (no sign). -/
+/-- Magnitude of a decimal float `INT[.FRAC][e±EXP]` (no sign). Same
+strictness rules as `parseHexFloatMag`. -/
 private def parseDecFloatMag (body : String) : Except Err Float := do
-  let (mant, expS) := match (body.replace "E" "e").splitOn "e" with
-    | [m]          => (m, "")
-    | m :: e :: _  => (m, e)
-    | []           => ("", "")
-  let (intP, fracP) := match mant.splitOn "." with
-    | [i]          => (i, "")
-    | i :: f :: _  => (i, f)
-    | []           => ("", "")
-  -- Same strictness rationale as `parseHexFloatMag`: garbage must not be 0.
+  let (mant, expS?) ← match (body.replace "E" "e").splitOn "e" with
+    | [m]     => .ok (m, none)
+    | [m, e]  => .ok (m, some e)
+    | _       => .error s!"bad float literal: {body}"
+  let (intP, fracP) ← match mant.splitOn "." with
+    | [i]     => .ok (i, "")
+    | [i, f]  => .ok (i, f)
+    | _       => .error s!"bad float literal: {body}"
   let some m := (intP ++ fracP).toNat?
     | .error s!"bad float literal: {body}"
-  let de ← parseDecExp expS
+  let de ← match expS? with
+    | none      => pure 0
+    | some expS => parseDecExp expS
   let exp := de - Int.ofNat fracP.length
   .ok (Float.ofScientific m (exp < 0) exp.natAbs)
 

--- a/justfile
+++ b/justfile
@@ -113,6 +113,18 @@ testsuite pattern="":
 testsuite-report:
     WASM_TOOLS_VERSION={{ quote(WASM_TOOLS_VERSION) }} scripts/testsuite-report.sh
 
+# ── differential ──────────────────────────────────────────────────────────────
+
+# Differential-test the runner against a trusted oracle (V8) via @jasisz's miscast.
+# Drives the runner as miscast's custom system-under-test; a SOUNDNESS row is the
+# runner accepting or running a module every oracle rejects or traps on (see #108).
+# With no args, runs the recgroup soundness mode; anything passed goes through to
+# miscast, e.g. `just differential --mode recgroup -n 300`.
+[group("differential")]
+[working-directory(ROOT)]
+differential *args:
+    scripts/differential.sh {{ args }}
+
 # ── verifier workflow ─────────────────────────────────────────────────────────
 # All verifier recipes run from programs/ (project root: rust/ + lean/).
 # Omit crate names to operate on all workspace crates.

--- a/scripts/differential.sh
+++ b/scripts/differential.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Differential-test the runner against a trusted oracle (V8) using miscast.
+#
+# miscast (@jasisz) generates or replays WebAssembly modules — GC included — runs
+# each on the runner and on V8, and reports a SOUNDNESS divergence when the runner
+# accepts or runs something V8 rejects or traps on. See cajal-technologies/talos#108.
+#
+# The runner speaks miscast's verdict contract directly, with no adapter: a value
+# on stdout reads as a result, a `trap:` line reads as a trap, and out-of-fuel
+# (exit 2, empty stdout) reads as unsupported — never a false divergence.
+#
+# Usage:
+#   just differential                                  # recgroup soundness mode, V8 oracle
+#   just differential --mode recgroup -n 300           # reproduce the full #108 cluster
+#   just differential --mode mutate --seeds differential/seeds
+#
+# Env:
+#   MISCAST_DIR=/path/to/miscast   use an existing checkout instead of the pinned clone
+#   SKIP_BUILD=1                   skip `lake build runner` (assume it is already built)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# miscast is pinned as an external dependency (not vendored) so it can evolve upstream.
+MISCAST_REPO="https://github.com/jasisz/miscast"
+MISCAST_REV="125d25b69b20462fe03505b30eb281851f0be3a8"
+CACHE="$ROOT/.differential-cache"
+
+# ── dependencies ──────────────────────────────────────────────────────────────
+for tool in python3 wasm-tools node git; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "differential: '$tool' not on PATH" >&2; exit 127; }
+done
+node_major=$(node -p 'process.versions.node.split(".")[0]')   # V8/WasmGC oracle needs node >= 22
+if (( node_major < 22 )); then
+    echo "differential: node >= 22 required for the V8 oracle (have $(node --version))" >&2
+    exit 1
+fi
+
+# ── miscast (pinned) ──────────────────────────────────────────────────────────
+if [[ -n "${MISCAST_DIR:-}" ]]; then
+    miscast="$(cd "$MISCAST_DIR" && pwd)"
+else
+    miscast="$CACHE/miscast"
+    if [[ ! -d "$miscast/.git" ]]; then
+        echo "differential: fetching miscast @ ${MISCAST_REV:0:12} …"
+        mkdir -p "$CACHE"
+        git clone -q "$MISCAST_REPO" "$miscast"
+    fi
+    git -C "$miscast" checkout -q "$MISCAST_REV" 2>/dev/null \
+        || { git -C "$miscast" fetch -q origin && git -C "$miscast" checkout -q "$MISCAST_REV"; }
+fi
+
+# ── build the runner (the system under test) ──────────────────────────────────
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+    ( cd "$ROOT/interpreter" && lake build runner )
+fi
+RUNNER="$ROOT/interpreter/.lake/build/bin/runner"
+[[ -x "$RUNNER" ]] || { echo "differential: runner not built at $RUNNER" >&2; exit 1; }
+
+# The runner reads .wat directly and takes `<file> <method> [args]`, exactly
+# miscast's {wat} {export} plus positional invoke args — so it plugs in unwrapped.
+export CUSTOM_CMD="$RUNNER {wat} {export}"
+
+# Resolve a relative `--seeds PATH` (relative to ROOT) to absolute, since miscast
+# runs from its own directory below.
+args=()
+while (( $# )); do
+    if [[ "$1" == "--seeds" && -n "${2:-}" && "$2" != /* ]]; then
+        args+=("--seeds" "$ROOT/$2"); shift 2; continue
+    fi
+    args+=("$1"); shift
+done
+# Default: the recgroup soundness mode that pins #108.
+(( ${#args[@]} )) || args=(--mode recgroup -n 50)
+
+cd "$miscast"
+echo "differential: runner   = $RUNNER"
+echo "differential: miscast  = $(git rev-parse --short HEAD)   oracle = v8 (node $(node --version))"
+python3 -B -m miscast --sut custom --oracles v8 "${args[@]}"
+echo "differential: reproducers under $miscast/work/repro/"

--- a/scripts/differential.sh
+++ b/scripts/differential.sh
@@ -6,8 +6,11 @@
 # accepts or runs something V8 rejects or traps on. See cajal-technologies/talos#108.
 #
 # The runner speaks miscast's verdict contract directly, with no adapter: a value
-# on stdout reads as a result, a `trap:` line reads as a trap, and out-of-fuel
-# (exit 2, empty stdout) reads as unsupported — never a false divergence.
+# on stdout reads as a result, a `trap:` line reads as a trap (including an
+# uncaught exception), float args take the same WAT literal grammar V8 sees, and
+# out-of-fuel (exit 2, empty stdout) reads as unsupported — never a false
+# divergence. (miscast also ships tools/talos_run.py, an adapter predating this
+# alignment; driving the runner directly keeps the contract in one place.)
 #
 # Usage:
 #   just differential                                  # recgroup soundness mode, V8 oracle
@@ -27,14 +30,9 @@ MISCAST_REV="125d25b69b20462fe03505b30eb281851f0be3a8"
 CACHE="$ROOT/.differential-cache"
 
 # ── dependencies ──────────────────────────────────────────────────────────────
-for tool in python3 wasm-tools node git; do
+for tool in python3 wasm-tools git; do
     command -v "$tool" >/dev/null 2>&1 || { echo "differential: '$tool' not on PATH" >&2; exit 127; }
 done
-node_major=$(node -p 'process.versions.node.split(".")[0]')   # V8/WasmGC oracle needs node >= 22
-if (( node_major < 22 )); then
-    echo "differential: node >= 22 required for the V8 oracle (have $(node --version))" >&2
-    exit 1
-fi
 
 # ── miscast (pinned) ──────────────────────────────────────────────────────────
 if [[ -n "${MISCAST_DIR:-}" ]]; then
@@ -50,6 +48,16 @@ else
         || { git -C "$miscast" fetch -q origin && git -C "$miscast" checkout -q "$MISCAST_REV"; }
 fi
 
+# ── node (the V8/WasmGC oracle, >= 22) ────────────────────────────────────────
+# Ask miscast's own discovery (PATH or ~/.nvm, `NODE` env override) rather than
+# re-implementing it: the gate then tests exactly the binary the oracle will use.
+NODE_BIN="$(cd "$miscast" && python3 -c 'from miscast.config import NODE; print(NODE or "")')"
+if [[ -z "$NODE_BIN" ]]; then
+    echo "differential: no node >= 22 found (PATH or ~/.nvm) — required for the V8 oracle" >&2
+    exit 1
+fi
+export NODE="$NODE_BIN"   # pin the run to the binary we just gated on
+
 # ── build the runner (the system under test) ──────────────────────────────────
 if [[ -z "${SKIP_BUILD:-}" ]]; then
     ( cd "$ROOT/interpreter" && lake build runner )
@@ -59,15 +67,25 @@ RUNNER="$ROOT/interpreter/.lake/build/bin/runner"
 
 # The runner reads .wat directly and takes `<file> <method> [args]`, exactly
 # miscast's {wat} {export} plus positional invoke args — so it plugs in unwrapped.
-export CUSTOM_CMD="$RUNNER {wat} {export}"
+# miscast shlex-splits this template, so the quotes keep a runner path that
+# contains spaces as one argv word.
+export CUSTOM_CMD="\"$RUNNER\" {wat} {export}"
 
-# Resolve a relative `--seeds PATH` (relative to ROOT) to absolute, since miscast
-# runs from its own directory below.
+# Resolve a relative `--seeds PATH` / `--seeds=PATH` (relative to ROOT) to
+# absolute, since miscast runs from its own directory below.
 args=()
 while (( $# )); do
-    if [[ "$1" == "--seeds" && -n "${2:-}" && "$2" != /* ]]; then
-        args+=("--seeds" "$ROOT/$2"); shift 2; continue
-    fi
+    case "$1" in
+        --seeds)
+            if [[ -n "${2:-}" && "$2" != /* ]]; then
+                args+=("--seeds" "$ROOT/$2"); shift 2; continue
+            fi ;;
+        --seeds=*)
+            v="${1#--seeds=}"
+            if [[ -n "$v" && "$v" != /* ]]; then
+                args+=("--seeds=$ROOT/$v"); shift; continue
+            fi ;;
+    esac
     args+=("$1"); shift
 done
 # Default: the recgroup soundness mode that pins #108.
@@ -75,6 +93,6 @@ done
 
 cd "$miscast"
 echo "differential: runner   = $RUNNER"
-echo "differential: miscast  = $(git rev-parse --short HEAD)   oracle = v8 (node $(node --version))"
+echo "differential: miscast  = $(git rev-parse --short HEAD)   oracle = v8 (node $("$NODE_BIN" --version))"
 python3 -B -m miscast --sut custom --oracles v8 "${args[@]}"
 echo "differential: reproducers under $miscast/work/repro/"

--- a/scripts/differential.sh
+++ b/scripts/differential.sh
@@ -7,15 +7,16 @@
 #
 # The runner speaks miscast's verdict contract directly, with no adapter: a value
 # on stdout reads as a result, a `trap:` line reads as a trap (including an
-# uncaught exception), float args take the same WAT literal grammar V8 sees, and
-# out-of-fuel (exit 2, empty stdout) reads as unsupported — never a false
-# divergence. (miscast also ships tools/talos_run.py, an adapter predating this
+# uncaught exception), and out-of-fuel (exit 2, empty stdout) reads as
+# unsupported — never a false divergence. Invoke arguments are i32/i64 only
+# (miscast skips float- and ref-arg actions upstream), read as plain integers on
+# both sides. (miscast also ships tools/talos_run.py, an adapter predating this
 # alignment; driving the runner directly keeps the contract in one place.)
 #
 # The contract is enforced, not assumed: every run starts with canaries that
-# probe the runner's actual output against miscast's own classification regexes
-# (see "contract canaries" below), and lints the seed corpus for the export-"f"
-# convention its loader requires.
+# probe the runner's actual output against miscast's own classification regexes,
+# and lints the seed corpus with miscast's own export detection (see "contract
+# canaries" below).
 #
 # Usage:
 #   just differential                                  # recgroup soundness mode, V8 oracle
@@ -44,16 +45,6 @@ done
 command -v node >/dev/null 2>&1 || [[ -n "${NODE:-}" ]] || [[ -d "$HOME/.nvm/versions/node" ]] \
     || { echo "differential: node not found (PATH, ~/.nvm, or NODE=) — required for the V8 oracle" >&2; exit 1; }
 
-# ── seed-corpus lint ──────────────────────────────────────────────────────────
-# miscast's corpus loader drives a bare .wat through the export named "f"; a
-# seed exporting anything else is silently skipped by the seed-driven modes.
-bad="$(grep -L -F '(export "f"' "$ROOT"/differential/seeds/*.wat 2>/dev/null || true)"
-if [[ -n "$bad" ]]; then
-    echo "differential: seeds must export their entry point as \"f\" (miscast's corpus convention):" >&2
-    echo "$bad" >&2
-    exit 1
-fi
-
 # ── miscast (pinned) ──────────────────────────────────────────────────────────
 if [[ -n "${MISCAST_DIR:-}" ]]; then
     miscast="$(cd "$MISCAST_DIR" && pwd)"
@@ -71,12 +62,17 @@ fi
 # ── node (the V8/WasmGC oracle, >= 22) ────────────────────────────────────────
 # Ask miscast's own discovery (PATH or ~/.nvm, `NODE` env override) rather than
 # re-implementing it: the gate then tests exactly the binary the oracle will use.
+# This is a separate (small) python launch from the canaries below on purpose —
+# it must run BEFORE the lake build so a node-less machine fails fast; exporting
+# NODE makes every later miscast import skip discovery and reuse this binary.
 NODE_BIN="$(cd "$miscast" && python3 -c 'from miscast.config import NODE; print(NODE or "")')"
 [[ -n "$NODE_BIN" ]] || { echo "differential: no node >= 22 found (PATH or ~/.nvm) — required for the V8 oracle" >&2; exit 1; }
 # find_node only returns >= 22, but a `NODE=` override reaches here unchecked —
-# gate it too, and catch a path that isn't runnable at all.
+# gate it too, and catch a path that isn't runnable (or isn't really node).
 node_major="$("$NODE_BIN" -p 'process.versions.node.split(".")[0]' 2>/dev/null)" \
     || { echo "differential: cannot run node at $NODE_BIN" >&2; exit 1; }
+[[ "$node_major" =~ ^[0-9]+$ ]] \
+    || { echo "differential: cannot parse a node version out of $NODE_BIN (got '$node_major')" >&2; exit 1; }
 if (( node_major < 22 )); then
     echo "differential: node >= 22 required for the V8 oracle ($NODE_BIN is $("$NODE_BIN" --version))" >&2
     exit 1
@@ -117,30 +113,41 @@ done
 
 cd "$miscast"
 
-# ── contract canaries ─────────────────────────────────────────────────────────
+# ── contract canaries + seed lint ─────────────────────────────────────────────
 # The no-adapter design couples the runner's output vocabulary to miscast's
-# classification regexes. That coupling is easy to break silently (a reworded
-# error message, a dropped `trap:` prefix), so probe it with the real regexes
-# before every run:
+# classification regexes, and the seed corpus to miscast's export detection.
+# Both couplings are easy to break silently (a reworded error message, a
+# dropped `trap:` prefix, a wrongly named export), so probe them with the real
+# regexes before every run:
+#   (0) a trivial module must run and print its value — separates a stale or
+#       broken runner build from a genuine contract regression;
 #   (a) a CLI arg-count complaint must NOT read as validator rejection or trap
 #       (else the validation differential records false REJECT agreement);
 #   (b) an uncaught exception must read as a trap (matching V8);
 #   (c) a garbage float arg must fail the run (empty stdout, no trap) — never
-#       parse as 0.0 and fake a comparable result.
+#       parse as a plausible value and fake a comparable result;
+#   (d) every seed must expose a func export named "f" — miscast's corpus
+#       loader drives exactly that; anything else is silently skipped.
 canary_dir="$(mktemp -d "${TMPDIR:-/tmp}/differential-canary.XXXXXX")"
 trap 'rm -rf "$canary_dir"' EXIT
+printf '(module (func (export "f") (result i32) i32.const 7))'                 > "$canary_dir/ok.wat"
 printf '(module (func (export "f") (param i32 i32) (result i32) local.get 0))' > "$canary_dir/args.wat"
 printf '(module (tag $t) (func (export "f") (throw $t)))'                      > "$canary_dir/exn.wat"
 printf '(module (func (export "f") (param f64) (result f64) local.get 0))'     > "$canary_dir/flt.wat"
-python3 - "$RUNNER" "$canary_dir" <<'EOF'
-import subprocess, sys
-from miscast.engines import _VALERR, _TRAP, _CRASH, _NUM
+python3 - "$RUNNER" "$canary_dir" "$ROOT/differential/seeds" <<'EOF'
+import glob, subprocess, sys
+from miscast.engines import _VALERR, _TRAP, _CRASH, _NUM, _EXPORT_RE, _FUNCEXPORT_RE
 
-runner, d = sys.argv[1], sys.argv[2]
+runner, d, seeds = sys.argv[1], sys.argv[2], sys.argv[3]
 
 def run(*argv):
     r = subprocess.run([runner, *argv], capture_output=True, text=True)
     return r, r.stdout + r.stderr
+
+r, both = run(f"{d}/ok.wat", "f")                         # (0) trivial module runs
+if r.returncode != 0 or r.stdout.strip() != "7":
+    sys.exit("differential: canary: runner cannot execute a trivial module — "
+             f"stale or broken build? (re-run without SKIP_BUILD=1)\n  output: {both.strip()!r}")
 
 r, both = run(f"{d}/args.wat", "f")                       # (a) arg-count wording
 if _VALERR.search(both) or _TRAP.search(both) or _CRASH.search(both):
@@ -153,6 +160,12 @@ if not _TRAP.search(both):
 r, both = run(f"{d}/flt.wat", "f", "not-a-float")         # (c) garbage float arg
 if r.returncode == 0 or _NUM.match(r.stdout.strip()) or _TRAP.search(both):
     sys.exit(f"differential: canary: garbage float arg did not fail cleanly: {both.strip()!r}")
+
+for p in sorted(glob.glob(f"{seeds}/*.wat")):             # (d) seed export convention
+    wat = open(p).read()
+    if "f" not in set(_EXPORT_RE.findall(wat)) | set(_FUNCEXPORT_RE.findall(wat)):
+        sys.exit(f"differential: seed {p} has no func export named \"f\" "
+                 "(miscast's corpus convention) — the seed-driven modes would silently skip it")
 EOF
 
 echo "differential: runner   = $RUNNER"

--- a/scripts/differential.sh
+++ b/scripts/differential.sh
@@ -12,6 +12,11 @@
 # divergence. (miscast also ships tools/talos_run.py, an adapter predating this
 # alignment; driving the runner directly keeps the contract in one place.)
 #
+# The contract is enforced, not assumed: every run starts with canaries that
+# probe the runner's actual output against miscast's own classification regexes
+# (see "contract canaries" below), and lints the seed corpus for the export-"f"
+# convention its loader requires.
+#
 # Usage:
 #   just differential                                  # recgroup soundness mode, V8 oracle
 #   just differential --mode recgroup -n 300           # reproduce the full #108 cluster
@@ -19,6 +24,7 @@
 #
 # Env:
 #   MISCAST_DIR=/path/to/miscast   use an existing checkout instead of the pinned clone
+#   NODE=/path/to/node             override oracle node discovery (still gated to >= 22)
 #   SKIP_BUILD=1                   skip `lake build runner` (assume it is already built)
 set -euo pipefail
 
@@ -33,6 +39,20 @@ CACHE="$ROOT/.differential-cache"
 for tool in python3 wasm-tools git; do
     command -v "$tool" >/dev/null 2>&1 || { echo "differential: '$tool' not on PATH" >&2; exit 127; }
 done
+# Fail fast (before any clone) when node is nowhere to be found. The
+# authoritative version gate runs below, via miscast's own discovery.
+command -v node >/dev/null 2>&1 || [[ -n "${NODE:-}" ]] || [[ -d "$HOME/.nvm/versions/node" ]] \
+    || { echo "differential: node not found (PATH, ~/.nvm, or NODE=) — required for the V8 oracle" >&2; exit 1; }
+
+# ── seed-corpus lint ──────────────────────────────────────────────────────────
+# miscast's corpus loader drives a bare .wat through the export named "f"; a
+# seed exporting anything else is silently skipped by the seed-driven modes.
+bad="$(grep -L -F '(export "f"' "$ROOT"/differential/seeds/*.wat 2>/dev/null || true)"
+if [[ -n "$bad" ]]; then
+    echo "differential: seeds must export their entry point as \"f\" (miscast's corpus convention):" >&2
+    echo "$bad" >&2
+    exit 1
+fi
 
 # ── miscast (pinned) ──────────────────────────────────────────────────────────
 if [[ -n "${MISCAST_DIR:-}" ]]; then
@@ -52,8 +72,13 @@ fi
 # Ask miscast's own discovery (PATH or ~/.nvm, `NODE` env override) rather than
 # re-implementing it: the gate then tests exactly the binary the oracle will use.
 NODE_BIN="$(cd "$miscast" && python3 -c 'from miscast.config import NODE; print(NODE or "")')"
-if [[ -z "$NODE_BIN" ]]; then
-    echo "differential: no node >= 22 found (PATH or ~/.nvm) — required for the V8 oracle" >&2
+[[ -n "$NODE_BIN" ]] || { echo "differential: no node >= 22 found (PATH or ~/.nvm) — required for the V8 oracle" >&2; exit 1; }
+# find_node only returns >= 22, but a `NODE=` override reaches here unchecked —
+# gate it too, and catch a path that isn't runnable at all.
+node_major="$("$NODE_BIN" -p 'process.versions.node.split(".")[0]' 2>/dev/null)" \
+    || { echo "differential: cannot run node at $NODE_BIN" >&2; exit 1; }
+if (( node_major < 22 )); then
+    echo "differential: node >= 22 required for the V8 oracle ($NODE_BIN is $("$NODE_BIN" --version))" >&2
     exit 1
 fi
 export NODE="$NODE_BIN"   # pin the run to the binary we just gated on
@@ -71,20 +96,19 @@ RUNNER="$ROOT/interpreter/.lake/build/bin/runner"
 # contains spaces as one argv word.
 export CUSTOM_CMD="\"$RUNNER\" {wat} {export}"
 
-# Resolve a relative `--seeds PATH` / `--seeds=PATH` (relative to ROOT) to
-# absolute, since miscast runs from its own directory below.
+# Resolve `--seeds PATH` / `--seeds=PATH` (relative to ROOT) to an absolute
+# existing directory, since miscast runs from its own directory below. An empty
+# or missing path must fail loudly here — passed through, miscast would glob an
+# empty corpus and report a green files=0 run.
 args=()
 while (( $# )); do
     case "$1" in
-        --seeds)
-            if [[ -n "${2:-}" && "$2" != /* ]]; then
-                args+=("--seeds" "$ROOT/$2"); shift 2; continue
-            fi ;;
-        --seeds=*)
-            v="${1#--seeds=}"
-            if [[ -n "$v" && "$v" != /* ]]; then
-                args+=("--seeds=$ROOT/$v"); shift; continue
-            fi ;;
+        --seeds|--seeds=*)
+            if [[ "$1" == --seeds ]]; then p="${2:-}"; n=2; else p="${1#--seeds=}"; n=1; fi
+            [[ -n "$p" ]] || { echo "differential: --seeds needs a path" >&2; exit 2; }
+            [[ "$p" == /* ]] || p="$ROOT/$p"
+            [[ -d "$p" ]] || { echo "differential: seeds directory not found: $p" >&2; exit 2; }
+            args+=("--seeds" "$p"); shift "$n"; continue ;;
     esac
     args+=("$1"); shift
 done
@@ -92,6 +116,45 @@ done
 (( ${#args[@]} )) || args=(--mode recgroup -n 50)
 
 cd "$miscast"
+
+# ── contract canaries ─────────────────────────────────────────────────────────
+# The no-adapter design couples the runner's output vocabulary to miscast's
+# classification regexes. That coupling is easy to break silently (a reworded
+# error message, a dropped `trap:` prefix), so probe it with the real regexes
+# before every run:
+#   (a) a CLI arg-count complaint must NOT read as validator rejection or trap
+#       (else the validation differential records false REJECT agreement);
+#   (b) an uncaught exception must read as a trap (matching V8);
+#   (c) a garbage float arg must fail the run (empty stdout, no trap) — never
+#       parse as 0.0 and fake a comparable result.
+canary_dir="$(mktemp -d "${TMPDIR:-/tmp}/differential-canary.XXXXXX")"
+trap 'rm -rf "$canary_dir"' EXIT
+printf '(module (func (export "f") (param i32 i32) (result i32) local.get 0))' > "$canary_dir/args.wat"
+printf '(module (tag $t) (func (export "f") (throw $t)))'                      > "$canary_dir/exn.wat"
+printf '(module (func (export "f") (param f64) (result f64) local.get 0))'     > "$canary_dir/flt.wat"
+python3 - "$RUNNER" "$canary_dir" <<'EOF'
+import subprocess, sys
+from miscast.engines import _VALERR, _TRAP, _CRASH, _NUM
+
+runner, d = sys.argv[1], sys.argv[2]
+
+def run(*argv):
+    r = subprocess.run([runner, *argv], capture_output=True, text=True)
+    return r, r.stdout + r.stderr
+
+r, both = run(f"{d}/args.wat", "f")                       # (a) arg-count wording
+if _VALERR.search(both) or _TRAP.search(both) or _CRASH.search(both):
+    sys.exit(f"differential: canary: arg-count wording matches miscast rejection/trap vocabulary: {both.strip()!r}")
+
+r, both = run(f"{d}/exn.wat", "f")                        # (b) uncaught exception
+if not _TRAP.search(both):
+    sys.exit(f"differential: canary: uncaught exception does not read as a trap: {both.strip()!r}")
+
+r, both = run(f"{d}/flt.wat", "f", "not-a-float")         # (c) garbage float arg
+if r.returncode == 0 or _NUM.match(r.stdout.strip()) or _TRAP.search(both):
+    sys.exit(f"differential: canary: garbage float arg did not fail cleanly: {both.strip()!r}")
+EOF
+
 echo "differential: runner   = $RUNNER"
 echo "differential: miscast  = $(git rev-parse --short HEAD)   oracle = v8 (node $("$NODE_BIN" --version))"
 python3 -B -m miscast --sut custom --oracles v8 "${args[@]}"


### PR DESCRIPTION
Part of #107 — the runnable harness. The CI gate follows as a second PR, as discussed in the thread.

Adds `just differential`, which keeps the runner in parity with a trusted oracle (V8) by driving it as the custom system-under-test for [@jasisz](https://github.com/jasisz)'s [miscast](https://github.com/jasisz/miscast), and flags divergences — above all **soundness**, where the runner accepts or runs a module every oracle rejects or traps on.

## Design

The runner plugs into miscast with **no adapter**: miscast invokes a custom SUT as `CUSTOM_CMD='<cmd> {wat} {export}'` and reads a value from stdout / a trap from a `trap:` line, which is exactly the runner's CLI and output contract. Out-of-fuel (exit 2, empty stdout) reads as unsupported, so it is never a false divergence.

miscast is pinned as an external dependency (a rev in `scripts/differential.sh`), not vendored. The first run clones it into `.differential-cache/` (gitignored); set `MISCAST_DIR=` to use a local checkout.

## What it turns up

- **#108 looks fixed.** The seed `differential/seeds/recgroup_callindirect.wat` (the minimal reordered-rec-group `call_indirect`) now traps with `indirect call type mismatch`, agreeing with V8. It is kept as a regression guard.
- **A full sweep (`just differential --mode all`) surfaces 27 candidate soundness divergences** of the #95 / #108 class — the runner accepts and runs spec-invalid modules that both V8 and `wasm-tools validate` reject — clustering into ~6 families: subtyping/variance, const-init typing, result/arity, array/table reftype ops, exception-handler typing, and `ref.test`/`br_on_cast`. I hand-checked three; all accept and run. Each is reproducible from the harness.

  Happy to fold these into a known-divergence baseline for the CI gate, or file the sharpest as individual issues — whichever you prefer.

## Contents

- `scripts/differential.sh` — build the runner, pin miscast, run against V8
- `differential/seeds/recgroup_callindirect.wat` — minimal #108 reproducer, now a regression guard
- `differential/README.md`, a `just differential` recipe, a `CONTRIBUTING.md` section, and a `.gitignore` entry

## Requirements

`wasm-tools` and `node` >= 22 (the V8 / WasmGC oracle).
