### PR TITLE
codelib: host-call Iris rules

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -38,6 +38,7 @@ import CodeLib.SepLogic.SmallStepLanguage
 import CodeLib.SepLogic.SmallStepState
 import CodeLib.SepLogic.SmallStepLifting
 import CodeLib.SepLogic.SmallStepAdequacy
+import CodeLib.SepLogic.HostCallExample
 
 /-!
 # CodeLib — umbrella import for downstream code

--- a/codelib/CodeLib/SepLogic/HostCallExample.lean
+++ b/codelib/CodeLib/SepLogic/HostCallExample.lean
@@ -1,0 +1,153 @@
+import CodeLib.SepLogic.SmallStepAdequacy
+
+namespace Wasm.SmallStep
+
+open Iris Iris.BI Iris.ProgramLogic OFE COFE Iris.Algebra
+  Language.Notation Std Wasm.SepLogic
+
+-- host import: takes (addr : i32, val : i32), writes val.toUInt8 to memory[addr]
+def writeByteHost : HostFn Unit where
+  params  := [.i32, .i32]
+  results := []
+  invoke  := fun wasmStore args =>
+    match args with
+    | [.i32 addr, .i32 val] =>
+      .Return [] { wasmStore with mem := wasmStore.mem.write8 addr val.toUInt8 }
+    | _ => .Trap wasmStore "writeByteHost: bad args"
+
+private abbrev writeByteImp : ImportDecl :=
+  { module := "", name := "writeByte", params := [.i32, .i32], results := [] }
+
+def writeByteModule : Module where
+  funcs   := []
+  imports := [writeByteImp]
+
+def writeByteRuntime : RuntimeEnv Unit where
+  module := writeByteModule
+  host   := { funcs := [writeByteHost] }
+
+def writeByteInitStore : Store Unit where
+  globals := { globals := [] }
+  mem     := Mem.empty 1
+  host    := ()
+
+-- stack [.i32 42, .i32 0]: val=42 on top, addr=0 below
+-- (values.take 2).reverse = [.i32 0, .i32 42] -> addr=0, val=42
+def writeByteConfig : Config Unit :=
+  { expr := .running
+      { locals := { values := [.i32 42, .i32 0] }
+        code := [.call 0], resultArity := 0, callerRemainder := [] }
+    store := { runtime := writeByteRuntime, wasm := writeByteInitStore } }
+
+theorem writeByte_partiallyMeets :
+    PartiallyMeets writeByteConfig (fun values (store : MachineStore Unit) =>
+        values = [] ∧ store.wasm.mem.read8 0 = 42) := by
+  letI : WasmHostGS Unit := { knownHostEnv := some writeByteRuntime.host }
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+    (α := Unit)
+    (σ := insert ∅ 0 (some (0 : UInt8)))
+    (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := rfl)
+  · intro addr v hget
+    by_cases h : addr = 0
+    · subst h
+      rw [get?_insert_eq rfl] at hget
+      have hv := Option.some.inj (Option.some.inj hget)
+      subst hv
+      decide
+    · rw [get?_insert_ne (Ne.symm h), get?_empty] at hget
+      contradiction
+  · intro addr v hget
+    by_cases h : addr = 0
+    · subst h; decide
+    · rw [get?_insert_ne (Ne.symm h), get?_empty] at hget
+      contradiction
+  · exact globalHeapAgrees_empty _
+  · intro gs
+    simp only [(BI.BigSepM.bigSepM_insert (get?_empty (0 : UInt32))).to_eq,
+               BI.BigSepM.bigSepM_empty.to_eq, BI.sep_emp.to_eq]
+    iintro ⟨Hpt, _Hglobals, Hruntime⟩
+    simp only [writeByteConfig, writeByteRuntime]
+    have hpost : ∀ values : List Value,
+        (iprop% ⌜values = []⌝ ∗
+          pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+            0 (DFrac.own 1) (some (42 : UInt8))) ⊢
+        (iprop% ∀ (store : MachineStore Unit)
+            (_observations : List StepKind),
+          stateInterp (GF := WasmHeapGF) store 0 [] 0 -∗
+          ⌜values = [] ∧ store.wasm.mem.read8 0 = 42⌝) := by
+      intro values
+      iintro ⟨%hvalues, Hbyte⟩ %store %_observations Hstate
+      imod stateInterp_pointsTo_read8 store 0 [] 0 0 (42 : UInt8)
+          $$ [$Hstate $Hbyte] with %hread
+      ipureintro
+      exact ⟨hvalues, hread⟩
+    iapply (wp_mono hpost)
+    iapply wp_callHost writeByteModule 0 writeByteImp writeByteHost
+        (by simp [writeByteModule]) rfl writeByteRuntime.host rfl rfl
+        (iprop(pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          0 (DFrac.own 1) (some (0 : UInt8))))
+        (fun _ => iprop(pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          0 (DFrac.own 1) (some (42 : UInt8))))
+        (iprop(False))
+        (iprop(False))
+        -- ghost write: pointsTo 0 (some 0) ∗ stateInterp ==∗ pointsTo 0 (some 42) ∗ stateInterp'
+        (fun store ns obs nt _ results postWasm h => by
+          simp [writeByteHost] at h
+          obtain ⟨h1, h2⟩ := h
+          subst h1; subst h2
+          iintro ⟨Hpt, Hσ⟩
+          ihave %HinBounds :
+              ⌜(0 : UInt32).toNat < store.wasm.mem.pages * 65536⌝ $$ [Hσ Hpt]
+          · imod stateInterp_pointsTo_inBounds store ns obs nt 0 (0 : UInt8)
+                $$ [$Hσ $Hpt] with %HinBounds
+            ipureintro
+            exact HinBounds
+          imod stateInterp_store8 store ns obs nt (0 : UInt32) (0 : UInt8) (42 : UInt8)
+              (by exact HinBounds) $$ [$Hσ $Hpt] with ⟨Hσ, Hpt⟩
+          imodintro
+          isplitl [Hpt]
+          · iexact Hpt
+          · iexact Hσ)
+        -- trap: impossible with args [.i32 0, .i32 42]
+        (fun _ _ _ _ _ _ _ h => by simp [writeByteHost] at h)
+        -- throw: impossible
+        (fun _ _ _ _ _ _ _ _ h => by simp [writeByteHost] at h)
+        (s := Stuckness.NotStuck) (E := ⊤)
+        (params := []) (localValues := []) (values := [.i32 42, .i32 0])
+        (code := []) (arity := 0) (remainder := []) (controls := []) (calls := [])
+        $$ [$Hpt] Hruntime
+    -- return: QRet [] = pointsTo 0 (some 42); close Φ_simple
+    · inext
+      iintro %preWasm %results %postWasm %h HQ
+      simp only [List.take_zero, List.nil_append, List.length_cons,
+                 List.length_nil, List.drop]
+      iapply wp_finish
+      inext
+      iapply wp_value'
+      isplitr [HQ]
+      · ipureintro
+        rfl
+      · iexact HQ
+    -- trap: refuted by simp
+    · inext
+      iintro %preWasm %postWasm %msg %h _HQ
+      simp [writeByteHost] at h
+    -- throw: refuted by simp
+    · inext
+      iintro %preWasm %postWasm %tag %xs %h _HQ
+      simp [writeByteHost] at h
+
+theorem writeByte_terminates :
+    TerminatesWith writeByteConfig (fun _ _ => True) :=
+  runSteps_checked_terminates (fuel := 20)
+    (fun _ _ => true)
+    (by native_decide)
+    (fun _ _ _ => trivial)
+
+theorem writeByte_result :
+    TerminatesWith writeByteConfig (fun values (store : MachineStore Unit) =>
+        values = [] ∧ store.wasm.mem.read8 0 = 42) :=
+  TerminatesWith.of_termination_and_partial writeByte_terminates writeByte_partiallyMeets
+
+end Wasm.SmallStep

--- a/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
@@ -211,7 +211,7 @@ theorem wasm_smallStep_adequacy
       heapAddressesInBounds_empty _,
       globalHeapAgrees_empty _,
       dataSegmentHeapAgrees_empty _,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, trivial⟩⟩
   · exact hwp
 
 /-- Public relational partial-correctness form of closed small-step adequacy.
@@ -231,8 +231,11 @@ theorem wasm_smallStep_partiallyMeets
 /-- Closed adequacy with persistent knowledge of the concrete runtime module.
 This is the call-capable counterpart of `wasm_smallStep_adequacy`. -/
 theorem wasm_smallStep_runtime_adequacy
-    [WasmSmallStepGpreS]
+    [WasmSmallStepGpreS] [WasmHostGS α]
     (config : Config α) (φ : List Value → Prop)
+    (hhost : match WasmHostGS.knownHostEnv (α := α) with
+      | some h => config.store.runtime.host = h
+      | none => True)
     (hwp : ∀ [WasmSmallStepGS .hasLC],
       runtimeModuleOwn config.store.runtime.module ⊢
         WP config.expr @ Stuckness.NotStuck; ⊤
@@ -329,22 +332,25 @@ theorem wasm_smallStep_runtime_adequacy
       heapAddressesInBounds_empty _,
       globalHeapAgrees_empty _,
       dataSegmentHeapAgrees_empty _,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, hhost⟩⟩
   · iapply hwp
     unfold runtimeModuleOwn
     iexact HruntimeWP
 
 /-- Relational partial-correctness form of call-capable runtime adequacy. -/
 theorem wasm_smallStep_runtime_partiallyMeets
-    [WasmSmallStepGpreS]
+    [WasmSmallStepGpreS] [WasmHostGS α]
     (config : Config α) (φ : List Value → Prop)
+    (hhost : match WasmHostGS.knownHostEnv (α := α) with
+      | some h => config.store.runtime.host = h
+      | none => True)
     (hwp : ∀ [WasmSmallStepGS .hasLC],
       runtimeModuleOwn config.store.runtime.module ⊢
         WP config.expr @ Stuckness.NotStuck; ⊤
           {{ values, ⌜φ values⌝ }}) :
     PartiallyMeets config (fun values _store => φ values) :=
   adequate_to_partiallyMeets config (fun values _store => φ values)
-    (wasm_smallStep_runtime_adequacy config φ hwp)
+    (wasm_smallStep_runtime_adequacy config φ hhost hwp)
 
 /-- Adequacy with an explicit authoritative byte footprint. `genHeap_init`
 allocates both the authoritative map used by `StateInterp` and the matching
@@ -446,7 +452,7 @@ theorem wasm_smallStep_heap_adequacy
     exact ⟨hagree, hinBounds,
       globalHeapAgrees_empty _,
       dataSegmentHeapAgrees_empty _,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, trivial⟩⟩
   · iapply hwp
     iexact Hpoints
 
@@ -563,7 +569,7 @@ theorem wasm_smallStep_heap_globals_runtime_adequacy
     ipureintro
     exact ⟨hagree, hinBounds, hglobals,
       dataSegmentHeapAgrees_empty _,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, trivial⟩⟩
   · iapply hwp
     isplitl [Hpoints]
     · iexact Hpoints
@@ -578,7 +584,7 @@ wrapper above, the WP post receives the final physical state interpretation
 and may use its returned byte/global ownership to prove a predicate about the
 actual reached `MachineStore`. -/
 theorem wasm_smallStep_heap_globals_runtime_store_adequacy
-    [WasmSmallStepGpreS]
+    [WasmSmallStepGpreS] [WasmHostGS α]
     (config : Config α)
     (σ : WasmHeapMap (Option UInt8))
     (globalσ : WasmGlobalMap Value)
@@ -586,6 +592,9 @@ theorem wasm_smallStep_heap_globals_runtime_store_adequacy
     (hagree : heapAgreesWithMem σ config.store.wasm.mem)
     (hinBounds : heapAddressesInBounds σ config.store.wasm.mem)
     (hglobals : globalHeapAgrees globalσ config.store.wasm.globals)
+    (hhost : match WasmHostGS.knownHostEnv (α := α) with
+      | some h => config.store.runtime.host = h
+      | none => True)
     (hwp : ∀ [WasmSmallStepGS .hasLC],
       (([∗map] address ↦ value ∈ σ,
           pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
@@ -689,7 +698,7 @@ theorem wasm_smallStep_heap_globals_runtime_store_adequacy
     ipureintro
     exact ⟨hagree, hinBounds, hglobals,
       dataSegmentHeapAgrees_empty _,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, hhost⟩⟩
   · iapply hwp
     isplitl [Hpoints]
     · iexact Hpoints
@@ -702,7 +711,7 @@ theorem wasm_smallStep_heap_globals_runtime_store_adequacy
 /-- Relational partial-correctness form of state-sensitive authoritative
 adequacy. -/
 theorem wasm_smallStep_heap_globals_runtime_store_partiallyMeets
-    [WasmSmallStepGpreS]
+    [WasmSmallStepGpreS] [WasmHostGS α]
     (config : Config α)
     (σ : WasmHeapMap (Option UInt8))
     (globalσ : WasmGlobalMap Value)
@@ -710,6 +719,9 @@ theorem wasm_smallStep_heap_globals_runtime_store_partiallyMeets
     (hagree : heapAgreesWithMem σ config.store.wasm.mem)
     (hinBounds : heapAddressesInBounds σ config.store.wasm.mem)
     (hglobals : globalHeapAgrees globalσ config.store.wasm.globals)
+    (hhost : match WasmHostGS.knownHostEnv (α := α) with
+      | some h => config.store.runtime.host = h
+      | none => True)
     (hwp : ∀ [WasmSmallStepGS .hasLC],
       (([∗map] address ↦ value ∈ σ,
           pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
@@ -725,7 +737,7 @@ theorem wasm_smallStep_heap_globals_runtime_store_partiallyMeets
     PartiallyMeets config post :=
   adequate_to_partiallyMeets config post
     (wasm_smallStep_heap_globals_runtime_store_adequacy
-      config σ globalσ post hagree hinBounds hglobals hwp)
+      config σ globalσ post hagree hinBounds hglobals hhost hwp)
 
 /-- State-sensitive adequacy with explicit authoritative ownership of passive
 data-segment status in addition to memory, globals, and the runtime module. -/
@@ -846,7 +858,7 @@ theorem wasm_smallStep_heap_globals_segments_runtime_store_adequacy
     iframe
     ipureintro
     exact ⟨hagree, hinBounds, hglobals, hsegments,
-      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _, trivial⟩⟩
   · iapply hwp
     isplitl [Hpoints]
     · iexact Hpoints
@@ -1026,7 +1038,7 @@ theorem wasm_smallStep_heap_globals_segments_tables_runtime_store_adequacy
     iframe
     ipureintro
     exact ⟨hagree, hinBounds, hglobals, hsegments,
-      ⟨htables, helementSegments⟩⟩
+      ⟨htables, helementSegments, trivial⟩⟩
   · iapply hwp
     isplitl [Hpoints]
     · iexact Hpoints
@@ -1280,7 +1292,7 @@ theorem noopCall_adequate :
     adequate Stuckness.NotStuck noopCallConfig.expr noopCallConfig.store
       (fun values _ => values = []) := by
   apply wasm_smallStep_runtime_adequacy.{0} (α := Unit)
-    (φ := fun values => values = [])
+    (φ := fun values => values = []) (hhost := trivial)
   intro gs
   simp only [noopCallConfig]
   iintro Hruntime
@@ -1423,6 +1435,7 @@ theorem wordRoundtrip_store_partiallyMeets (oldWord : UInt32) :
     (α := Unit)
     (σ := word16Heap oldWord)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · unfold word16Heap
     apply store32_sound
       (σ := (∅ : WasmHeapMap (Option UInt8)))
@@ -1599,6 +1612,7 @@ theorem swapWords_store_partiallyMeets :
     (α := Unit)
     (σ := swapWordsHeap)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply swapWordsHeap_agrees
   · apply swapWordsHeap_inBounds
     native_decide
@@ -1728,6 +1742,7 @@ theorem reverseThreeWords_store_partiallyMeets :
     (α := Unit)
     (σ := reverseThreeWordsHeap)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply reverseThreeWordsHeap_agrees
   · apply reverseThreeWordsHeap_inBounds
     native_decide
@@ -1893,6 +1908,7 @@ theorem partitionThreeWords_store_partiallyMeets :
     (α := Unit)
     (σ := partitionThreeWordsHeap)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply partitionThreeWordsHeap_agrees
   · apply partitionThreeWordsHeap_inBounds
     native_decide
@@ -2046,6 +2062,7 @@ theorem mergeTwoWords_store_partiallyMeets :
     (α := Unit)
     (σ := mergeTwoWordsHeap)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply mergeTwoWordsHeap_agrees
   · apply mergeTwoWordsHeap_inBounds
     native_decide
@@ -2198,6 +2215,7 @@ theorem fillFourBytes_store_partiallyMeets (oldWord : UInt32) :
     (α := Unit)
     (σ := fillFourBytesHeap oldWord)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply fillFourBytesHeap_agrees
   · apply fillFourBytesHeap_inBounds
     native_decide
@@ -2336,6 +2354,7 @@ theorem copyWord_store_partiallyMeets (oldDestination : UInt32) :
     (α := Unit)
     (σ := copyWordHeap oldDestination)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply copyWordHeap_agrees
   · apply copyWordHeap_inBounds
     native_decide
@@ -2444,6 +2463,7 @@ theorem copyOverlapWord_store_partiallyMeets :
     (α := Unit)
     (σ := copyOverlapWordHeap)
     (globalσ := (∅ : WasmGlobalMap Value))
+    (hhost := trivial)
   · apply copyOverlapWordHeap_agrees
   · apply copyOverlapWordHeap_inBounds
     native_decide

--- a/codelib/CodeLib/SepLogic/SmallStepLifting.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepLifting.lean
@@ -13,7 +13,7 @@ namespace Wasm.SmallStep
 open Iris Iris.ProgramLogic Language.Notation
 open Wasm.SepLogic
 
-variable [WasmSmallStepGS hlc]
+variable [WasmSmallStepGS hlc] [WasmHostGS α]
 local instance instWasmIrisGS :
     IrisGS_gen hlc (Expr α) WasmHeapGF :=
   instIrisGS
@@ -1216,6 +1216,226 @@ theorem wp_call
   · iapply Hwp
     iexact Hruntime
   · itrivial
+
+/-- Execute an imported (host) function call.
+`runtimeModule` and `hhostFn` tie the proof-time host function to the
+physical store seen by `PrimStep`. `P` is a ghost resource consumed by the
+host, and `QRet`/`QTrap`/`QThrow` are the resources delivered to each
+continuation. The three transfer lemmas are `==∗` proofs that shuttle
+`P ∗ stateInterp` through the host's store update for each outcome. -/
+theorem wp_callHost
+    (runtimeModule : Module) (functionIndex : Nat) (imp : ImportDecl)
+    (hostFn : HostFn α)
+    (himports : functionIndex < runtimeModule.imports.length)
+    (himp : runtimeModule.imports[functionIndex] = imp)
+    (hostEnv : HostEnv α)
+    (hhostFn : WasmHostGS.knownHostEnv (α := α) = some hostEnv)
+    (hfuncs : hostEnv.funcs[functionIndex]? = some hostFn)
+    {params localValues values : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (P : IProp WasmHeapGF)
+    (QRet : List Value → IProp WasmHeapGF)
+    (QTrap : IProp WasmHeapGF)
+    (QThrow : IProp WasmHeapGF)
+    (hRetTransfer : ∀ (store : MachineStore α) (ns : Nat)
+        (obs : List StepKind) (nt : Nat),
+        store.runtime.module = runtimeModule →
+        ∀ results postWasm,
+        hostFn.invoke store.wasm (values.take imp.params.length).reverse =
+          .Return results postWasm →
+        P ∗ stateInterp (GF := WasmHeapGF) store ns obs nt ==∗
+        QRet results ∗
+        stateInterp (GF := WasmHeapGF) { store with wasm := postWasm } ns obs nt)
+    (hTrapTransfer : ∀ (store : MachineStore α) (ns : Nat)
+        (obs : List StepKind) (nt : Nat),
+        store.runtime.module = runtimeModule →
+        ∀ postWasm msg,
+        hostFn.invoke store.wasm (values.take imp.params.length).reverse =
+          .Trap postWasm msg →
+        P ∗ stateInterp (GF := WasmHeapGF) store ns obs nt ==∗
+        QTrap ∗
+        stateInterp (GF := WasmHeapGF) { store with wasm := postWasm } ns obs nt)
+    (hThrowTransfer : ∀ (store : MachineStore α) (ns : Nat)
+        (obs : List StepKind) (nt : Nat),
+        store.runtime.module = runtimeModule →
+        ∀ postWasm tag xs,
+        hostFn.invoke store.wasm (values.take imp.params.length).reverse =
+          .Throw postWasm tag xs →
+        P ∗ stateInterp (GF := WasmHeapGF) store ns obs nt ==∗
+        QThrow ∗
+        stateInterp (GF := WasmHeapGF) { store with wasm := postWasm } ns obs nt) :
+    let current : ThreadState α :=
+      ⟨⟨params, localValues, values⟩, .call functionIndex :: code,
+        arity, remainder, controls, calls⟩
+    P -∗
+    ▷ runtimeModuleOwn runtimeModule -∗
+    ▷ (∀ preWasm results postWasm
+          (_h : hostFn.invoke preWasm (values.take imp.params.length).reverse =
+            .Return results postWasm),
+        QRet results -∗
+        WP (Expr.running
+            ⟨⟨params, localValues,
+                results.take imp.results.length ++
+                  values.drop imp.params.length⟩,
+              code, arity, remainder, controls, calls⟩ : Expr α)
+          @ s; E {{ Φ }}) -∗
+    ▷ (∀ preWasm postWasm msg
+          (_h : hostFn.invoke preWasm (values.take imp.params.length).reverse =
+            .Trap postWasm msg),
+        QTrap -∗
+        WP (Expr.trapped (.host msg) : Expr α) @ s; E {{ Φ }}) -∗
+    ▷ (∀ preWasm postWasm tag xs
+          (h : hostFn.invoke preWasm (values.take imp.params.length).reverse =
+            .Throw postWasm tag xs),
+        QThrow -∗
+        WP (Expr.running
+            ⟨⟨params, localValues, values.drop imp.params.length⟩,
+              [], arity, remainder,
+              [{ kind := .throwing tag xs
+                 paramArity := 0
+                 resultArity := 0
+                 body := []
+                 continuation := []
+                 belowStack := [] }] ++ controls,
+              calls⟩ : Expr α)
+          @ s; E {{ Φ }}) -∗
+    WP (Expr.running current : Expr α) @ s; E {{ Φ }} := by
+  dsimp only
+  iintro HP >Hruntime HwpRet HwpTrap HwpThrow
+  iapply wp_lift_step rfl
+  iintro %store %ns %obs %obs' %nt Hσ
+  ihave %Hmodule : ⌜store.runtime.module = runtimeModule⌝ $$
+      [Hσ Hruntime]
+  · imod stateInterp_runtimeModule_agree store ns (obs ++ obs') nt
+      runtimeModule $$ [$Hσ $Hruntime] with %Hmodule
+    ipureintro
+    exact Hmodule
+  have himports' : functionIndex < store.runtime.module.imports.length := by
+    simpa only [Hmodule] using himports
+  have himp' : store.runtime.module.imports[functionIndex] = imp := by
+    simpa only [Hmodule] using himp
+  ihave %Hhost : ⌜store.runtime.host = hostEnv⌝ $$ [Hσ]
+  · imod stateInterp_hostEnv store ns (obs ++ obs') nt
+        hostEnv hhostFn $$ [$Hσ] with %Hhost
+    ipureintro
+    exact Hhost
+  have hhost' : store.runtime.host.funcs[functionIndex]? = some hostFn := by
+    rw [Hhost]; exact hfuncs
+  match h : hostFn.invoke store.wasm (values.take imp.params.length).reverse with
+  | .Return results newWasm =>
+    iapply fupd_mask_intro Std.LawfulSet.empty_subset
+    iintro Hclose
+    isplitr
+    · ipureintro
+      cases s <;> simp only [Stuckness.MaybeReducible]
+      exact ⟨[.host functionIndex],
+        .running ⟨⟨params, localValues,
+            results.take imp.results.length ++
+              values.drop imp.params.length⟩,
+          code, arity, remainder, controls, calls⟩,
+        { store with wasm := newWasm }, [],
+        ⟨rfl, _, rfl, Step.callHostReturn himports' himp' hhost' h⟩⟩
+    iintro !> %e₂ %store₂ %forks %Hstep Hcredit
+    rcases Hstep with ⟨hforks, kind, hobs, wasmStep⟩
+    change forks = [] at hforks
+    subst forks
+    subst obs
+    obtain ⟨rfl, hconfig⟩ :=
+      step_deterministic (Step.callHostReturn (α := α) himports' himp' hhost' h) wasmStep
+    have parts := Config.mk.inj hconfig
+    have hexpr := parts.1
+    have hstore := parts.2
+    simp only at hexpr hstore
+    subst e₂
+    subst store₂
+    simp only [List.length_nil, Nat.add_zero, Iris.Algebra.BigOpL.bigOpL_nil]
+    imod hRetTransfer store ns obs' nt Hmodule results newWasm h $$ [$HP $Hσ] with ⟨HQ, Hσ⟩
+    imod Hclose
+    imodintro
+    isplitl [Hσ]
+    · iexact Hσ
+    ispecialize HwpRet $$ %(store.wasm) %results %newWasm %h
+    isplitl [HwpRet HQ]
+    · iapply HwpRet
+      iexact HQ
+    · itrivial
+  | .Trap newWasm msg =>
+    iapply fupd_mask_intro Std.LawfulSet.empty_subset
+    iintro Hclose
+    isplitr
+    · ipureintro
+      cases s <;> simp only [Stuckness.MaybeReducible]
+      exact ⟨[.host functionIndex],
+        .trapped (.host msg),
+        { store with wasm := newWasm }, [],
+        ⟨rfl, _, rfl, Step.callHostTrap himports' himp' hhost' h⟩⟩
+    iintro !> %e₂ %store₂ %forks %Hstep Hcredit
+    rcases Hstep with ⟨hforks, kind, hobs, wasmStep⟩
+    change forks = [] at hforks
+    subst forks
+    subst obs
+    obtain ⟨rfl, hconfig⟩ :=
+      step_deterministic (Step.callHostTrap (α := α) himports' himp' hhost' h) wasmStep
+    have parts := Config.mk.inj hconfig
+    have hexpr := parts.1
+    have hstore := parts.2
+    simp only at hexpr hstore
+    subst e₂
+    subst store₂
+    simp only [List.length_nil, Nat.add_zero, Iris.Algebra.BigOpL.bigOpL_nil]
+    imod hTrapTransfer store ns obs' nt Hmodule newWasm msg h $$ [$HP $Hσ] with ⟨HQ, Hσ⟩
+    imod Hclose
+    imodintro
+    isplitl [Hσ]
+    · iexact Hσ
+    ispecialize HwpTrap $$ %(store.wasm) %newWasm %msg %h
+    isplitl [HwpTrap HQ]
+    · iapply HwpTrap
+      iexact HQ
+    · itrivial
+  | .Throw newWasm tag xs =>
+    iapply fupd_mask_intro Std.LawfulSet.empty_subset
+    iintro Hclose
+    isplitr
+    · ipureintro
+      cases s <;> simp only [Stuckness.MaybeReducible]
+      exact ⟨[.host functionIndex],
+        .running ⟨⟨params, localValues, values.drop imp.params.length⟩,
+          [], arity, remainder,
+          [{ kind := .throwing tag xs
+             paramArity := 0
+             resultArity := 0
+             body := []
+             continuation := []
+             belowStack := [] }] ++ controls,
+          calls⟩,
+        { store with wasm := newWasm }, [],
+        ⟨rfl, _, rfl, Step.callHostThrow himports' himp' hhost' h⟩⟩
+    iintro !> %e₂ %store₂ %forks %Hstep Hcredit
+    rcases Hstep with ⟨hforks, kind, hobs, wasmStep⟩
+    change forks = [] at hforks
+    subst forks
+    subst obs
+    obtain ⟨rfl, hconfig⟩ :=
+      step_deterministic (Step.callHostThrow (α := α) himports' himp' hhost' h) wasmStep
+    have parts := Config.mk.inj hconfig
+    have hexpr := parts.1
+    have hstore := parts.2
+    simp only at hexpr hstore
+    subst e₂
+    subst store₂
+    simp only [List.length_nil, Nat.add_zero, Iris.Algebra.BigOpL.bigOpL_nil]
+    imod hThrowTransfer store ns obs' nt Hmodule newWasm tag xs h $$ [$HP $Hσ] with ⟨HQ, Hσ⟩
+    imod Hclose
+    imodintro
+    isplitl [Hσ]
+    · iexact Hσ
+    ispecialize HwpThrow $$ %(store.wasm) %newWasm %tag %xs %h
+    isplitl [HwpThrow HQ]
+    · iapply HwpThrow
+      iexact HQ
+    · itrivial
 
 /-- Resume a suspended caller after an explicit callee return. -/
 theorem wp_returnFromCallExplicit

--- a/codelib/CodeLib/SepLogic/SmallStepState.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepState.lean
@@ -33,6 +33,17 @@ attribute [reducible, instance] WasmSmallStepGS.table
 attribute [reducible, instance] WasmSmallStepGS.elementSegment
 attribute [reducible, instance] WasmSmallStepGS.runtime
 
+/-- Optional witness of the host environment for the Iris state interpretation.
+The default instance provides `none`, giving `True` as the host agreement fact.
+Override with a specific instance to witness the physical host env in proofs. -/
+class WasmHostGS (α : Type) where
+  knownHostEnv : Option (HostEnv α) := none
+
+instance instDefaultWasmHostGS : WasmHostGS α where
+  knownHostEnv := none
+
+variable [WasmHostGS α]
+
 instance instStateInterp [WasmSmallStepGS hlc] :
     StateInterp (MachineStore α) StepKind WasmHeapGF where
   stateInterp store _ _ _ := iprop%
@@ -59,7 +70,10 @@ instance instStateInterp [WasmSmallStepGS hlc] :
         dataSegmentHeapAgrees dataSegmentσ store.wasm.dataSegments ∧
         tableHeapAgrees tableσ store.wasm.tables ∧
         elementSegmentHeapAgrees elementSegmentσ
-          store.wasm.elementSegments⌝
+          store.wasm.elementSegments ∧
+        match WasmHostGS.knownHostEnv (α := α) with
+        | some h => store.runtime.host = h
+        | none => True⌝
 
 theorem stateInterp_eq [WasmSmallStepGS hlc]
     (store : MachineStore α) (steps : Nat)
@@ -88,7 +102,10 @@ theorem stateInterp_eq [WasmSmallStepGS hlc]
           dataSegmentHeapAgrees dataSegmentσ store.wasm.dataSegments ∧
           tableHeapAgrees tableσ store.wasm.tables ∧
           elementSegmentHeapAgrees elementSegmentσ
-            store.wasm.elementSegments⌝) :=
+            store.wasm.elementSegments ∧
+          match WasmHostGS.knownHostEnv (α := α) with
+          | some h => store.runtime.host = h
+          | none => True⌝) :=
   .rfl
 
 theorem stateInterp_pointsTo_read8 [WasmSmallStepGS hlc]
@@ -311,7 +328,7 @@ theorem stateInterp_elementSegment_facts_frame [WasmSmallStepGS hlc]
   · isplitl [Hsegment]
     · iexact Hsegment
     · ipureintro
-      exact Hfacts.2.2.2.2.2 index value hlookup
+      exact Hfacts.2.2.2.2.2.1 index value hlookup
 
 /-- `elem.drop` changes the physical segment status and authoritative ghost
 entry to `none` without renumbering any segment. -/
@@ -359,7 +376,8 @@ theorem stateInterp_elementSegment_drop [WasmSmallStepGS hlc]
       ⟨Hfacts.2.2.2.2.1,
         elementSegment_store_sound elementSegmentσ
           store.wasm.elementSegments index oldValue none
-          Hfacts.2.2.2.2.2 hlookup⟩⟩
+          Hfacts.2.2.2.2.2.1 hlookup,
+        Hfacts.2.2.2.2.2.2⟩⟩
   · iexact Hsegment
 
 /-- Owning a table fragment identifies the complete physical instantiated
@@ -942,6 +960,64 @@ theorem stateInterp_memoryGrow [WasmSmallStepGS hlc]
     grow_inBounds σ store.wasm.mem memory delta
       store.runtime.module.memoryCap previousPages hgrow Hfacts.2.1,
     Hfacts.2.2⟩
+
+/-- After a host-call `.Return`, the store's `wasm` field is replaced by the
+host-returned store. `runtime` is unchanged, so all ghost authorities are
+preserved; agreement must be re-established by the caller for each component
+that the host may have modified. -/
+theorem stateInterp_hostCallReturn [WasmSmallStepGS hlc]
+    (store : MachineStore α) (newWasm : Store α)
+    (steps : Nat) (observations : List StepKind) (threads : Nat) :
+    (∀ σ, heapAgreesWithMem σ store.wasm.mem →
+          heapAgreesWithMem σ newWasm.mem) →
+    (∀ σ, heapAddressesInBounds σ store.wasm.mem →
+          heapAddressesInBounds σ newWasm.mem) →
+    (∀ σ, globalHeapAgrees σ store.wasm.globals →
+          globalHeapAgrees σ newWasm.globals) →
+    (∀ σ, dataSegmentHeapAgrees σ store.wasm.dataSegments →
+          dataSegmentHeapAgrees σ newWasm.dataSegments) →
+    (∀ σ, tableHeapAgrees σ store.wasm.tables →
+          tableHeapAgrees σ newWasm.tables) →
+    (∀ σ, elementSegmentHeapAgrees σ store.wasm.elementSegments →
+          elementSegmentHeapAgrees σ newWasm.elementSegments) →
+    stateInterp (GF := WasmHeapGF) store steps observations threads ⊢
+      stateInterp (GF := WasmHeapGF) { store with wasm := newWasm }
+        steps observations threads := by
+  intro hMem hBounds hGlobals hData hTables hElems
+  iintro Hstate
+  icases (stateInterp_eq store steps observations threads).mp $$ Hstate with
+    ⟨%σ, %globalσ, %dataSegmentσ, %tableσ, %elementSegmentσ,
+      Hheap, Hglobals, Hsegments, Htables, HelementSegments, Hruntime, %Hfacts⟩
+  iapply (stateInterp_eq
+    { store with wasm := newWasm }
+    steps observations threads).mpr
+  iexists σ
+  iexists globalσ
+  iexists dataSegmentσ
+  iexists tableσ
+  iexists elementSegmentσ
+  iframe Hheap Hglobals Hsegments Htables HelementSegments Hruntime
+  ipureintro
+  exact ⟨hMem σ Hfacts.1, hBounds σ Hfacts.2.1, hGlobals globalσ Hfacts.2.2.1,
+    hData dataSegmentσ Hfacts.2.2.2.1, hTables tableσ Hfacts.2.2.2.2.1,
+    hElems elementSegmentσ Hfacts.2.2.2.2.2.1, Hfacts.2.2.2.2.2.2⟩
+
+/-- Extract the host env agreement from stateInterp when a specific host env is known. -/
+theorem stateInterp_hostEnv [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat)
+    (observations : List StepKind) (threads : Nat)
+    (hostEnv : HostEnv α)
+    (h : WasmHostGS.knownHostEnv (α := α) = some hostEnv) :
+    stateInterp (GF := WasmHeapGF) store steps observations threads ==∗
+      ⌜store.runtime.host = hostEnv⌝ := by
+  iintro Hstate
+  icases (stateInterp_eq store steps observations threads).mp $$ Hstate with
+    ⟨%σ, %globalσ, %dataSegmentσ, %tableσ, %elementSegmentσ,
+      Hheap, Hglobals, Hsegments, Htables, HelementSegments, Hruntime, %Hfacts⟩
+  ipureintro
+  have hhost := Hfacts.2.2.2.2.2.2
+  simp only [h] at hhost
+  exact hhost
 
 /-- Four-byte fill update used by the manual memory example. Ownership of the
 whole affected range is required and is updated atomically. -/

--- a/programs/lean/Project/FloatReinterpret/Spec.lean
+++ b/programs/lean/Project/FloatReinterpret/Spec.lean
@@ -148,7 +148,7 @@ theorem func9_smallStep_wp
 theorem func9_smallStep (x : UInt32) :
     PartiallyMeets (func9Config x)
       (fun rs _store => rs = [.f32 (2147483647 &&& x)]) := by
-  apply wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit)
+  apply wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit) (hhost := trivial)
   intro gs
   simp only [func9Config]
   iapply func9_smallStep_wp
@@ -231,7 +231,7 @@ theorem func4_smallStep_wp
 theorem func4_smallStep (x y : UInt32) :
     PartiallyMeets (func4Config x y)
       (fun rs _store => rs = [.f32 (func4Result x y)]) := by
-  apply wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit)
+  apply wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit) (hhost := trivial)
   intro gs
   simp only [func4Config]
   iapply func4_smallStep_wp

--- a/programs/lean/Project/RustArrayTests/Spec.lean
+++ b/programs/lean/Project/RustArrayTests/Spec.lean
@@ -91,7 +91,7 @@ def EmptyPlusThreeSpec : Prop := ∀ (ptr len : UInt32),
 @[proves Project.RustArrayTests.Spec.EmptyPlusThreeSpec]
 theorem empty_plus_three_correct : EmptyPlusThreeSpec := by
   intro ptr len
-  apply SmallStep.wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit)
+  apply SmallStep.wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit) (hhost := trivial)
   intro gs
   simp only [bodyConfig, func4]
   iintro Hruntime
@@ -147,7 +147,7 @@ def EmptyXorFlagSpec : Prop := ∀ (ptr len flag : UInt32),
 @[proves Project.RustArrayTests.Spec.EmptyXorFlagSpec]
 theorem empty_xor_flag_correct : EmptyXorFlagSpec := by
   intro ptr len flag
-  apply SmallStep.wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit)
+  apply SmallStep.wasm_smallStep_runtime_partiallyMeets.{0} (α := Unit) (hhost := trivial)
   intro gs
   simp only [bodyConfig, func2]
   iintro Hruntime

--- a/programs/lean/Project/SwapElements/SwapSepLogic.lean
+++ b/programs/lean/Project/SwapElements/SwapSepLogic.lean
@@ -1109,7 +1109,7 @@ theorem func4_distinct_store_partiallyMeets
     simpa using UInt32.add_ofNat_toNat_noWrap addressJ 7 (by omega) (by omega)
   apply
     Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
-      (α := Unit) (σ := σ) (globalσ := globalσ)
+      (α := Unit) (σ := σ) (globalσ := globalσ) (hhost := trivial)
   · exact hagree
   · exact hinBounds
   · exact hglobals
@@ -1199,7 +1199,7 @@ theorem func4_alias_store_partiallyMeets
     simpa using UInt32.add_ofNat_toNat_noWrap address 7 (by omega) (by omega)
   apply
     Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
-      (α := Unit) (σ := σ) (globalσ := globalσ)
+      (α := Unit) (σ := σ) (globalσ := globalσ) (hhost := trivial)
   · exact hagree
   · exact hinBounds
   · exact hglobals
@@ -1499,7 +1499,7 @@ theorem func4Example_store_smallStep :
   apply
     Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
       (α := Unit) (σ := func4ExampleHeap)
-      (globalσ := func4ExampleGlobals)
+      (globalσ := func4ExampleGlobals) (hhost := trivial)
   · exact func4ExampleHeap_agrees
   · exact func4ExampleHeap_inBounds
   · exact func4ExampleGlobals_agree
@@ -1675,7 +1675,7 @@ theorem func4Alias_store_smallStep :
   apply
     Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
       (α := Unit) (σ := func4AliasHeap)
-      (globalσ := func4ExampleGlobals)
+      (globalσ := func4ExampleGlobals) (hhost := trivial)
   · exact func4AliasHeap_agrees
   · exact func4AliasHeap_inBounds
   · exact func4ExampleGlobals_agree

--- a/programs/lean/Project/SwapElementsOpt3/SmallStepEquivalence.lean
+++ b/programs/lean/Project/SwapElementsOpt3/SmallStepEquivalence.lean
@@ -260,7 +260,7 @@ theorem opt3_func0_distinct_store_partiallyMeets
     simpa using UInt32.add_ofNat_toNat_noWrap addressJ 7 (by omega) (by omega)
   apply
     Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
-      (α := Unit) (σ := σ) (globalσ := globalσ)
+      (α := Unit) (σ := σ) (globalσ := globalσ) (hhost := trivial)
   · exact hagree
   · exact hinBounds
   · exact hglobals


### PR DESCRIPTION
Add `wp_callHost`,  the first Iris lifting rule for host function calls, this is the foundation for module-linking and migrating the NEAR host to small-step Iris.

## What's added

**`WasmHostGS` class** : a new typeclass with a default instance (`knownHostEnv := none`) that adds an optional host-environment witness to `stateInterp`. The default instance resolves automatically, so all existing rules compile without changes. Proofs that reason about a specific host override it locally with `letI`.

 `WasmHostGS` was added as a separate class (alongside `WasmHeapGS`, `WasmGlobalGS`, etc.). The alternative choice was to parameterize `WasmHeapGF` by the host-state type `α`, which  would add a meaningless `α` to every `pointsTo`, `arrayAt`, and `globalPointsTo` in the codebase. 

**`wp_callHost`**: covers Return, Trap, and Throw outcomes in one rule. Takes user-provided ghost resources (`P` consumed, `Q` produced) with `==∗` transfer hypotheses, following the `stateInterp_store8` pattern used by `wp_store8`. For a memory-modifying host, the user calls `stateInterp_store8` inside the transfer. For a host that only touches host state, the transfer is trivial.

**Supporting theorems** : `stateInterp_hostCallReturn` (transfers stateInterp when agreement predicates are preserved) and
`stateInterp_hostEnv` (extracts host env identity from stateInterp).

**Example** : `writeByteHost` writes a byte to Wasm memory. Proved end-to-end: `PartiallyMeets` via Iris adequacy with `stateInterp_store8` ghost update, `TerminatesWith` via `native_decide`, total correctness
via `of_termination_and_partial`. Postcondition reads the written byte from physical memory.

## Per-PR checklist

1. **Milestone:** M6 (WP rules for calls).
2. **Oracle:** Legacy `wp_call_host_cons` (`Wp/Call.lean:214`):  same host-call semantics, new proof API. The legacy rule operates on the big-step interpreter; `wp_callHost` operates on the small-step `Step` relation via `step_deterministic`.
3. **Step/step?:** No new constructors added. This PR adds Iris rules for the existing `callHostReturn`/`callHostTrap`/`callHostThrow` Step constructors.
4. **Correctness:** `wp_callHost` proved via existing `step_deterministic`. No changes to soundness, completeness, or
   determinism proofs.
5. **Nondeterminism:** None,  `HostFn.invoke` is a pure Lean function.
6. **Cases:** Return path exercised end-to-end with memory modification and ghost-state update. Trap and Throw paths are structurally identical in the rule proof; dismissed by contradiction in the example since `writeByteHost` returns `.Return` for valid args. A trapping host example will ship with the NEAR migration.
7. **Framing:** `stateInterp_hostCallReturn` preserves all six agreement predicates. The host-env fact is preserved by `runtime_preserved`.
8. **Ported:** No host-call Iris examples existed previously. NEAR (`Near/Examples/KvSetter.lean`) uses the legacy big-step API and will be migrated to `wp_callHost` in a follow-up PR.
9. **Build:** `lake build --wfail` on interpreter, codelib, programs/lean 
10. **Atomicity:** Unchanged, host calls were already one `PrimStep`.
11. **TODOs:**  next steps are module-linking (instance tables, cross-instance calls) and migrating the NEAR host (`codelib/CodeLib/Near/`) to use `wp_callHost` instead of the legacy `wp_call_host_cons`.

Generated with Claude Code