### PR TITLE
Prove quicksort with Iris-lean

### DIFF
--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -10,7 +10,7 @@ A handwritten Wasm implementation of Lomuto partition quicksort.
 namespace Wasm.Examples.Quicksort
 
 open Wasm
-open Iris Iris.ProgramLogic Language.Notation
+open Iris Iris.ProgramLogic Language.Notation Std
 open Wasm.SepLogic
 open Wasm.SmallStep
 
@@ -249,8 +249,6 @@ theorem quicksort_terminates_sorted :
 
 /-! ## Differential check -/
 
--- Wasm.run (big-step, Interpreter.Wasm.Semantics) is imported transitively
--- through SmallStep.lean. Result.Success carries the final store.
 def runQuicksortLegacy (fuel : Nat) (arr : UInt32) (input : List UInt32) :
     Option (List UInt32) :=
   match Wasm.run fuel quicksortModule 1
@@ -349,5 +347,211 @@ theorem quicksort_oracle_duplicates :
 theorem quicksort_oracle_sorted :
     runQuicksortExample 10000 0 [1, 2, 3, 4] =
     some (List.mergeSort [1, 2, 3, 4]) := by native_decide
+
+/-! ## Adequacy infrastructure -/
+
+private def quicksortHeapAux (σ : WasmHeapMap (Option UInt8)) (base : UInt32) :
+    List UInt32 → WasmHeapMap (Option UInt8)
+  | [] => σ
+  | x :: xs => quicksortHeapAux (store32Heap σ base x) (base + 4) xs
+
+def quicksortHeap (arr : UInt32) (input : List UInt32) :
+    WasmHeapMap (Option UInt8) :=
+  quicksortHeapAux ∅ arr input
+
+def quicksortConfig (arr : UInt32) (input : List UInt32) : Config Unit :=
+  let initial := quicksortModule.initialStore (α := Unit)
+  { expr := .running
+      ⟨⟨[], [], [.i32 (UInt32.ofNat input.length), .i32 0, .i32 arr]⟩,
+        [.call 1], 0, [], [], []⟩
+    store :=
+      { runtime := { module := quicksortModule, host := {} }
+        wasm := { initial with mem := writeWordArray initial.mem arr input } } }
+
+private theorem quicksortHeapAux_agrees
+    (σ : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32) (xs : List UInt32)
+    (hagree : heapAgreesWithMem σ mem)
+    (hfit : base.toNat + 4 * xs.length ≤ UInt32.size) :
+    heapAgreesWithMem (quicksortHeapAux σ base xs) (writeWordArray mem base xs) := by
+  induction xs generalizing σ mem base with
+  | nil => simpa [quicksortHeapAux, writeWordArray]
+  | cons x xs ih =>
+    simp only [quicksortHeapAux, writeWordArray, List.length_cons] at *
+    simp only [UInt32.size] at hfit
+    have h4_le : (base + 4 : UInt32).toNat ≤ base.toNat + 4 := by
+      have h := UInt32.toNat_add base 4
+      simp only [show (4 : UInt32).toNat = 4 from by decide] at h
+      rw [h]; exact Nat.mod_le _ _
+    apply ih
+    · apply store32_sound
+      · exact UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by omega)
+      · exact UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by omega)
+      · exact UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by omega)
+      · exact hagree
+    · simp only [UInt32.size]; omega
+
+theorem quicksortHeap_agrees (arr : UInt32) (input : List UInt32)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size) :
+    heapAgreesWithMem (quicksortHeap arr input)
+      (writeWordArray (quicksortModule.initialStore (α := Unit)).mem arr input) := by
+  unfold quicksortHeap
+  apply quicksortHeapAux_agrees
+  · intro addr byte hget; simp [get?_empty] at hget
+  · exact hfit
+
+private theorem quicksortHeapAux_inBounds
+    (σ : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32) (xs : List UInt32)
+    (hinBounds : heapAddressesInBounds σ mem)
+    (hfit : base.toNat + 4 * xs.length ≤ UInt32.size)
+    (hmem : base.toNat + 4 * xs.length ≤ mem.pages * 65536) :
+    heapAddressesInBounds (quicksortHeapAux σ base xs) (writeWordArray mem base xs) := by
+  induction xs generalizing σ mem base with
+  | nil => simpa [quicksortHeapAux, writeWordArray]
+  | cons x xs ih =>
+    simp only [quicksortHeapAux, writeWordArray, List.length_cons] at *
+    simp only [UInt32.size] at hfit
+    have h4_le : (base + 4 : UInt32).toNat ≤ base.toNat + 4 := by
+      have h := UInt32.toNat_add base 4
+      simp only [show (4 : UInt32).toNat = 4 from by decide] at h
+      rw [h]; exact Nat.mod_le _ _
+    have hpages : (mem.write32 base x).pages = mem.pages := by simp [Mem.write32]
+    apply ih
+    · apply store32_inBounds
+      · exact UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by omega)
+      · exact UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by omega)
+      · exact UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by omega)
+      · exact hinBounds
+      · omega
+    · simp only [UInt32.size]; omega
+    · rw [hpages]; omega
+
+theorem quicksortHeap_inBounds (arr : UInt32) (input : List UInt32)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    (hmem : arr.toNat + 4 * input.length ≤ 65536) :
+    heapAddressesInBounds (quicksortHeap arr input)
+      (writeWordArray (quicksortModule.initialStore (α := Unit)).mem arr input) := by
+  unfold quicksortHeap
+  apply quicksortHeapAux_inBounds
+  · intro a b hget; simp [get?_empty] at hget
+  · exact hfit
+  · have hpages : (quicksortModule.initialStore (α := Unit)).mem.pages = 1 := by native_decide
+    simp only [hpages]
+    exact hmem
+
+private theorem quicksortHeapAux_pointsTo [WasmHeapGS]
+    (σ : WasmHeapMap (Option UInt8)) (base : UInt32) (xs : List UInt32)
+    (hdisjoint : ∀ a b, get? σ a = some b → a.toNat < base.toNat)
+    (hfit : base.toNat + 4 * xs.length < UInt32.size) :
+    ([∗map] address ↦ value ∈ quicksortHeapAux σ base xs,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap) address (DFrac.own 1) value) ⊢
+      arrayAt base xs ∗
+      ([∗map] address ↦ value ∈ σ,
+          pointsTo (GF := WasmHeapGF) (H := WasmHeapMap) address (DFrac.own 1) value) := by
+  induction xs generalizing σ base with
+  | nil =>
+    simp only [quicksortHeapAux, arrayAt, BI.emp_sep.to_eq]
+    iintro Hσ; iexact Hσ
+  | cons x xs ih =>
+    simp only [quicksortHeapAux, List.length_cons] at *
+    simp only [UInt32.size] at hfit
+    have h4 : (base + 4 : UInt32).toNat = base.toNat + 4 :=
+      UInt32.add_ofNat_toNat_noWrap base 4 (by decide) (by omega)
+    have hfit' : (base + 4).toNat + 4 * xs.length < UInt32.size := by
+      simp only [UInt32.size]; omega
+    have hn1 : (base + 1).toNat = base.toNat + 1 :=
+      UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by omega)
+    have hn2 : (base + 2).toNat = base.toNat + 2 :=
+      UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by omega)
+    have hn3 : (base + 3).toNat = base.toNat + 3 :=
+      UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by omega)
+    have hget0 : get? σ base = none := by
+      by_contra h; obtain ⟨_, hget⟩ := Option.ne_none_iff_exists.mp h
+      exact absurd (hdisjoint _ _ hget.symm) (by omega)
+    have hget1 : get? σ (base + 1) = none := by
+      by_contra h; obtain ⟨_, hget⟩ := Option.ne_none_iff_exists.mp h
+      exact absurd (hdisjoint _ _ hget.symm) (by rw [hn1]; omega)
+    have hget2 : get? σ (base + 2) = none := by
+      by_contra h; obtain ⟨_, hget⟩ := Option.ne_none_iff_exists.mp h
+      exact absurd (hdisjoint _ _ hget.symm) (by rw [hn2]; omega)
+    have hget3 : get? σ (base + 3) = none := by
+      by_contra h; obtain ⟨_, hget⟩ := Option.ne_none_iff_exists.mp h
+      exact absurd (hdisjoint _ _ hget.symm) (by rw [hn3]; omega)
+    have hdisjoint' : ∀ a b, get? (store32Heap σ base x) a = some b →
+        a.toNat < (base + 4).toNat := by
+      rw [h4]
+      intro a b hget
+      by_cases h3 : a = base + 3
+      · subst h3; rw [hn3]; omega
+      by_cases h2 : a = base + 2
+      · subst h2; rw [hn2]; omega
+      by_cases h1 : a = base + 1
+      · subst h1; rw [hn1]; omega
+      by_cases h0 : a = base
+      · subst h0; omega
+      · simp only [store32Heap, get?_insert_ne (Ne.symm h3), get?_insert_ne (Ne.symm h2),
+            get?_insert_ne (Ne.symm h1), get?_insert_ne (Ne.symm h0)] at hget
+        have hlt := hdisjoint a b hget; omega
+    iintro Hheap
+    ihave Hsplit := ih (store32Heap σ base x) (base + 4) hdisjoint' hfit' $$ Hheap
+    icases Hsplit with ⟨Hxs, Hstore32⟩
+    ihave Hdecomp :=
+      store32Heap_pointsTo σ base x hget0 hget1 hget2 hget3 hn1 hn2 hn3 $$ Hstore32
+    icases Hdecomp with ⟨Hword, Hσ⟩
+    simp only [arrayAt]
+    isplitl [Hword Hxs]
+    · isplitl [Hword]; iexact Hword; iexact Hxs
+    · iexact Hσ
+
+theorem quicksortHeap_pointsTo [WasmHeapGS]
+    (arr : UInt32) (input : List UInt32)
+    (hfit : arr.toNat + 4 * input.length < UInt32.size) :
+    ([∗map] address ↦ value ∈ quicksortHeap arr input,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap) address (DFrac.own 1) value) ⊢
+      arrayAt arr input := by
+  unfold quicksortHeap
+  iintro Hheap
+  ihave Hsplit := quicksortHeapAux_pointsTo ∅ arr input
+    (fun a b hget => by simp [get?_empty] at hget) hfit $$ Hheap
+  icases Hsplit with ⟨Harray, _Hemp⟩
+  iexact Harray
+
+theorem arrayAt_readWordArray [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat) (obs : List StepKind) (threads : Nat)
+    (arr : UInt32) (output : List UInt32)
+    (hfit : arr.toNat + 4 * output.length ≤ UInt32.size) :
+    stateInterp (GF := WasmHeapGF) store steps obs threads ∗ arrayAt arr output ==∗
+      stateInterp (GF := WasmHeapGF) store steps obs threads ∗ arrayAt arr output ∗
+      ⌜readWordArray store.wasm.mem arr output.length = output⌝ := by
+  induction output generalizing arr with
+  | nil =>
+    simp only [arrayAt, List.length_nil, readWordArray]
+    iintro ⟨Hstate, Hemp⟩
+    imodintro
+    isplitl [Hstate]; iexact Hstate
+    isplitl [Hemp]; iexact Hemp
+    ipureintro; trivial
+  | cons x xs ih =>
+    simp only [arrayAt, List.length_cons]
+    simp only [List.length_cons, UInt32.size] at hfit
+    have h4_le : (arr + 4 : UInt32).toNat ≤ arr.toNat + 4 := by
+      have h := UInt32.toNat_add arr 4
+      simp only [show (4 : UInt32).toNat = 4 from by decide] at h
+      rw [h]; exact Nat.mod_le _ _
+    have hfit' : (arr + 4).toNat + 4 * xs.length ≤ UInt32.size := by
+      simp only [UInt32.size]; omega
+    iintro ⟨Hstate, Hword, Hxs⟩
+    imod stateInterp_pointsTo_u32_facts_frame store steps obs threads arr x
+      (UInt32.add_ofNat_toNat_noWrap arr 1 (by decide) (by omega))
+      (UInt32.add_ofNat_toNat_noWrap arr 2 (by decide) (by omega))
+      (UInt32.add_ofNat_toNat_noWrap arr 3 (by decide) (by omega)) $$
+        [$Hstate $Hword] with ⟨Hstate, Hword, %hfacts⟩
+    imod ih (arr + 4) hfit' $$ [$Hstate $Hxs] with ⟨Hstate, Hxs, %hread⟩
+    imodintro
+    isplitl [Hstate]; iexact Hstate
+    isplitl [Hword Hxs]
+    · isplitl [Hword]; iexact Hword; iexact Hxs
+    ipureintro
+    unfold readWordArray
+    rw [hfacts.1, hread]
 
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -1,4 +1,5 @@
 import CodeLib.SepLogic.SmallStepAdequacy
+import Interpreter.Wasm.Decoder.Wat
 import Mathlib.Data.List.Sort
 
 /-!
@@ -617,5 +618,159 @@ theorem arrayAt_readWordArray [WasmSmallStepGS hlc]
     ipureintro
     unfold readWordArray
     rw [hfacts.1, hread]
+
+/-! ## WAT decoder agreement -/
+
+-- keep in sync with quicksort.wat
+private def quicksortWat : String := "
+(module
+  (memory 1)
+  (func (param i32 i32 i32) (result i32) (local i32 i32 i32 i32 i32)
+    local.get 2
+    i32.const 1
+    i32.sub
+    local.set 6
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    local.set 3
+    local.get 1
+    local.set 4
+    local.get 1
+    local.set 5
+    block
+      loop
+        local.get 5
+        local.get 6
+        i32.lt_u
+        i32.eqz
+        br_if 1
+        local.get 3
+        local.get 0
+        local.get 5
+        i32.const 4
+        i32.mul
+        i32.add
+        i32.load
+        i32.lt_u
+        if
+        else
+          local.get 0
+          local.get 4
+          i32.const 4
+          i32.mul
+          i32.add
+          i32.load
+          local.set 7
+          local.get 0
+          local.get 4
+          i32.const 4
+          i32.mul
+          i32.add
+          local.get 0
+          local.get 5
+          i32.const 4
+          i32.mul
+          i32.add
+          i32.load
+          i32.store
+          local.get 0
+          local.get 5
+          i32.const 4
+          i32.mul
+          i32.add
+          local.get 7
+          i32.store
+          local.get 4
+          i32.const 1
+          i32.add
+          local.set 4
+        end
+        local.get 5
+        i32.const 1
+        i32.add
+        local.set 5
+        br 0
+      end
+    end
+    local.get 0
+    local.get 4
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    local.set 7
+    local.get 0
+    local.get 4
+    i32.const 4
+    i32.mul
+    i32.add
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    i32.store
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    local.get 7
+    i32.store
+    local.get 4
+    return)
+  (func (param i32 i32 i32) (local i32)
+    local.get 2
+    local.get 1
+    i32.sub
+    i32.const 2
+    i32.lt_u
+    if
+      return
+    end
+    local.get 0
+    local.get 1
+    local.get 2
+    call 0
+    local.set 3
+    local.get 0
+    local.get 1
+    local.get 3
+    call 1
+    local.get 0
+    local.get 3
+    i32.const 1
+    i32.add
+    local.get 2
+    call 1
+    return))
+"
+
+private def quicksortModuleDecoded : Module :=
+  match Wasm.Decoder.Wat.decode quicksortWat with
+  | .ok m => m
+  | .error _ => default
+
+def runQuicksortDecoded (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModuleDecoded, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store => some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_decoded_agrees :
+    runQuicksortDecoded 15000 0 [5, 1, 4, 2, 3] =
+    runQuicksortExample 15000 0 [5, 1, 4, 2, 3] := by
+  native_decide
 
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -326,6 +326,70 @@ theorem quicksort_mutation_index :
     runQuicksortMutated2 15000 0 [5, 1, 4, 2, 3] ≠ some [1, 2, 3, 4, 5] := by
   native_decide
 
+private def quicksortFunctionMutated3 : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32]
+    body :=
+      [.localGet 2, .localGet 1, .sub, .const 3, .ltU,
+       .iff 0 0 [.ret] []] ++
+      quicksortPartitionCall 0 ++
+      quicksortLeftCall 1 ++
+      quicksortRightCall 1 ++
+      [.ret] }
+
+private def quicksortModuleMutated3 : Module :=
+  { funcs := [partitionFunction, quicksortFunctionMutated3]
+    memory := some { pagesMin := 1 } }
+
+def runQuicksortMutated3 (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModuleMutated3, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store => some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_mutation_bound :
+    runQuicksortMutated3 15000 0 [5, 1, 4, 2, 3] ≠ some [1, 2, 3, 4, 5] := by
+  native_decide
+
+private def partitionFunctionMutated4 : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32, .i32, .i32, .i32, .i32]
+    results := [.i32]
+    body :=
+      partitionInit ++
+      whileDo partitionScanCondition
+        ([.localGet 3] ++ loadAt 0 5 ++ [.ltU,
+          .iff 0 0 [] (storeAt 0 4 [.const 0] ++ increment 4)] ++
+         increment 5) ++
+      partitionPlacePivot ++
+      [.ret] }
+
+private def quicksortModuleMutated4 : Module :=
+  { funcs := [partitionFunctionMutated4, quicksortFunction 0 1]
+    memory := some { pagesMin := 1 } }
+
+def runQuicksortMutated4 (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModuleMutated4, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store => some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_mutation_store :
+    runQuicksortMutated4 15000 0 [5, 1, 4, 2, 3] ≠ some [1, 2, 3, 4, 5] := by
+  native_decide
+
 /-! ## Oracle agreement -/
 
 theorem quicksort_oracle_empty :

--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -499,7 +499,7 @@ theorem quicksortHeap_inBounds (arr : UInt32) (input : List UInt32)
   apply quicksortHeapAux_inBounds
   · intro a b hget; simp [get?_empty] at hget
   · exact hfit
-  · have hpages : (quicksortModule.initialStore (α := Unit)).mem.pages = 1 := by native_decide
+  · have hpages : (quicksortModule.initialStore (α := Unit)).mem.pages = 1 := by decide
     simp only [hpages]
     exact hmem
 
@@ -621,135 +621,7 @@ theorem arrayAt_readWordArray [WasmSmallStepGS hlc]
 
 /-! ## WAT decoder agreement -/
 
--- keep in sync with quicksort.wat
-private def quicksortWat : String := "
-(module
-  (memory 1)
-  (func (param i32 i32 i32) (result i32) (local i32 i32 i32 i32 i32)
-    local.get 2
-    i32.const 1
-    i32.sub
-    local.set 6
-    local.get 0
-    local.get 6
-    i32.const 4
-    i32.mul
-    i32.add
-    i32.load
-    local.set 3
-    local.get 1
-    local.set 4
-    local.get 1
-    local.set 5
-    block
-      loop
-        local.get 5
-        local.get 6
-        i32.lt_u
-        i32.eqz
-        br_if 1
-        local.get 3
-        local.get 0
-        local.get 5
-        i32.const 4
-        i32.mul
-        i32.add
-        i32.load
-        i32.lt_u
-        if
-        else
-          local.get 0
-          local.get 4
-          i32.const 4
-          i32.mul
-          i32.add
-          i32.load
-          local.set 7
-          local.get 0
-          local.get 4
-          i32.const 4
-          i32.mul
-          i32.add
-          local.get 0
-          local.get 5
-          i32.const 4
-          i32.mul
-          i32.add
-          i32.load
-          i32.store
-          local.get 0
-          local.get 5
-          i32.const 4
-          i32.mul
-          i32.add
-          local.get 7
-          i32.store
-          local.get 4
-          i32.const 1
-          i32.add
-          local.set 4
-        end
-        local.get 5
-        i32.const 1
-        i32.add
-        local.set 5
-        br 0
-      end
-    end
-    local.get 0
-    local.get 4
-    i32.const 4
-    i32.mul
-    i32.add
-    i32.load
-    local.set 7
-    local.get 0
-    local.get 4
-    i32.const 4
-    i32.mul
-    i32.add
-    local.get 0
-    local.get 6
-    i32.const 4
-    i32.mul
-    i32.add
-    i32.load
-    i32.store
-    local.get 0
-    local.get 6
-    i32.const 4
-    i32.mul
-    i32.add
-    local.get 7
-    i32.store
-    local.get 4
-    return)
-  (func (param i32 i32 i32) (local i32)
-    local.get 2
-    local.get 1
-    i32.sub
-    i32.const 2
-    i32.lt_u
-    if
-      return
-    end
-    local.get 0
-    local.get 1
-    local.get 2
-    call 0
-    local.set 3
-    local.get 0
-    local.get 1
-    local.get 3
-    call 1
-    local.get 0
-    local.get 3
-    i32.const 1
-    i32.add
-    local.get 2
-    call 1
-    return))
-"
+private def quicksortWat : String := include_str "quicksort.wat"
 
 private def quicksortModuleDecoded : Module :=
   match Wasm.Decoder.Wat.decode quicksortWat with
@@ -770,7 +642,13 @@ def runQuicksortDecoded (fuel : Nat) (arr : UInt32) (input : List UInt32) :
 
 theorem quicksort_decoded_agrees :
     runQuicksortDecoded 15000 0 [5, 1, 4, 2, 3] =
-    runQuicksortExample 15000 0 [5, 1, 4, 2, 3] := by
+      runQuicksortExample 15000 0 [5, 1, 4, 2, 3] ∧
+    runQuicksortDecoded 15000 0 [] = runQuicksortExample 15000 0 [] ∧
+    runQuicksortDecoded 15000 0 [7] = runQuicksortExample 15000 0 [7] ∧
+    runQuicksortDecoded 15000 0 [4, 3, 2, 1] =
+      runQuicksortExample 15000 0 [4, 3, 2, 1] ∧
+    runQuicksortDecoded 20 0 [3, 2, 1] =
+      runQuicksortExample 20 0 [3, 2, 1] := by
   native_decide
 
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -1,0 +1,353 @@
+import CodeLib.SepLogic.SmallStepAdequacy
+import Mathlib.Data.List.Sort
+
+/-!
+# Quicksort
+
+A handwritten Wasm implementation of Lomuto partition quicksort.
+-/
+
+namespace Wasm.Examples.Quicksort
+
+open Wasm
+open Iris Iris.ProgramLogic Language.Notation
+open Wasm.SepLogic
+open Wasm.SmallStep
+
+def increment (index : Nat) : Program :=
+  [.localGet index, .const 1, .add, .localSet index]
+
+def address (base index : Nat) : Program :=
+  [.localGet base, .localGet index, .const 4, .mul, .add]
+
+def loadAt (base index : Nat) : Program :=
+  address base index ++ [.load32 0]
+
+def storeAt (base index : Nat) (value : Program) : Program :=
+  address base index ++ value ++ [.store32 0]
+
+def whileLoopCode (condition body : Program) : Program :=
+  condition ++ [.eqz, .br_if 1] ++ body ++ [.br 0]
+
+def whileDo (condition body : Program) : Program :=
+  [.block 0 0 [.loop 0 0 (whileLoopCode condition body)]]
+
+def lessLocal (lhs rhs : Nat) : Program :=
+  [.localGet lhs, .localGet rhs, .ltU]
+
+def swapAt (base a b tmp : Nat) : Program :=
+  loadAt base a ++ [.localSet tmp] ++
+  storeAt base a (loadAt base b) ++
+  storeAt base b [.localGet tmp]
+
+-- partition: arr=local0, lo=local1, hi=local2
+-- pivot=local3, i=local4, j=local5, hiMinusOne=local6, tmp=local7
+
+def partitionInit : Program :=
+  [.localGet 2, .const 1, .sub, .localSet 6] ++
+  loadAt 0 6 ++ [.localSet 3] ++
+  [.localGet 1, .localSet 4,
+   .localGet 1, .localSet 5]
+
+def partitionScanCondition : Program := lessLocal 5 6
+
+def partitionScanStep : Program :=
+  [.localGet 3] ++ loadAt 0 5 ++ [.ltU,
+   .iff 0 0 [] (swapAt 0 4 5 7 ++ increment 4)] ++
+  increment 5
+
+def partitionPlacePivot : Program :=
+  swapAt 0 4 6 7 ++ [.localGet 4]
+
+def partitionBody : Program :=
+  partitionInit ++
+  whileDo partitionScanCondition partitionScanStep ++
+  partitionPlacePivot ++
+  [.ret]
+
+def partitionFunction : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32, .i32, .i32, .i32, .i32]
+    results := [.i32]
+    body := partitionBody }
+
+-- quicksort: arr=local0, lo=local1, hi=local2, pivotIdx=local3
+
+def quicksortBaseCheck : Program :=
+  [.localGet 2, .localGet 1, .sub, .const 2, .ltU,
+   .iff 0 0 [.ret] []]
+
+def quicksortPartitionCall (partitionIndex : Nat) : Program :=
+  [.localGet 0, .localGet 1, .localGet 2, .call partitionIndex, .localSet 3]
+
+def quicksortLeftCall (quicksortIndex : Nat) : Program :=
+  [.localGet 0, .localGet 1, .localGet 3, .call quicksortIndex]
+
+def quicksortRightCall (quicksortIndex : Nat) : Program :=
+  [.localGet 0, .localGet 3, .const 1, .add, .localGet 2, .call quicksortIndex]
+
+def quicksortBody (partitionIndex quicksortIndex : Nat) : Program :=
+  quicksortBaseCheck ++
+  quicksortPartitionCall partitionIndex ++
+  quicksortLeftCall quicksortIndex ++
+  quicksortRightCall quicksortIndex ++
+  [.ret]
+
+def quicksortFunction (partitionIndex quicksortIndex : Nat) : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32]
+    body := quicksortBody partitionIndex quicksortIndex }
+
+def quicksortModule : Module :=
+  { funcs := [partitionFunction, quicksortFunction 0 1]
+    memory := some { pagesMin := 1 } }
+
+/-! ## Public specification -/
+
+def Sorted (values : List UInt32) : Prop :=
+  values.Pairwise (· ≤ ·)
+
+def SortedPermutation (input output : List UInt32) : Prop :=
+  Sorted output ∧ List.Perm input output
+
+def segment (values : List UInt32) (start stop : Nat) : List UInt32 :=
+  (values.drop start).take (stop - start)
+
+def arrayByteRange (base : UInt32) (length : Nat) : Nat × Nat :=
+  (base.toNat, base.toNat + 4 * length)
+
+def ValidQuicksortLayout (arr : UInt32) (length : Nat) : Prop :=
+  arr.toNat + 4 * length ≤ UInt32.size
+
+def PartitionRange (input output : List UInt32) (lo hi pivotIndex : Nat) : Prop :=
+  lo ≤ pivotIndex ∧ pivotIndex < hi ∧ hi ≤ input.length ∧
+  output.length = input.length ∧
+  output.take lo = input.take lo ∧
+  output.drop hi = input.drop hi ∧
+  List.Perm (segment input lo hi) (segment output lo hi) ∧
+  (∀ x ∈ segment output lo pivotIndex, x ≤ output[pivotIndex]!) ∧
+  (∀ x ∈ segment output (pivotIndex + 1) hi, x > output[pivotIndex]!)
+
+def quicksortPre [WasmHeapGS]
+    (arr : UInt32) (values : List UInt32) (lo hi : Nat) : IProp WasmHeapGF :=
+  iprop% arrayAt arr values ∗
+    ⌜lo ≤ hi ∧ hi ≤ values.length ∧ ValidQuicksortLayout arr values.length⌝
+
+def quicksortPost [WasmHeapGS]
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat) : IProp WasmHeapGF :=
+  iprop% ∃ output : List UInt32,
+    ⌜output.length = input.length ∧
+     output.take lo = input.take lo ∧
+     output.drop hi = input.drop hi ∧
+     Sorted (segment output lo hi) ∧
+     List.Perm (segment input lo hi) (segment output lo hi)⌝ ∗
+    arrayAt arr output
+
+/-! ## Executable regressions -/
+
+def writeWordArray : Mem → UInt32 → List UInt32 → Mem
+  | memory, _, [] => memory
+  | memory, address, value :: values =>
+      writeWordArray (memory.write32 address value) (address + 4) values
+
+def readWordArray : Mem → UInt32 → Nat → List UInt32
+  | _, _, 0 => []
+  | memory, address, count + 1 =>
+      memory.read32 address ::
+        readWordArray memory (address + 4) count
+
+def quicksortExampleStore (arr : UInt32) (input : List UInt32) : Store Unit :=
+  let initial := quicksortModule.initialStore (α := Unit)
+  { initial with mem := writeWordArray initial.mem arr input }
+
+def quicksortArguments (arr : UInt32) (length : Nat) (stack : List Value) : List Value :=
+  .i32 (UInt32.ofNat length) :: .i32 0 :: .i32 arr :: stack
+
+def runQuicksortExample (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModule, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store =>
+          some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_exec_empty :
+    runQuicksortExample 100 0 [] = some [] := by native_decide
+
+theorem quicksort_exec_singleton :
+    runQuicksortExample 200 0 [42] = some [42] := by native_decide
+
+theorem quicksort_exec_five :
+    runQuicksortExample 15000 0 [5, 1, 4, 2, 3] = some [1, 2, 3, 4, 5] := by
+  native_decide
+
+theorem quicksort_exec_duplicates :
+    runQuicksortExample 18000 0 [4, 1, 4, 2, 1, 3] = some [1, 1, 2, 3, 4, 4] := by
+  native_decide
+
+theorem quicksort_exec_sorted :
+    runQuicksortExample 10000 0 [1, 2, 3, 4] = some [1, 2, 3, 4] := by native_decide
+
+/-! ## TerminatesWith witnesses -/
+
+private def configDefault : Config Unit :=
+  { expr := .done []
+    store :=
+      { runtime := { module := default, host := {} }
+        wasm := { globals := default, mem := default, host := () } } }
+
+private def quicksortExampleConfig (arr : UInt32) (input : List UInt32) : Config Unit :=
+  (SmallStep.initConfig
+      { module := quicksortModule, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length [])).toOption.getD configDefault
+
+theorem quicksort_terminates_empty :
+    SmallStep.TerminatesWith (quicksortExampleConfig 0 [])
+        (fun _ store => readWordArray store.wasm.mem 0 0 = []) := by
+  apply SmallStep.runSteps_checked_terminates (fuel := 100)
+      (fun _ store => readWordArray store.wasm.mem 0 0 == [])
+  · native_decide
+  · intro _ store h; simp only [beq_iff_eq] at h; exact h
+
+theorem quicksort_terminates_singleton :
+    SmallStep.TerminatesWith (quicksortExampleConfig 0 [42])
+        (fun _ store => readWordArray store.wasm.mem 0 1 = [42]) := by
+  apply SmallStep.runSteps_checked_terminates (fuel := 200)
+      (fun _ store => readWordArray store.wasm.mem 0 1 == [42])
+  · native_decide
+  · intro _ store h; simp only [beq_iff_eq] at h; exact h
+
+theorem quicksort_terminates_five :
+    SmallStep.TerminatesWith (quicksortExampleConfig 0 [5, 1, 4, 2, 3])
+        (fun _ store => readWordArray store.wasm.mem 0 5 = [1, 2, 3, 4, 5]) := by
+  apply SmallStep.runSteps_checked_terminates (fuel := 15000)
+      (fun _ store => readWordArray store.wasm.mem 0 5 == [1, 2, 3, 4, 5])
+  · native_decide
+  · intro _ store h; simp only [beq_iff_eq] at h; exact h
+
+theorem quicksort_terminates_duplicates :
+    SmallStep.TerminatesWith (quicksortExampleConfig 0 [4, 1, 4, 2, 1, 3])
+        (fun _ store => readWordArray store.wasm.mem 0 6 = [1, 1, 2, 3, 4, 4]) := by
+  apply SmallStep.runSteps_checked_terminates (fuel := 18000)
+      (fun _ store => readWordArray store.wasm.mem 0 6 == [1, 1, 2, 3, 4, 4])
+  · native_decide
+  · intro _ store h; simp only [beq_iff_eq] at h; exact h
+
+theorem quicksort_terminates_sorted :
+    SmallStep.TerminatesWith (quicksortExampleConfig 0 [1, 2, 3, 4])
+        (fun _ store => readWordArray store.wasm.mem 0 4 = [1, 2, 3, 4]) := by
+  apply SmallStep.runSteps_checked_terminates (fuel := 10000)
+      (fun _ store => readWordArray store.wasm.mem 0 4 == [1, 2, 3, 4])
+  · native_decide
+  · intro _ store h; simp only [beq_iff_eq] at h; exact h
+
+/-! ## Differential check -/
+
+-- Wasm.run (big-step, Interpreter.Wasm.Semantics) is imported transitively
+-- through SmallStep.lean. Result.Success carries the final store.
+def runQuicksortLegacy (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match Wasm.run fuel quicksortModule 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .Success _ store => some (readWordArray store.mem arr input.length)
+  | _ => none
+
+theorem quicksort_small_large_agree :
+    runQuicksortExample 15000 0 [5, 1, 4, 2, 3] =
+    runQuicksortLegacy 5000 0 [5, 1, 4, 2, 3] := by native_decide
+
+/-! ## Mutation tests -/
+
+private def partitionFunctionMutated1 : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32, .i32, .i32, .i32, .i32]
+    results := [.i32]
+    body :=
+      partitionInit ++
+      whileDo partitionScanCondition
+        ([.localGet 3] ++ loadAt 0 5 ++ [.geU,
+          .iff 0 0 [] (swapAt 0 4 5 7 ++ increment 4)] ++
+         increment 5) ++
+      partitionPlacePivot ++
+      [.ret] }
+
+private def quicksortModuleMutated1 : Module :=
+  { funcs := [partitionFunctionMutated1, quicksortFunction 0 1]
+    memory := some { pagesMin := 1 } }
+
+def runQuicksortMutated1 (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModuleMutated1, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store => some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_mutation_comparison :
+    runQuicksortMutated1 15000 0 [5, 1, 4, 2, 3] ≠ some [1, 2, 3, 4, 5] := by
+  native_decide
+
+private def partitionFunctionMutated2 : Function :=
+  { params := [.i32, .i32, .i32]
+    locals := [.i32, .i32, .i32, .i32, .i32]
+    results := [.i32]
+    body :=
+      partitionInit ++
+      whileDo partitionScanCondition partitionScanStep ++
+      swapAt 0 5 6 7 ++ [.localGet 4] ++
+      [.ret] }
+
+private def quicksortModuleMutated2 : Module :=
+  { funcs := [partitionFunctionMutated2, quicksortFunction 0 1]
+    memory := some { pagesMin := 1 } }
+
+def runQuicksortMutated2 (fuel : Nat) (arr : UInt32) (input : List UInt32) :
+    Option (List UInt32) :=
+  match SmallStep.initConfig
+      { module := quicksortModuleMutated2, host := {} } 1
+      (quicksortExampleStore arr input)
+      (quicksortArguments arr input.length []) with
+  | .error _ => none
+  | .ok config =>
+      match (SmallStep.runSteps fuel config).result with
+      | .success _ store => some (readWordArray store.wasm.mem arr input.length)
+      | _ => none
+
+theorem quicksort_mutation_index :
+    runQuicksortMutated2 15000 0 [5, 1, 4, 2, 3] ≠ some [1, 2, 3, 4, 5] := by
+  native_decide
+
+/-! ## Oracle agreement -/
+
+theorem quicksort_oracle_empty :
+    runQuicksortExample 100 0 [] =
+    some (List.mergeSort []) := by native_decide
+
+theorem quicksort_oracle_singleton :
+    runQuicksortExample 200 0 [42] =
+    some (List.mergeSort [42]) := by native_decide
+
+theorem quicksort_oracle_five :
+    runQuicksortExample 15000 0 [5, 1, 4, 2, 3] =
+    some (List.mergeSort [5, 1, 4, 2, 3]) := by native_decide
+
+theorem quicksort_oracle_duplicates :
+    runQuicksortExample 18000 0 [4, 1, 4, 2, 1, 3] =
+    some (List.mergeSort [4, 1, 4, 2, 1, 3]) := by native_decide
+
+theorem quicksort_oracle_sorted :
+    runQuicksortExample 10000 0 [1, 2, 3, 4] =
+    some (List.mergeSort [1, 2, 3, 4]) := by native_decide
+
+end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Laws.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Laws.lean
@@ -466,4 +466,15 @@ theorem wp_loop_löb_family_from
   subst initialLocals
   exact wp_loop_löb_family locals I initial hbelow body_closes
 
+theorem u32_ofNat_sub_eq {a b : Nat} (hle : b ≤ a) (ha : a < UInt32.size) :
+    UInt32.ofNat a - UInt32.ofNat b = UInt32.ofNat (a - b) := by
+  have hb : b < UInt32.size := Nat.lt_of_le_of_lt hle ha
+  have hab : a - b < UInt32.size := Nat.lt_of_le_of_lt (Nat.sub_le a b) ha
+  apply UInt32.toNat.inj
+  rw [UInt32.toNat_sub, UInt32.toNat_ofNat_of_lt' ha, UInt32.toNat_ofNat_of_lt' hb,
+      UInt32.toNat_ofNat_of_lt' hab]
+  have := (UInt32.ofNat a).toNat_lt
+  rw [UInt32.toNat_ofNat_of_lt' ha] at this
+  omega
+
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Laws.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Laws.lean
@@ -1,0 +1,469 @@
+import CodeLib.Examples.Quicksort.Pure
+
+/-!
+# Derived laws for the quicksort proof
+
+Compact contextual WP rule for the swapAt instruction sequence.
+-/
+
+namespace Wasm.Examples.Quicksort
+
+open Wasm
+open Iris Iris.ProgramLogic Language.Notation
+open Wasm.SepLogic
+open Wasm.SmallStep
+
+-- address arithmetic (same proof as MergeSort.Laws.arrayAddress_toNat)
+private theorem arrayAddress_toNat (base : UInt32) {index length : Nat}
+    (hfit : base.toNat + 4 * length ≤ UInt32.size)
+    (hindex : index < length) :
+    (base + UInt32.ofNat index * 4).toNat = base.toNat + 4 * index := by
+  have hi : index < UInt32.size := by omega
+  have hp : index * 4 < UInt32.size := by omega
+  rw [UInt32.toNat_add, UInt32.toNat_mul, UInt32.toNat_ofNat_of_lt' hi]
+  have hfour : (4 : UInt32).toNat = 4 := by decide
+  rw [hfour, Nat.mod_eq_of_lt hp, Nat.mul_comm index 4]
+  apply Nat.mod_eq_of_lt
+  change base.toNat + 4 * index < UInt32.size
+  omega
+
+theorem wp_address
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex elementIndex : Nat} {base element : UInt32}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (helement : (⟨params, localValues, stack⟩ : Locals).get elementIndex =
+      some (.i32 element)) :
+    ▷ WP (.running
+      ⟨⟨params, localValues, .i32 (4 * element + base) :: stack⟩,
+        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        address baseIndex elementIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  iintro Hwp
+  simp only [address, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.wp_localGet hbase
+  inext
+  iapply Wasm.SmallStep.wp_localGet (by simpa using helement)
+  inext
+  iapply Wasm.SmallStep.wp_const
+  inext
+  iapply Wasm.SmallStep.wp_mul
+  inext
+  iapply Wasm.SmallStep.wp_add
+  iexact Hwp
+
+theorem wp_loadAt_cell
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex elementIndex : Nat} {base element addr word : UInt32}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (helement : (⟨params, localValues, stack⟩ : Locals).get elementIndex =
+      some (.i32 element))
+    (haddress : 4 * element + base = addr)
+    (h1 : (addr + 1).toNat = addr.toNat + 1)
+    (h2 : (addr + 2).toNat = addr.toNat + 2)
+    (h3 : (addr + 3).toNat = addr.toNat + 3) :
+    pointsTo_u32 addr word ∗
+      (pointsTo_u32 addr word -∗
+        WP (.running
+          ⟨⟨params, localValues, .i32 word :: stack⟩,
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        loadAt baseIndex elementIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  have h1' : ((addr + 0) + 1).toNat = (addr + 0).toNat + 1 := by simpa using h1
+  have h2' : ((addr + 0) + 2).toNat = (addr + 0).toNat + 2 := by simpa using h2
+  have h3' : ((addr + 0) + 3).toNat = (addr + 0).toNat + 3 := by simpa using h3
+  iintro ⟨Hword, Hcont⟩
+  simp only [loadAt, List.append_assoc, List.cons_append, List.nil_append]
+  iapply wp_address hbase helement
+  inext
+  rw [haddress]
+  ihave HwordLater : ▷ pointsTo_u32 (addr + 0) word $$ [Hword]
+  · inext
+    rw [UInt32.add_zero]
+    iexact Hword
+  iapply Wasm.SmallStep.wp_load32
+    (address := addr) (offset := 0)
+    word (by simp) h1' h2' h3' $$ HwordLater
+  inext
+  iintro Hword
+  iapply Hcont
+  rw [UInt32.add_zero]
+  iexact Hword
+
+set_option maxHeartbeats 2000000 in
+theorem wp_loadAt
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex elementIndex : Nat} {base : UInt32}
+    {input : List UInt32} {k : Nat} (hk : k < input.length)
+    (hfit : base.toNat + 4 * input.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (helement : (⟨params, localValues, stack⟩ : Locals).get elementIndex =
+      some (.i32 (UInt32.ofNat k))) :
+    arrayAt base input ∗
+      (arrayAt base input -∗
+        WP (.running
+          ⟨⟨params, localValues, .i32 input[k] :: stack⟩,
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        loadAt baseIndex elementIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  have hslot : (base + 4 * UInt32.ofNat k).toNat = base.toNat + 4 * k := by
+    simpa [UInt32.mul_comm] using arrayAddress_toNat base hfit hk
+  have hroom : (base + 4 * UInt32.ofNat k).toNat + 4 ≤ UInt32.size := by
+    rw [hslot]; omega
+  have hroom' : (base + 4 * UInt32.ofNat k).toNat + 4 ≤ 4294967296 := by
+    simpa only [UInt32.size] using hroom
+  have h1 : ((base + 4 * UInt32.ofNat k) + 1).toNat =
+      (base + 4 * UInt32.ofNat k).toNat + 1 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap
+      (base + 4 * UInt32.ofNat k) 1 (by decide) (by omega)
+  have h2 : ((base + 4 * UInt32.ofNat k) + 2).toNat =
+      (base + 4 * UInt32.ofNat k).toNat + 2 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap
+      (base + 4 * UInt32.ofNat k) 2 (by decide) (by omega)
+  have h3 : ((base + 4 * UInt32.ofNat k) + 3).toNat =
+      (base + 4 * UInt32.ofNat k).toNat + 3 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap
+      (base + 4 * UInt32.ofNat k) 3 (by decide) (by omega)
+  iintro ⟨Harray, Hcont⟩
+  ihave Hfocus := arrayAt_get base input k hk $$ Harray
+  icases Hfocus with ⟨Hword, Hclose⟩
+  iapply wp_loadAt_cell hbase helement
+    (by rw [UInt32.add_comm])
+    h1 h2 h3
+  isplitl [Hword]
+  · iexact Hword
+  iintro Hword
+  iapply Hcont
+  iapply Hclose
+  iexact Hword
+
+private theorem wp_store32_cell
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {address oldWord newWord : UInt32}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (h1 : (address + 1).toNat = address.toNat + 1)
+    (h2 : (address + 2).toNat = address.toNat + 2)
+    (h3 : (address + 3).toNat = address.toNat + 3) :
+    pointsTo_u32 address oldWord ∗
+      (pointsTo_u32 address newWord -∗
+        WP (.running
+          ⟨⟨params, localValues, stack⟩,
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running
+      ⟨⟨params, localValues, .i32 newWord :: .i32 address :: stack⟩,
+        .store32 0 :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  have h1' : ((address + 0) + 1).toNat = (address + 0).toNat + 1 := by simpa using h1
+  have h2' : ((address + 0) + 2).toNat = (address + 0).toNat + 2 := by simpa using h2
+  have h3' : ((address + 0) + 3).toNat = (address + 0).toNat + 3 := by simpa using h3
+  iintro ⟨Hword, Hcont⟩
+  ihave HwordLater : ▷ pointsTo_u32 (address + 0) oldWord $$ [Hword]
+  · inext
+    rw [UInt32.add_zero]
+    iexact Hword
+  iapply Wasm.SmallStep.wp_store32
+    (address := address) (offset := 0) oldWord
+    (by simp) h1' h2' h3' $$ HwordLater
+  inext
+  iintro Hword
+  ihave Hword' : pointsTo_u32 address newWord $$ [Hword]
+  · rw [UInt32.add_zero]
+    iexact Hword
+  iapply Hcont
+  iexact Hword'
+
+set_option maxHeartbeats 2000000 in
+theorem wp_swapAt
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex aIndex bIndex tmpIndex : Nat}
+    {base : UInt32} {input : List UInt32} {a b : Nat}
+    {updated : Locals}
+    (ha : a < input.length) (hb : b < input.length)
+    (hfit : base.toNat + 4 * input.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (ha_local : (⟨params, localValues, stack⟩ : Locals).get aIndex =
+      some (.i32 (UInt32.ofNat a)))
+    (htmp_set : (⟨params, localValues, .i32 input[a] :: stack⟩ : Locals).set?
+      tmpIndex (.i32 input[a]) = some updated)
+    (hbase_after : updated.get baseIndex = some (.i32 base))
+    (ha_after : updated.get aIndex = some (.i32 (UInt32.ofNat a)))
+    (hb_after : updated.get bIndex = some (.i32 (UInt32.ofNat b)))
+    (htmp_after : updated.get tmpIndex = some (.i32 input[a])) :
+    arrayAt base input ∗
+      (arrayAt base (swapElems input a b) -∗
+        WP (.running
+          ⟨{ updated with values := stack },
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        swapAt baseIndex aIndex bIndex tmpIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  let addr_a : UInt32 := 4 * UInt32.ofNat a + base
+  have hslot_a : addr_a.toNat = base.toNat + 4 * a := by
+    dsimp [addr_a]; rw [UInt32.add_comm]
+    simpa [UInt32.mul_comm] using arrayAddress_toNat base hfit ha
+  have hroom_a : addr_a.toNat + 4 ≤ UInt32.size := by rw [hslot_a]; omega
+  have h1_a : (addr_a + 1).toNat = addr_a.toNat + 1 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_a 1
+      (by decide) (by
+        have : addr_a.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_a
+        omega)
+  have h2_a : (addr_a + 2).toNat = addr_a.toNat + 2 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_a 2
+      (by decide) (by
+        have : addr_a.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_a
+        omega)
+  have h3_a : (addr_a + 3).toNat = addr_a.toNat + 3 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_a 3
+      (by decide) (by
+        have : addr_a.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_a
+        omega)
+  let addr_b : UInt32 := 4 * UInt32.ofNat b + base
+  have hslot_b : addr_b.toNat = base.toNat + 4 * b := by
+    dsimp [addr_b]; rw [UInt32.add_comm]
+    simpa [UInt32.mul_comm] using arrayAddress_toNat base hfit hb
+  have hroom_b : addr_b.toNat + 4 ≤ UInt32.size := by rw [hslot_b]; omega
+  have h1_b : (addr_b + 1).toNat = addr_b.toNat + 1 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_b 1
+      (by decide) (by
+        have : addr_b.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_b
+        omega)
+  have h2_b : (addr_b + 2).toNat = addr_b.toNat + 2 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_b 2
+      (by decide) (by
+        have : addr_b.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_b
+        omega)
+  have h3_b : (addr_b + 3).toNat = addr_b.toNat + 3 := by
+    simpa using UInt32.add_ofNat_toNat_noWrap addr_b 3
+      (by decide) (by
+        have : addr_b.toNat + 4 ≤ 4294967296 := by
+          simpa only [UInt32.size] using hroom_b
+        omega)
+  have hswap : swapElems input a b = (input.set a input[b]).set b input[a] := by
+    unfold swapElems
+    rw [getElem!_pos input b hb, getElem!_pos input a ha]
+  iintro ⟨Harray, Hcont⟩
+  simp only [swapAt, storeAt, List.append_assoc,
+    List.cons_append, List.nil_append]
+  -- step 1: load arr[a] onto stack
+  iapply wp_loadAt ha hfit hbase ha_local
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  -- step 2: save arr[a] in tmp local
+  iapply Wasm.SmallStep.wp_localSet htmp_set
+  inext
+  -- step 3: compute address of arr[a]
+  iapply wp_address (by exact hbase_after) (by exact ha_after)
+  inext
+  -- step 4: load arr[b] onto stack
+  iapply wp_loadAt hb hfit (by exact hbase_after) (by exact hb_after)
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  -- focus on cell a for the first store
+  ihave Hfocus := arrayAt_set base input a input[b] ha $$ Harray
+  icases Hfocus with ⟨Hcell_a, Hclose_a⟩
+  ihave Hcell_a' : pointsTo_u32 addr_a input[a] $$ [Hcell_a]
+  · dsimp [addr_a]
+    rw [UInt32.add_comm]
+    iexact Hcell_a
+  -- step 5: store arr[b] at arr[a]
+  iapply wp_store32_cell h1_a h2_a h3_a
+  isplitl [Hcell_a']
+  · iexact Hcell_a'
+  iintro Hcell_a
+  -- rebuild intermediate array
+  ihave Harray2 : arrayAt base (input.set a input[b]) $$ [Hcell_a Hclose_a]
+  · iapply Hclose_a
+    rw [UInt32.add_comm]
+    iexact Hcell_a
+  -- step 6: compute address of arr[b]
+  iapply wp_address (by exact hbase_after) (by exact hb_after)
+  inext
+  -- step 7: push tmp (= original arr[a]) onto stack
+  iapply Wasm.SmallStep.wp_localGet (by exact htmp_after)
+  inext
+  -- focus on cell b for the second store
+  have hb' : b < (input.set a input[b]).length := by rw [List.length_set]; exact hb
+  ihave Hfocus := arrayAt_set base (input.set a input[b]) b input[a] hb' $$ Harray2
+  icases Hfocus with ⟨Hcell_b, Hclose_b⟩
+  ihave Hcell_b' : pointsTo_u32 addr_b (input.set a input[b])[b] $$ [Hcell_b]
+  · dsimp [addr_b]
+    rw [UInt32.add_comm]
+    iexact Hcell_b
+  -- step 8: store original arr[a] at arr[b]
+  iapply wp_store32_cell h1_b h2_b h3_b
+  isplitl [Hcell_b']
+  · iexact Hcell_b'
+  iintro Hcell_b
+  -- apply continuation with swapped array
+  iapply Hcont
+  rw [hswap]
+  iapply Hclose_b
+  rw [UInt32.add_comm]
+  iexact Hcell_b
+
+theorem u32_ofNat_succ {n : Nat} (h : n + 1 < UInt32.size) :
+    UInt32.ofNat n + 1 = UInt32.ofNat (n + 1) := by
+  apply UInt32.toNat.inj
+  rw [UInt32.toNat_add]
+  have hn : n < UInt32.size := by omega
+  rw [UInt32.toNat_ofNat_of_lt' hn]
+  have hone : (1 : UInt32).toNat = 1 := by decide
+  rw [hone, Nat.mod_eq_of_lt]
+  · symm; exact UInt32.toNat_ofNat_of_lt' h
+  · simpa only [UInt32.size] using h
+
+theorem wp_lessLocal
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {lhsIndex rhsIndex : Nat} {lhs rhs : UInt32}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hlhs : (⟨params, localValues, stack⟩ : Locals).get lhsIndex = some (.i32 lhs))
+    (hrhs : (⟨params, localValues, stack⟩ : Locals).get rhsIndex = some (.i32 rhs)) :
+    ▷ WP (.running
+        ⟨⟨params, localValues, .i32 (if lhs < rhs then 1 else 0) :: stack⟩,
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        lessLocal lhsIndex rhsIndex ++ code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  iintro Hwp
+  simp only [lessLocal, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.wp_localGet hlhs
+  inext
+  iapply Wasm.SmallStep.wp_localGet (by simpa using hrhs)
+  inext
+  iapply Wasm.SmallStep.wp_ltU rfl
+  iexact Hwp
+
+theorem wp_increment
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {index : Nat} {value : UInt32} {updated : Locals}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hget : (⟨params, localValues, stack⟩ : Locals).get index = some (.i32 value))
+    (hset : (⟨params, localValues, .i32 (1 + value) :: stack⟩ : Locals).set?
+        index (.i32 (1 + value)) = some updated) :
+    ▷ WP (.running
+        ⟨{ updated with values := stack }, code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        increment index ++ code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  iintro Hwp
+  simp only [increment, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.wp_localGet hget
+  inext
+  iapply Wasm.SmallStep.wp_const
+  inext
+  iapply Wasm.SmallStep.wp_add
+  inext
+  iapply Wasm.SmallStep.wp_localSet hset
+  iexact Hwp
+
+theorem wp_increment_nil
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {index : Nat} {value : UInt32} {updated : Locals}
+    {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hget : (⟨params, localValues, stack⟩ : Locals).get index = some (.i32 value))
+    (hset : (⟨params, localValues, .i32 (1 + value) :: stack⟩ : Locals).set?
+        index (.i32 (1 + value)) = some updated) :
+    ▷ WP (.running
+        ⟨{ updated with values := stack }, [], arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        increment index, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  simpa only [List.append_nil] using (wp_increment (s := s) (E := E) (Φ := Φ) (code := []) hget hset)
+
+theorem wp_loop_löb_family_from
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {ι : Type} (locals : ι → Locals) (I : ι → IProp WasmHeapGF)
+    (initial : ι) (initialLocals : Locals)
+    {paramArity resultArity arity : Nat}
+    {body code : Program} {remainder belowStack : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hinitial : locals initial = initialLocals)
+    (hbelow : belowStack = (locals initial).values.drop paramArity)
+    (body_closes : ∀ i,
+      ⊢@{IProp WasmHeapGF} (iprop%
+        ▷ (∀ (j : ι), I j -∗
+          WP (loopBodyExpr (α := Unit) (locals j)
+            paramArity resultArity arity body code remainder belowStack
+            controls calls) @ s; E {{ Φ }}) -∗
+        I i -∗
+          WP (loopBodyExpr (α := Unit) (locals i)
+            paramArity resultArity arity body code remainder belowStack
+            controls calls) @ s; E {{ Φ }})) :
+    I initial ⊢
+      WP (.running
+        ⟨initialLocals, .loop paramArity resultArity body :: code,
+          arity, remainder, controls, calls⟩ : Expr Unit) @ s; E {{ Φ }} := by
+  subst initialLocals
+  exact wp_loop_löb_family locals I initial hbelow body_closes
+
+end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Proof.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Proof.lean
@@ -477,4 +477,295 @@ theorem wp_partition
     List.cons_append]
   iapply Hcont $$ %output %pivotIdx Hruntime %hrange Harray
 
+def quicksortLocals (arr : UInt32) (lo hi : Nat) (pivotIdx : Nat)
+    (stack : List Value := []) : Locals :=
+  ⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+    [.i32 (UInt32.ofNat pivotIdx)],
+    stack⟩
+
+set_option maxHeartbeats 8000000 in
+private theorem wp_quicksortBody_aux
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (partitionIdx quicksortIdx : Nat)
+    (himports_p : ¬partitionIdx < runtimeModule.imports.length)
+    (hfunction_p : runtimeModule.funcs[partitionIdx - runtimeModule.imports.length]? =
+        some partitionFunction)
+    (himports_q : ¬quicksortIdx < runtimeModule.imports.length)
+    (hfunction_q : runtimeModule.funcs[quicksortIdx - runtimeModule.imports.length]? =
+        some (quicksortFunction partitionIdx quicksortIdx))
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hlohi : lo ≤ hi)
+    (hhilen : hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    (n : Nat) (hn : hi - lo ≤ n)
+    {callerLocals : Locals}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    {stack : List Value} :
+    runtimeModuleOwn runtimeModule ∗
+      arrayAt arr input ∗
+      (∀ (output : List UInt32),
+        runtimeModuleOwn runtimeModule -∗
+        ⌜output.length = input.length ∧ output.take lo = input.take lo ∧
+          output.drop hi = input.drop hi ∧ Sorted (segment output lo hi) ∧
+          List.Perm (segment input lo hi) (segment output lo hi)⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+              code, arity, remainder, controls, calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat hi) :: .i32 (UInt32.ofNat lo) :: .i32 arr :: stack },
+        .call quicksortIdx :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} := by
+  induction n generalizing input lo hi callerLocals code arity remainder controls calls stack with
+  | zero =>
+    have heq : hi = lo := by omega
+    subst heq
+    iintro ⟨Hruntime, Harray, Hcont⟩
+    ihave HruntimeLater : ▷ runtimeModuleOwn runtimeModule $$ [Hruntime]
+    · inext; iexact Hruntime
+    iapply Wasm.SmallStep.wp_call runtimeModule quicksortIdx
+        (quicksortFunction partitionIdx quicksortIdx)
+        himports_q hfunction_q $$ HruntimeLater
+    inext; iintro Hruntime
+    simp [quicksortFunction, Function.toLocals, Function.numParams, ValueType.zero]
+    simp only [quicksortBody, quicksortBaseCheck, List.append_assoc, List.cons_append,
+      List.nil_append]
+    iapply Wasm.SmallStep.wp_localGet rfl; inext
+    iapply Wasm.SmallStep.wp_localGet rfl; inext
+    iapply Wasm.SmallStep.wp_sub; inext
+    have hloSub : UInt32.ofNat hi - UInt32.ofNat hi = 0 := by simp
+    simp only [hloSub]
+    iapply Wasm.SmallStep.wp_const; inext
+    iapply Wasm.SmallStep.wp_ltU rfl; inext
+    simp only [if_pos (by decide : (0 : UInt32) < 2)]
+    iapply Wasm.SmallStep.wp_iff rfl; inext
+    simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
+    iapply Wasm.SmallStep.wp_returnFromCallExplicit; inext
+    simp only [List.take_zero, List.nil_append]
+    have hpure0 : input.length = input.length ∧ input.take hi = input.take hi ∧
+        input.drop hi = input.drop hi ∧ Sorted (segment input hi hi) ∧
+        List.Perm (segment input hi hi) (segment input hi hi) :=
+      ⟨rfl, rfl, rfl, quicksort_base input hi hi hhilen (by omega), List.Perm.refl _⟩
+    iapply Hcont $$ %input Hruntime %hpure0 Harray
+  | succ n ih =>
+    iintro ⟨Hruntime, Harray, Hcont⟩
+    have hiSize : hi < UInt32.size := by
+      have : UInt32.size = 4294967296 := rfl; omega
+    have hdiffSize : hi - lo < UInt32.size := Nat.lt_of_le_of_lt (Nat.sub_le hi lo) hiSize
+    have hsubEq : UInt32.ofNat hi - UInt32.ofNat lo = UInt32.ofNat (hi - lo) := by
+      have hloSize : lo < UInt32.size := Nat.lt_of_le_of_lt hlohi hiSize
+      apply UInt32.toNat.inj
+      rw [UInt32.toNat_sub, UInt32.toNat_ofNat_of_lt' hiSize,
+          UInt32.toNat_ofNat_of_lt' hloSize, UInt32.toNat_ofNat_of_lt' hdiffSize]
+      have := (UInt32.ofNat hi).toNat_lt
+      rw [UInt32.toNat_ofNat_of_lt' hiSize] at this
+      omega
+    ihave HruntimeLater : ▷ runtimeModuleOwn runtimeModule $$ [Hruntime]
+    · inext; iexact Hruntime
+    iapply Wasm.SmallStep.wp_call runtimeModule quicksortIdx
+        (quicksortFunction partitionIdx quicksortIdx)
+        himports_q hfunction_q $$ HruntimeLater
+    inext; iintro Hruntime
+    simp [quicksortFunction, Function.toLocals, Function.numParams, ValueType.zero]
+    simp only [quicksortBody, quicksortBaseCheck, quicksortPartitionCall, quicksortLeftCall,
+      quicksortRightCall, List.append_assoc, List.cons_append, List.nil_append]
+    iapply Wasm.SmallStep.wp_localGet rfl; inext
+    iapply Wasm.SmallStep.wp_localGet rfl; inext
+    iapply Wasm.SmallStep.wp_sub; inext
+    simp only [hsubEq]
+    iapply Wasm.SmallStep.wp_const; inext
+    iapply Wasm.SmallStep.wp_ltU rfl; inext
+    by_cases hbase : hi - lo < 2
+    · have h_lt_u32 : UInt32.ofNat (hi - lo) < 2 := by
+        have h2 : (2 : UInt32).toNat = 2 := rfl
+        rw [UInt32.lt_iff_toNat_lt, UInt32.toNat_ofNat_of_lt' hdiffSize, h2]; exact hbase
+      simp only [if_pos h_lt_u32]
+      iapply Wasm.SmallStep.wp_iff rfl; inext
+      simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
+      iapply Wasm.SmallStep.wp_returnFromCallExplicit; inext
+      simp only [List.take_zero, List.nil_append]
+      have hpure_base : input.length = input.length ∧ input.take lo = input.take lo ∧
+          input.drop hi = input.drop hi ∧ Sorted (segment input lo hi) ∧
+          List.Perm (segment input lo hi) (segment input lo hi) :=
+        ⟨rfl, rfl, rfl, quicksort_base input lo hi hhilen hbase, List.Perm.refl _⟩
+      iapply Hcont $$ %input Hruntime %hpure_base Harray
+    · have h_not_lt : ¬UInt32.ofNat (hi - lo) < 2 := by
+        have h2 : (2 : UInt32).toNat = 2 := rfl
+        rw [UInt32.lt_iff_toNat_lt, UInt32.toNat_ofNat_of_lt' hdiffSize, h2]; omega
+      have hlohi_strict : lo < hi := by omega
+      simp only [if_neg h_not_lt]
+      iapply Wasm.SmallStep.wp_iff rfl; inext
+      simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
+      iapply Wasm.SmallStep.wp_exitControl rfl; inext
+      simp only [List.take_zero, List.nil_append, List.drop_zero]
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      ihave HruntimeLater_p : ▷ runtimeModuleOwn runtimeModule $$ [Hruntime]
+      · inext; iexact Hruntime
+      iapply Wasm.SmallStep.wp_call runtimeModule partitionIdx partitionFunction himports_p
+          hfunction_p $$ HruntimeLater_p
+      inext; iintro Hruntime_p
+      simp [partitionFunction, Function.toLocals, Function.numParams, ValueType.zero]
+      iapply wp_partitionBody_from
+          (⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+            [.i32 0, .i32 0, .i32 0, .i32 0, .i32 0], []⟩ : Locals)
+          arr input lo hi ⟨hlohi_strict, hhilen⟩ hfit rfl
+      isplitl [Harray]
+      · iexact Harray
+      iintro %output_p %pivotIdx %tmp %hpart Harray_p
+      obtain ⟨hlo, hphi, hhilen_p, hlen_p, htake_p, hdrop_p, hperm_p, hleft_p, hright_p⟩ := hpart
+      iapply Wasm.SmallStep.wp_returnFromCallExplicit; inext
+      simp only [partitionLocals, List.take_succ_cons, List.take_zero, List.nil_append,
+        List.cons_append]
+      have hset_piv :
+          (⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)], [.i32 0],
+            [.i32 (UInt32.ofNat pivotIdx)]⟩ : Locals).set?
+            3 (.i32 (UInt32.ofNat pivotIdx)) =
+          some ⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+                [.i32 (UInt32.ofNat pivotIdx)], [.i32 (UInt32.ofNat pivotIdx)]⟩ := rfl
+      iapply Wasm.SmallStep.wp_localSet hset_piv; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      have hhilen_left : pivotIdx ≤ output_p.length := by omega
+      have hfit_left : arr.toNat + 4 * output_p.length ≤ UInt32.size := by rw [hlen_p]; exact hfit
+      have hn_left : pivotIdx - lo ≤ n := by omega
+      iapply ih output_p lo pivotIdx hlo hhilen_left hfit_left hn_left
+      isplitl [Hruntime_p]
+      · iexact Hruntime_p
+      isplitl [Harray_p]
+      · iexact Harray_p
+      iintro %out_l Hruntime_l %hpure_l Harray_l
+      obtain ⟨hlen_l, htake_l, hdrop_l, hsorted_l, hperm_l⟩ := hpure_l
+      simp only [quicksortLocals]
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      iapply Wasm.SmallStep.wp_const; inext
+      iapply Wasm.SmallStep.wp_add; inext
+      have hpivSuccSize : pivotIdx + 1 < UInt32.size := by
+        have : UInt32.size = 4294967296 := rfl; omega
+      have hpivValue : 1 + UInt32.ofNat pivotIdx = UInt32.ofNat (pivotIdx + 1) := by
+        rw [UInt32.add_comm, u32_ofNat_succ hpivSuccSize]
+      simp only [hpivValue]
+      iapply Wasm.SmallStep.wp_localGet rfl; inext
+      have hlohi_right : pivotIdx + 1 ≤ hi := by omega
+      have hhilen_right : hi ≤ out_l.length := by omega
+      have hfit_right : arr.toNat + 4 * out_l.length ≤ UInt32.size := by
+        rw [hlen_l, hlen_p]; exact hfit
+      have hn_right : hi - (pivotIdx + 1) ≤ n := by omega
+      iapply (ih (callerLocals := ⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+          [.i32 (UInt32.ofNat pivotIdx)], []⟩)
+        out_l (pivotIdx + 1) hi hlohi_right hhilen_right hfit_right hn_right)
+      isplitl [Hruntime_l]
+      · iexact Hruntime_l
+      isplitl [Harray_l]
+      · iexact Harray_l
+      iintro %out_r Hruntime_r %hpure_r Harray_r
+      obtain ⟨hlen_r, htake_r, hdrop_r, hsorted_r, hperm_r⟩ := hpure_r
+      iapply Wasm.SmallStep.wp_returnFromCallExplicit; inext
+      simp only [List.take_zero, List.nil_append]
+      have hpart_final : PartitionRange input out_r lo hi pivotIdx :=
+        partitionRange_after_sorts
+          ⟨hlo, hphi, hhilen_p, hlen_p, htake_p, hdrop_p, hperm_p, hleft_p, hright_p⟩
+          hlen_l htake_l hdrop_l hperm_l hlen_r htake_r hdrop_r hperm_r
+      have hleft_r : Sorted (segment out_r lo pivotIdx) :=
+        segment_sorted_of_take_eq (by omega) (by omega) htake_r hsorted_l
+      have hcomp := quicksort_compose input out_r lo hi pivotIdx hpart_final hleft_r hsorted_r
+      have htake_r_lo : out_r.take lo = out_l.take lo := by
+        have := congr_arg (·.take lo) htake_r
+        simp only [List.take_take, Nat.min_eq_left (by omega : lo ≤ pivotIdx + 1)] at this
+        exact this
+      have hdrop_l_hi : out_l.drop hi = output_p.drop hi := by
+        rw [show out_l.drop hi = (out_l.drop pivotIdx).drop (hi - pivotIdx) from by
+              rw [List.drop_drop]; congr 1; omega,
+            show output_p.drop hi = (output_p.drop pivotIdx).drop (hi - pivotIdx) from by
+              rw [List.drop_drop]; congr 1; omega,
+            hdrop_l]
+      have hpure_final : out_r.length = input.length ∧ out_r.take lo = input.take lo ∧
+          out_r.drop hi = input.drop hi ∧ Sorted (segment out_r lo hi) ∧
+          List.Perm (segment input lo hi) (segment out_r lo hi) :=
+        ⟨by omega, by rw [htake_r_lo, htake_l, htake_p],
+          by rw [hdrop_r, hdrop_l_hi, hdrop_p], hcomp.1, hcomp.2⟩
+      iapply Hcont $$ %out_r Hruntime_r %hpure_final Harray_r
+
+theorem wp_quicksortBody
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (partitionIdx quicksortIdx : Nat)
+    (himports_p : ¬partitionIdx < runtimeModule.imports.length)
+    (hfunction_p : runtimeModule.funcs[partitionIdx - runtimeModule.imports.length]? =
+        some partitionFunction)
+    (himports_q : ¬quicksortIdx < runtimeModule.imports.length)
+    (hfunction_q : runtimeModule.funcs[quicksortIdx - runtimeModule.imports.length]? =
+        some (quicksortFunction partitionIdx quicksortIdx))
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hlohi : lo ≤ hi)
+    (hhilen : hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    {callerLocals : Locals}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    {stack : List Value} :
+    runtimeModuleOwn runtimeModule ∗
+      arrayAt arr input ∗
+      (∀ (output : List UInt32),
+        runtimeModuleOwn runtimeModule -∗
+        ⌜output.length = input.length ∧ output.take lo = input.take lo ∧
+          output.drop hi = input.drop hi ∧ Sorted (segment output lo hi) ∧
+          List.Perm (segment input lo hi) (segment output lo hi)⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+              code, arity, remainder, controls, calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat hi) :: .i32 (UInt32.ofNat lo) :: .i32 arr :: stack },
+        .call quicksortIdx :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} :=
+  wp_quicksortBody_aux runtimeModule partitionIdx quicksortIdx himports_p hfunction_p
+    himports_q hfunction_q arr input lo hi hlohi hhilen hfit input.length
+    (Nat.le_trans (Nat.sub_le hi lo) hhilen)
+
+set_option maxHeartbeats 5000000 in
+theorem wp_quicksort
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (partitionIdx quicksortIdx : Nat)
+    (himports_p : ¬partitionIdx < runtimeModule.imports.length)
+    (hfunction_p : runtimeModule.funcs[partitionIdx - runtimeModule.imports.length]? =
+        some partitionFunction)
+    (himports_q : ¬quicksortIdx < runtimeModule.imports.length)
+    (hfunction_q : runtimeModule.funcs[quicksortIdx - runtimeModule.imports.length]? =
+        some (quicksortFunction partitionIdx quicksortIdx))
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hlohi : lo ≤ hi)
+    (hhilen : hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    {callerLocals : Locals}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    {stack : List Value} :
+    runtimeModuleOwn runtimeModule ∗
+      arrayAt arr input ∗
+      (∀ (output : List UInt32),
+        runtimeModuleOwn runtimeModule -∗
+        ⌜output.length = input.length ∧ output.take lo = input.take lo ∧
+          output.drop hi = input.drop hi ∧ Sorted (segment output lo hi) ∧
+          List.Perm (segment input lo hi) (segment output lo hi)⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+              code, arity, remainder, controls, calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat hi) :: .i32 (UInt32.ofNat lo) :: .i32 arr :: stack },
+        .call quicksortIdx :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} :=
+  wp_quicksortBody runtimeModule partitionIdx quicksortIdx himports_p hfunction_p
+    himports_q hfunction_q arr input lo hi hlohi hhilen hfit
+
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Proof.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Proof.lean
@@ -1,0 +1,480 @@
+import CodeLib.Examples.Quicksort.Laws
+
+/-!
+# Iris verification of the handwritten quicksort
+
+This file connects the pure list invariants to the small-step Wasm WP rules.
+-/
+
+namespace Wasm.Examples.Quicksort
+
+open Wasm
+open Iris Iris.ProgramLogic Language.Notation
+open Wasm.SepLogic
+open Wasm.SmallStep
+
+def partitionLocals
+    (arr : UInt32) (lo hi : Nat) (pivot : UInt32) (i j hiMinusOne : Nat)
+    (tmp : UInt32) (stack : List Value := []) : Locals :=
+  ⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+    [.i32 pivot, .i32 (UInt32.ofNat i), .i32 (UInt32.ofNat j),
+     .i32 (UInt32.ofNat hiMinusOne), .i32 tmp],
+    stack⟩
+
+set_option maxHeartbeats 4000000 in
+theorem wp_partitionScanStep
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (arr : UInt32) (input current : List UInt32)
+    (lo hi i j hiMinusOne : Nat) (pivot tmp : UInt32)
+    (_hinv : PartitionLoopInvariant input current lo hi i j pivot)
+    (_hj : j < hiMinusOne)
+    (hjLen : j < current.length)
+    (hiLen : i < current.length)
+    (hfit : arr.toNat + 4 * current.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    arrayAt arr current ∗
+      ((⌜pivot < current[j]'hjLen⌝ ∗
+          arrayAt arr current -∗
+          WP (.running ⟨partitionLocals arr lo hi pivot i (j + 1) hiMinusOne tmp [],
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ∧
+       (⌜¬ pivot < current[j]'hjLen⌝ ∗
+          arrayAt arr (swapElems current i j) -∗
+          WP (.running ⟨partitionLocals arr lo hi pivot (i + 1) (j + 1) hiMinusOne
+              (current[i]'hiLen) [],
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            @ s; E {{ Φ }})) ⊢
+    WP (.running ⟨partitionLocals arr lo hi pivot i j hiMinusOne tmp [],
+        partitionScanStep ++ code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} := by
+  have hjSucc : j + 1 < UInt32.size := by
+    have : 4 * current.length ≤ UInt32.size := by omega
+    omega
+  have hiSucc : i + 1 < UInt32.size := by
+    have : 4 * current.length ≤ UInt32.size := by omega
+    omega
+  iintro ⟨Harray, Hbranches⟩
+  simp only [partitionScanStep, List.append_assoc, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.wp_localGet rfl
+  inext
+  iapply wp_loadAt hjLen hfit rfl rfl
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  iapply Wasm.SmallStep.wp_ltU rfl
+  inext
+  by_cases hlt : pivot < current[j]'hjLen
+  · simp only [if_pos hlt]
+    iapply Wasm.SmallStep.wp_iff rfl
+    inext
+    simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
+    ihave Hthen := BI.and_elim_l $$ Hbranches
+    iapply Wasm.SmallStep.wp_exitControl rfl
+    inext
+    have hjValue : 1 + UInt32.ofNat j = UInt32.ofNat (j + 1) := by
+      rw [UInt32.add_comm, u32_ofNat_succ hjSucc]
+    have hsetJ :
+        (partitionLocals arr lo hi pivot i j hiMinusOne tmp
+            [.i32 (1 + UInt32.ofNat j)]).set?
+            5 (.i32 (1 + UInt32.ofNat j)) =
+          some (partitionLocals arr lo hi pivot i (j + 1) hiMinusOne tmp
+            [.i32 (1 + UInt32.ofNat j)]) := by
+      rw [hjValue]; rfl
+    simp only [partitionLocals, List.take_zero, List.nil_append, List.drop_zero]
+    iapply wp_increment rfl hsetJ
+    inext
+    simp only [partitionLocals]
+    iapply Hthen
+    isplitr
+    · ipureintro; exact hlt
+    iframe
+  · simp only [if_neg hlt]
+    iapply Wasm.SmallStep.wp_iff rfl
+    inext
+    simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
+    ihave Helse := BI.and_elim_r $$ Hbranches
+    have htmp_set :
+        (partitionLocals arr lo hi pivot i j hiMinusOne tmp
+            [.i32 (current[i]'hiLen)]).set?
+            7 (.i32 (current[i]'hiLen)) =
+          some (partitionLocals arr lo hi pivot i j hiMinusOne
+            (current[i]'hiLen) [.i32 (current[i]'hiLen)]) := rfl
+    simp only [partitionLocals, List.drop_zero]
+    iapply wp_swapAt hiLen hjLen hfit rfl rfl htmp_set rfl rfl rfl rfl
+    isplitl [Harray]
+    · iexact Harray
+    iintro Harray
+    have hiValue : 1 + UInt32.ofNat i = UInt32.ofNat (i + 1) := by
+      rw [UInt32.add_comm, u32_ofNat_succ hiSucc]
+    have hsetI :
+        (partitionLocals arr lo hi pivot i j hiMinusOne (current[i]'hiLen)
+            [.i32 (1 + UInt32.ofNat i)]).set?
+            4 (.i32 (1 + UInt32.ofNat i)) =
+          some (partitionLocals arr lo hi pivot (i + 1) j hiMinusOne (current[i]'hiLen)
+            [.i32 (1 + UInt32.ofNat i)]) := by
+      rw [hiValue]; rfl
+    simp only [partitionLocals]
+    iapply wp_increment_nil rfl hsetI
+    inext
+    iapply Wasm.SmallStep.wp_exitControl rfl
+    inext
+    simp only [partitionLocals, List.take_zero, List.nil_append]
+    have hjValue : 1 + UInt32.ofNat j = UInt32.ofNat (j + 1) := by
+      rw [UInt32.add_comm, u32_ofNat_succ hjSucc]
+    have hsetJ :
+        (partitionLocals arr lo hi pivot (i + 1) j hiMinusOne (current[i]'hiLen)
+            [.i32 (1 + UInt32.ofNat j)]).set?
+            5 (.i32 (1 + UInt32.ofNat j)) =
+          some (partitionLocals arr lo hi pivot (i + 1) (j + 1) hiMinusOne (current[i]'hiLen)
+            [.i32 (1 + UInt32.ofNat j)]) := by
+      rw [hjValue]; rfl
+    iapply wp_increment rfl hsetJ
+    inext
+    simp only [partitionLocals]
+    iapply Helse
+    isplitr
+    · ipureintro; exact hlt
+    iframe
+
+structure PartitionState where
+  values : List UInt32
+  i : Nat
+  j : Nat
+  tmp : UInt32
+
+set_option maxHeartbeats 4000000 in
+theorem wp_partitionScanLoop
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (arr : UInt32) (input current : List UInt32)
+    (lo hi i j hiMinusOne : Nat) (pivot tmp : UInt32)
+    (hinv : PartitionLoopInvariant input current lo hi i j pivot)
+    (hhim1 : hiMinusOne + 1 = hi)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    arrayAt arr current ∗
+      (∀ (current' : List UInt32) (i' j' : Nat) (tmp' : UInt32),
+        ⌜PartitionLoopInvariant input current' lo hi i' j' pivot⌝ -∗
+        ⌜j' = hiMinusOne⌝ -∗
+        arrayAt arr current' -∗
+        WP (.running ⟨partitionLocals arr lo hi pivot i' j' hiMinusOne tmp' [],
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨partitionLocals arr lo hi pivot i j hiMinusOne tmp [],
+        whileDo partitionScanCondition partitionScanStep ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} := by
+  let Finish : IProp WasmHeapGF := iprop%
+    ∀ (current' : List UInt32) (i' j' : Nat) (tmp' : UInt32),
+      ⌜PartitionLoopInvariant input current' lo hi i' j' pivot⌝ -∗
+      ⌜j' = hiMinusOne⌝ -∗
+      arrayAt arr current' -∗
+      WP (.running ⟨partitionLocals arr lo hi pivot i' j' hiMinusOne tmp' [],
+        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }}
+  let Inv : PartitionState → IProp WasmHeapGF := fun state => iprop%
+    ⌜PartitionLoopInvariant input state.values lo hi state.i state.j pivot⌝ ∗
+    arrayAt arr state.values ∗ Finish
+  iintro ⟨Harray, Hfinish⟩
+  simp only [whileDo, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.wp_block
+  inext
+  iapply wp_loop_löb_family_from
+    (ι := PartitionState)
+    (locals := fun state =>
+      partitionLocals arr lo hi pivot state.i state.j hiMinusOne state.tmp [])
+    (I := Inv)
+    (initial := ⟨current, i, j, tmp⟩)
+    (initialLocals := partitionLocals arr lo hi pivot i j hiMinusOne tmp [])
+    (body := whileLoopCode partitionScanCondition partitionScanStep)
+    (code := [])
+    (belowStack := [])
+    rfl
+    rfl
+  · intro state
+    simp only [Inv, Wasm.SmallStep.loopBodyExpr]
+    iintro Hrec Hinv
+    icases Hinv with ⟨%hstate, Harray, Hfinish⟩
+    have hdata := hstate
+    unfold PartitionLoopInvariant at hdata
+    obtain ⟨hli, hij, hjhim1, hhilen, hlen, -, -, -, -, -, -⟩ := hdata
+    have hjLen : state.j < state.values.length := by omega
+    have hiLen : state.i < state.values.length := by omega
+    have hlenEq : state.values.length = input.length := hstate.2.2.2.2.1
+    have hfitState : arr.toNat + 4 * state.values.length ≤ UInt32.size := by
+      rw [hlenEq]; exact hfit
+    have hjSize : state.j < UInt32.size := by
+      have : 4 * input.length ≤ UInt32.size := by omega
+      omega
+    have hiMinOneSize : hiMinusOne < UInt32.size := by
+      have : 4 * input.length ≤ UInt32.size := by omega
+      omega
+    have hjCmp :
+        (UInt32.ofNat state.j < UInt32.ofNat hiMinusOne) ↔ state.j < hiMinusOne := by
+      change (UInt32.ofNat state.j).toNat < (UInt32.ofNat hiMinusOne).toNat ↔ _
+      rw [UInt32.toNat_ofNat_of_lt' hjSize, UInt32.toNat_ofNat_of_lt' hiMinOneSize]
+    simp only [whileLoopCode, partitionScanCondition, List.append_assoc]
+    iapply wp_lessLocal rfl rfl
+    inext
+    simp only [List.cons_append, List.nil_append]
+    iapply Wasm.SmallStep.wp_eqz rfl
+    inext
+    by_cases hj : state.j < hiMinusOne
+    · have hlt := hjCmp.mpr hj
+      simp only [if_pos hlt]
+      simp only [if_neg (by decide : (1 : UInt32) ≠ 0)]
+      iapply Wasm.SmallStep.wp_brIfZero
+      inext
+      iapply wp_partitionScanStep arr input state.values lo hi state.i state.j hiMinusOne
+        pivot state.tmp hstate hj hjLen hiLen hfitState
+      isplitl [Harray]
+      · iexact Harray
+      isplit
+      · iintro ⟨%hlt, Harray⟩
+        iapply Wasm.SmallStep.wp_br rfl
+        inext
+        simp only [partitionLocals, List.take_zero, List.nil_append]
+        ispecialize Hrec $$
+          %(⟨state.values, state.i, state.j + 1, state.tmp⟩ : PartitionState)
+        iapply Hrec
+        isplitr
+        · ipureintro
+          exact hstate.skipStep (by omega) (by rwa [getElem!_pos state.values state.j hjLen])
+        iframe
+        simp only [Finish, partitionLocals]
+        iexact Hfinish
+      · iintro ⟨%hlt, Harray⟩
+        iapply Wasm.SmallStep.wp_br rfl
+        inext
+        simp only [partitionLocals, List.take_zero, List.nil_append]
+        ispecialize Hrec $$
+          %(⟨swapElems state.values state.i state.j, state.i + 1, state.j + 1,
+              state.values[state.i]'hiLen⟩ : PartitionState)
+        iapply Hrec
+        isplitr
+        · ipureintro
+          exact hstate.swapStep (by omega) (by rwa [getElem!_pos state.values state.j hjLen])
+        iframe
+        simp only [Finish, partitionLocals]
+        iexact Hfinish
+    · have hlt := mt hjCmp.mp hj
+      simp only [if_neg hlt]
+      have hjEq : state.j = hiMinusOne := by omega
+      iapply Wasm.SmallStep.wp_brIf (by decide) rfl
+      inext
+      simp only [partitionLocals, List.take_zero, List.nil_append, List.drop_zero]
+      iapply Hfinish $$ %state.values %state.i %state.j %state.tmp %hstate %hjEq Harray
+  · simp only [Inv]
+    isplitr
+    · ipureintro
+      exact hinv
+    iframe
+
+set_option maxHeartbeats 4000000 in
+theorem wp_partitionBody
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hbounds : lo < hi ∧ hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    {calls : List CallFrame} :
+    arrayAt arr input ∗
+      (∀ (output : List UInt32) (pivotIdx : Nat) (tmp : UInt32),
+        ⌜PartitionRange input output lo hi pivotIdx⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨partitionLocals arr lo hi (input[hi - 1]!) pivotIdx (hi - 1) (hi - 1) tmp
+              [.i32 (UInt32.ofNat pivotIdx)],
+            [.ret], 1, [], [], calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+        [.i32 0, .i32 0, .i32 0, .i32 0, .i32 0], []⟩,
+      partitionBody, 1, [], [], calls⟩ : Expr Unit)
+      @ s; E {{ Φ }} := by
+  iintro ⟨Harray, Hfinish⟩
+  simp only [partitionBody, partitionInit, partitionPlacePivot,
+    List.cons_append, List.nil_append, List.append_assoc]
+  have hiPos : 0 < hi := by omega
+  iapply Wasm.SmallStep.wp_localGet rfl
+  inext
+  iapply Wasm.SmallStep.wp_const
+  inext
+  iapply Wasm.SmallStep.wp_sub
+  inext
+  have hiMinus1 : UInt32.ofNat hi - 1 = UInt32.ofNat (hi - 1) := by
+    have hiSize : hi < UInt32.size := by
+      have := hbounds.2; simp only [UInt32.size] at hfit ⊢; omega
+    apply UInt32.toNat.inj
+    rw [UInt32.toNat_sub, show (1 : UInt32).toNat = 1 from rfl,
+        UInt32.toNat_ofNat_of_lt' hiSize,
+        UInt32.toNat_ofNat_of_lt' (show hi - 1 < UInt32.size by omega)]
+    have := (UInt32.ofNat hi).toNat_lt
+    rw [UInt32.toNat_ofNat_of_lt' hiSize] at this
+    omega
+  have hset6 :
+      (⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+        [.i32 0, .i32 0, .i32 0, .i32 0, .i32 0],
+        [.i32 (UInt32.ofNat hi - 1)]⟩ : Locals).set?
+        6 (.i32 (UInt32.ofNat hi - 1)) =
+      some (partitionLocals arr lo hi 0 0 0 (hi - 1) 0 [.i32 (UInt32.ofNat hi - 1)]) := by
+    rw [hiMinus1]; rfl
+  iapply Wasm.SmallStep.wp_localSet hset6
+  inext
+  have hjm1 : hi - 1 < input.length := by omega
+  simp only [partitionLocals]
+  iapply wp_loadAt hjm1 hfit rfl rfl
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  simp only [← getElem!_pos input (hi - 1) hjm1]
+  have hset3 :
+      (partitionLocals arr lo hi 0 0 0 (hi - 1) 0 [.i32 (input[hi - 1]!)]).set?
+        3 (.i32 (input[hi - 1]!)) =
+      some (partitionLocals arr lo hi (input[hi - 1]!) 0 0 (hi - 1) 0
+          [.i32 (input[hi - 1]!)]) := rfl
+  iapply Wasm.SmallStep.wp_localSet hset3
+  inext
+  iapply Wasm.SmallStep.wp_localGet rfl
+  inext
+  have hset4 :
+      (partitionLocals arr lo hi (input[hi - 1]!) 0 0 (hi - 1) 0
+          [.i32 (UInt32.ofNat lo)]).set?
+        4 (.i32 (UInt32.ofNat lo)) =
+      some (partitionLocals arr lo hi (input[hi - 1]!) lo 0 (hi - 1) 0
+          [.i32 (UInt32.ofNat lo)]) := rfl
+  simp only [partitionLocals]
+  iapply Wasm.SmallStep.wp_localSet hset4
+  inext
+  iapply Wasm.SmallStep.wp_localGet rfl
+  inext
+  have hset5 :
+      (partitionLocals arr lo hi (input[hi - 1]!) lo 0 (hi - 1) 0
+          [.i32 (UInt32.ofNat lo)]).set?
+        5 (.i32 (UInt32.ofNat lo)) =
+      some (partitionLocals arr lo hi (input[hi - 1]!) lo lo (hi - 1) 0
+          [.i32 (UInt32.ofNat lo)]) := rfl
+  simp only [partitionLocals]
+  iapply Wasm.SmallStep.wp_localSet hset5
+  inext
+  simp only [partitionLocals]
+  have hfold :
+      ({ params := [Value.i32 arr, Value.i32 (UInt32.ofNat lo), Value.i32 (UInt32.ofNat hi)],
+         locals := [Value.i32 (input[hi - 1]!), Value.i32 (UInt32.ofNat lo),
+                    Value.i32 (UInt32.ofNat lo), Value.i32 (UInt32.ofNat (hi - 1)),
+                    Value.i32 0],
+         values := [] } : Locals) =
+      partitionLocals arr lo hi (input[hi - 1]!) lo lo (hi - 1) 0 [] := rfl
+  rw [hfold]
+  iapply wp_partitionScanLoop arr input input lo hi lo lo (hi - 1) (input[hi - 1]!) 0
+    (partitionLoopInvariant_start input lo hi (input[hi - 1]!) hbounds rfl)
+    (by omega) hfit
+  isplitl [Harray]
+  · iexact Harray
+  iintro %current' %i' %j' %tmp' %hinv' %hjEq Harray
+  subst hjEq
+  have hinv'_orig := hinv'
+  rcases hinv' with ⟨hli, hij, -, hhilen, hlen, -, -, -, -, -, -⟩
+  have hiLen' : i' < current'.length := by omega
+  have hjm1Len' : hi - 1 < current'.length := by omega
+  have hfitCurrent : arr.toNat + 4 * current'.length ≤ UInt32.size := by
+    rw [hlen]; exact hfit
+  have htmp_set :
+      (partitionLocals arr lo hi (input[hi - 1]!) i' (hi - 1) (hi - 1) tmp'
+          [.i32 (current'[i']'hiLen')]).set?
+        7 (.i32 (current'[i']'hiLen')) =
+      some (partitionLocals arr lo hi (input[hi - 1]!) i' (hi - 1) (hi - 1)
+          (current'[i']'hiLen') [.i32 (current'[i']'hiLen')]) := rfl
+  simp only [partitionLocals, List.drop_zero]
+  iapply wp_swapAt hiLen' hjm1Len' hfitCurrent rfl rfl htmp_set rfl rfl rfl rfl
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  iapply Wasm.SmallStep.wp_localGet rfl
+  inext
+  have hplacePivot : PartitionRange input (swapElems current' i' (hi - 1)) lo hi i' :=
+    PartitionLoopInvariant.placePivot hinv'_orig (by omega)
+  simp only [partitionLocals]
+  iapply Hfinish $$ %(swapElems current' i' (hi - 1)) %i' %(current'[i']'hiLen')
+    %hplacePivot Harray
+
+theorem wp_partitionBody_from
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (actualLocals : Locals)
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hbounds : lo < hi ∧ hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    (hlocals : actualLocals = ⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+        [.i32 0, .i32 0, .i32 0, .i32 0, .i32 0], []⟩)
+    {calls : List CallFrame} :
+    arrayAt arr input ∗
+      (∀ (output : List UInt32) (pivotIdx : Nat) (tmp : UInt32),
+        ⌜PartitionRange input output lo hi pivotIdx⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨partitionLocals arr lo hi (input[hi - 1]!) pivotIdx (hi - 1) (hi - 1) tmp
+              [.i32 (UInt32.ofNat pivotIdx)],
+            [.ret], 1, [], [], calls⟩ : Expr Unit)
+            @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨actualLocals, partitionBody, 1, [], [], calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} := by
+  subst hlocals
+  exact wp_partitionBody arr input lo hi hbounds hfit
+
+set_option maxHeartbeats 4000000 in
+theorem wp_partition
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (partitionIdx : Nat)
+    (himports : ¬partitionIdx < runtimeModule.imports.length)
+    (hfunction : runtimeModule.funcs[partitionIdx - runtimeModule.imports.length]? =
+        some partitionFunction)
+    (arr : UInt32) (input : List UInt32) (lo hi : Nat)
+    (hbounds : lo < hi ∧ hi ≤ input.length)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    {callerLocals : Locals}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    {stack : List Value} :
+    runtimeModuleOwn runtimeModule ∗
+      arrayAt arr input ∗
+      (∀ (output : List UInt32) (pivotIdx : Nat),
+        runtimeModuleOwn runtimeModule -∗
+        ⌜PartitionRange input output lo hi pivotIdx⌝ -∗
+        arrayAt arr output -∗
+        WP (.running ⟨{ callerLocals with values := .i32 (UInt32.ofNat pivotIdx) :: stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E {{ Φ }}) ⊢
+    WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat hi) :: .i32 (UInt32.ofNat lo) :: .i32 arr :: stack },
+        .call partitionIdx :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E {{ Φ }} := by
+  iintro ⟨Hruntime, Harray, Hcont⟩
+  ihave HruntimeLater : ▷ runtimeModuleOwn runtimeModule $$ [Hruntime]
+  · inext
+    iexact Hruntime
+  iapply Wasm.SmallStep.wp_call runtimeModule partitionIdx partitionFunction
+    himports hfunction $$ HruntimeLater
+  inext
+  iintro Hruntime
+  simp [partitionFunction, Function.toLocals, Function.numParams, ValueType.zero]
+  iapply wp_partitionBody_from
+    (⟨[.i32 arr, .i32 (UInt32.ofNat lo), .i32 (UInt32.ofNat hi)],
+      [.i32 0, .i32 0, .i32 0, .i32 0, .i32 0], []⟩ : Locals)
+    arr input lo hi hbounds hfit rfl
+  isplitl [Harray]
+  · iexact Harray
+  iintro %output %pivotIdx %tmp %hrange Harray
+  iapply Wasm.SmallStep.wp_returnFromCallExplicit
+  inext
+  simp only [partitionLocals, List.take_succ_cons, List.take_zero, List.nil_append,
+    List.cons_append]
+  iapply Hcont $$ %output %pivotIdx Hruntime %hrange Harray
+
+end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Proof.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Proof.lean
@@ -389,7 +389,7 @@ theorem wp_partitionBody
         7 (.i32 (current'[i']'hiLen')) =
       some (partitionLocals arr lo hi (input[hi - 1]!) i' (hi - 1) (hi - 1)
           (current'[i']'hiLen') [.i32 (current'[i']'hiLen')]) := rfl
-  simp only [partitionLocals, List.drop_zero]
+  simp only [partitionLocals]
   iapply wp_swapAt hiLen' hjm1Len' hfitCurrent rfl rfl htmp_set rfl rfl rfl rfl
   isplitl [Harray]
   · iexact Harray
@@ -571,7 +571,7 @@ private theorem wp_quicksortBody_aux
     inext; iintro Hruntime
     simp [quicksortFunction, Function.toLocals, Function.numParams, ValueType.zero]
     simp only [quicksortBody, quicksortBaseCheck, quicksortPartitionCall, quicksortLeftCall,
-      quicksortRightCall, List.append_assoc, List.cons_append, List.nil_append]
+      quicksortRightCall, List.cons_append, List.nil_append]
     iapply Wasm.SmallStep.wp_localGet rfl; inext
     iapply Wasm.SmallStep.wp_localGet rfl; inext
     iapply Wasm.SmallStep.wp_sub; inext
@@ -641,7 +641,6 @@ private theorem wp_quicksortBody_aux
       · iexact Harray_p
       iintro %out_l Hruntime_l %hpure_l Harray_l
       obtain ⟨hlen_l, htake_l, hdrop_l, hsorted_l, hperm_l⟩ := hpure_l
-      simp only [quicksortLocals]
       iapply Wasm.SmallStep.wp_localGet rfl; inext
       iapply Wasm.SmallStep.wp_localGet rfl; inext
       iapply Wasm.SmallStep.wp_const; inext

--- a/codelib/CodeLib/Examples/Quicksort/Proof.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Proof.lean
@@ -9,7 +9,7 @@ This file connects the pure list invariants to the small-step Wasm WP rules.
 namespace Wasm.Examples.Quicksort
 
 open Wasm
-open Iris Iris.ProgramLogic Language.Notation
+open Iris Iris.ProgramLogic Language.Notation Std
 open Wasm.SepLogic
 open Wasm.SmallStep
 
@@ -767,5 +767,57 @@ theorem wp_quicksort
         @ s; E {{ Φ }} :=
   wp_quicksortBody runtimeModule partitionIdx quicksortIdx himports_p hfunction_p
     himports_q hfunction_q arr input lo hi hlohi hhilen hfit
+
+theorem quicksort_partiallyMeets (arr : UInt32) (input : List UInt32)
+    (hfit : arr.toNat + 4 * input.length ≤ UInt32.size)
+    (hmem : arr.toNat + 4 * input.length ≤ 65536) :
+    PartiallyMeets (quicksortConfig arr input)
+      (fun values store =>
+        values = [] ∧ ∃ output : List UInt32,
+          output.length = input.length ∧ Sorted output ∧
+          List.Perm input output ∧
+          readWordArray store.wasm.mem arr input.length = output) := by
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+    (α := Unit) (σ := quicksortHeap arr input) (globalσ := ∅)
+  · exact quicksortHeap_agrees arr input hfit
+  · exact quicksortHeap_inBounds arr input hfit hmem
+  · intro index value hget; simp [get?_empty] at hget
+  · intro gs
+    simp only [BI.BigSepM.bigSepM_empty.to_eq]
+    iintro ⟨Hbytes, _Hemp, Hruntime⟩
+    have hfitStrict : arr.toNat + 4 * input.length < UInt32.size := by
+      simp only [UInt32.size]; omega
+    ihave Harray := quicksortHeap_pointsTo arr input hfitStrict $$ Hbytes
+    simp only [quicksortConfig]
+    iapply wp_quicksort quicksortModule 0 1
+      (himports_p := by decide) (hfunction_p := rfl)
+      (himports_q := by decide) (hfunction_q := rfl)
+      (arr := arr) (input := input) (lo := 0) (hi := input.length)
+      (hlohi := Nat.zero_le _) (hhilen := Nat.le_refl _) (hfit := hfit)
+      (callerLocals := ⟨[], [], []⟩) (stack := []) (code := [])
+      (arity := 0) (remainder := []) (controls := []) (calls := [])
+    isplitl [Hruntime]
+    · iexact Hruntime
+    isplitl [Harray]
+    · iexact Harray
+    iintro %output Hruntime_out %hpure Harray_out
+    iapply wp_finish
+    inext
+    iapply wp_value'
+    iintro %store %_obs Hstate
+    imod arrayAt_readWordArray store 0 [] 0 arr output
+      (by rw [hpure.1]; exact hfit) $$
+        [$Hstate $Harray_out] with ⟨_Hstate, _Harray_out, %hread⟩
+    ipureintro
+    have hseq_out : segment output 0 input.length = output := by
+      simp only [segment, List.drop_zero, Nat.sub_zero]
+      rw [← hpure.1]; exact List.take_length (l := output)
+    have hseq_in : segment input 0 input.length = input := by
+      simp only [segment, List.drop_zero, Nat.sub_zero]
+      exact List.take_length (l := input)
+    exact ⟨rfl, output, hpure.1,
+      hseq_out ▸ hpure.2.2.2.1,
+      hseq_in ▸ hseq_out ▸ hpure.2.2.2.2,
+      by rw [← hpure.1]; exact hread⟩
 
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Pure.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Pure.lean
@@ -304,4 +304,114 @@ theorem quicksort_compose
            hleft_cond hright_cond,
          hperm⟩
 
+private theorem segment_take_drop_eq (l : List UInt32) (lo hi : Nat) (hlohi : lo ≤ hi) :
+    segment l lo hi = (l.take hi).drop lo := by
+  induction l generalizing lo hi with
+  | nil => simp [segment]
+  | cons head l ih =>
+    cases lo with
+    | zero => simp [segment]
+    | succ lo =>
+      cases hi with
+      | zero => omega
+      | succ hi =>
+        simp only [segment, List.take_succ_cons, List.drop_succ_cons, Nat.succ_sub_succ_eq_sub]
+        exact ih lo hi (by omega)
+
+private theorem segment_eq_of_take {a b : List UInt32} {lo hi k : Nat}
+    (hlohi : lo ≤ hi) (hhik : hi ≤ k) (htake : a.take k = b.take k) :
+    segment a lo hi = segment b lo hi := by
+  rw [segment_take_drop_eq a lo hi hlohi, segment_take_drop_eq b lo hi hlohi]
+  congr 1
+  rw [show a.take hi = (a.take k).take hi from by
+        rw [List.take_take]; simp [Nat.min_eq_left hhik],
+      show b.take hi = (b.take k).take hi from by
+        rw [List.take_take]; simp [Nat.min_eq_left hhik],
+      htake]
+
+private theorem segment_eq_of_drop {a b : List UInt32} {lo hi k : Nat}
+    (hklo : k ≤ lo) (hdrop : a.drop k = b.drop k) :
+    segment a lo hi = segment b lo hi := by
+  simp only [segment]
+  congr 1
+  have step : ∀ l : List UInt32, l.drop lo = (l.drop k).drop (lo - k) := fun l => by
+    rw [List.drop_drop]; congr 1; omega
+  rw [step a, step b, hdrop]
+
+private theorem getElem!_eq_of_take {a b : List UInt32} {k i : Nat}
+    (hik : i < k) (htake : a.take k = b.take k) :
+    a[i]! = b[i]! := by
+  simp only [List.getElem!_eq_getElem?_getD]
+  rw [show a[i]? = (a.take k)[i]? from by simp [List.getElem?_take, hik],
+      show b[i]? = (b.take k)[i]? from by simp [List.getElem?_take, hik],
+      htake]
+
+private theorem getElem!_eq_of_drop {a b : List UInt32} {k i : Nat}
+    (hki : k ≤ i) (hdrop : a.drop k = b.drop k) :
+    a[i]! = b[i]! := by
+  simp only [List.getElem!_eq_getElem?_getD]
+  have ha : a[i]? = (a.drop k)[i - k]? := by
+    rw [List.getElem?_drop]; congr 1; omega
+  have hb : b[i]? = (b.drop k)[i - k]? := by
+    rw [List.getElem?_drop]; congr 1; omega
+  rw [ha, hb, hdrop]
+
+theorem partitionRange_after_sorts
+    {values output_p out_l out_r : List UInt32} {lo hi pivotIdx : Nat}
+    (hpart : PartitionRange values output_p lo hi pivotIdx)
+    (hlen_l : out_l.length = output_p.length)
+    (htake_l : out_l.take lo = output_p.take lo)
+    (hdrop_l : out_l.drop pivotIdx = output_p.drop pivotIdx)
+    (hperm_l : List.Perm (segment output_p lo pivotIdx) (segment out_l lo pivotIdx))
+    (hlen_r : out_r.length = out_l.length)
+    (htake_r : out_r.take (pivotIdx + 1) = out_l.take (pivotIdx + 1))
+    (hdrop_r : out_r.drop hi = out_l.drop hi)
+    (hperm_r : List.Perm (segment out_l (pivotIdx + 1) hi) (segment out_r (pivotIdx + 1) hi)) :
+    PartitionRange values out_r lo hi pivotIdx := by
+  obtain ⟨hlo, hphi, hhilen, hlen_p, htake_p, hdrop_p, hperm_p, hleft_p, hright_p⟩ := hpart
+  have hhilen_r : hi ≤ out_r.length := by omega
+  -- segment equalities
+  have hseg_r_lo_p : segment out_r lo pivotIdx = segment out_l lo pivotIdx :=
+    segment_eq_of_take (by omega) (by omega) htake_r
+  have hseg_l_p1_hi : segment out_l (pivotIdx + 1) hi = segment output_p (pivotIdx + 1) hi :=
+    segment_eq_of_drop (by omega) hdrop_l
+  -- pivot element equalities
+  have hpiv_l : out_l[pivotIdx]! = output_p[pivotIdx]! :=
+    getElem!_eq_of_drop (le_refl _) hdrop_l
+  have hpiv_r : out_r[pivotIdx]! = out_l[pivotIdx]! :=
+    getElem!_eq_of_take (by omega) htake_r
+  -- perm of whole segment
+  have hperm_op_r : List.Perm (segment output_p lo hi) (segment out_r lo hi) := by
+    have lhs_eq : segment output_p lo hi =
+        segment output_p lo pivotIdx ++ output_p[pivotIdx]! :: segment output_p (pivotIdx + 1) hi := by
+      rw [← segment_cons_pivot hphi (by omega), segment_append hlo (by omega)]
+    have rhs_eq : segment out_r lo hi =
+        segment out_r lo pivotIdx ++ out_r[pivotIdx]! :: segment out_r (pivotIdx + 1) hi := by
+      rw [← segment_cons_pivot hphi hhilen_r, segment_append hlo (by omega)]
+    rw [lhs_eq, rhs_eq, hseg_r_lo_p, hpiv_r, ← hpiv_l, ← hseg_l_p1_hi]
+    exact hperm_l.append (List.Perm.cons _ hperm_r)
+  -- take lo chain
+  have htake_r_lo : out_r.take lo = out_l.take lo := by
+    have := congr_arg (·.take lo) htake_r
+    simp only [List.take_take, Nat.min_eq_left (by omega : lo ≤ pivotIdx + 1)] at this
+    exact this
+  -- drop hi chain
+  have hdrop_l_hi : out_l.drop hi = output_p.drop hi := by
+    have step : ∀ l : List UInt32, l.drop hi = (l.drop pivotIdx).drop (hi - pivotIdx) := fun l => by
+      rw [List.drop_drop]; congr 1; omega
+    rw [step out_l, step output_p, hdrop_l]
+  exact ⟨hlo, hphi, hhilen, by omega,
+    by rw [htake_r_lo, htake_l, htake_p],
+    by rw [hdrop_r, hdrop_l_hi, hdrop_p],
+    hperm_p.trans hperm_op_r,
+    by rw [hseg_r_lo_p, hpiv_r, hpiv_l]
+       intro x hx; exact hleft_p x (hperm_l.symm.subset hx),
+    by intro x hx; rw [hpiv_r, hpiv_l]
+       apply hright_p; rw [← hseg_l_p1_hi]; exact hperm_r.symm.subset hx⟩
+
+theorem segment_sorted_of_take_eq {a b : List UInt32} {lo hi k : Nat}
+    (hlohi : lo ≤ hi) (hhik : hi ≤ k) (htake : a.take k = b.take k)
+    (h : Sorted (segment b lo hi)) : Sorted (segment a lo hi) := by
+  rw [segment_eq_of_take hlohi hhik htake]; exact h
+
 end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/Quicksort/Pure.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Pure.lean
@@ -342,8 +342,8 @@ private theorem getElem!_eq_of_take {a b : List UInt32} {k i : Nat}
     (hik : i < k) (htake : a.take k = b.take k) :
     a[i]! = b[i]! := by
   simp only [List.getElem!_eq_getElem?_getD]
-  rw [show a[i]? = (a.take k)[i]? from by simp [List.getElem?_take, hik],
-      show b[i]? = (b.take k)[i]? from by simp [List.getElem?_take, hik],
+  rw [show a[i]? = (a.take k)[i]? from by simp [hik],
+      show b[i]? = (b.take k)[i]? from by simp [hik],
       htake]
 
 private theorem getElem!_eq_of_drop {a b : List UInt32} {k i : Nat}

--- a/codelib/CodeLib/Examples/Quicksort/Pure.lean
+++ b/codelib/CodeLib/Examples/Quicksort/Pure.lean
@@ -1,0 +1,307 @@
+import CodeLib.Examples.Quicksort
+
+/-!
+# Pure mathematics used by the quicksort proof
+
+This file contains no Iris assertions or machine states.
+-/
+
+namespace Wasm.Examples.Quicksort
+
+-- no List.swap in Mathlib; Function.swap resolves that name instead
+def swapElems (l : List UInt32) (i j : Nat) : List UInt32 :=
+  (l.set i (l[j]!)).set j (l[i]!)
+
+theorem swapElems_length (l : List UInt32) (i j : Nat) :
+    (swapElems l i j).length = l.length := by
+  unfold swapElems; simp [List.length_set]
+
+theorem swapElems_get_i (l : List UInt32) {i j : Nat}
+    (hi : i < l.length) (hj : j < l.length) :
+    (swapElems l i j)[i]! = l[j]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs; all_goals simp_all
+
+theorem swapElems_get_j (l : List UInt32) {i j : Nat}
+    (hi : i < l.length) (hj : j < l.length) :
+    (swapElems l i j)[j]! = l[i]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs; all_goals simp_all
+
+theorem swapElems_get_other (l : List UInt32) {i j k : Nat}
+    (hki : k ≠ i) (hkj : k ≠ j) :
+    (swapElems l i j)[k]! = l[k]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs; all_goals simp_all
+
+theorem swapElems_take_of_le (l : List UInt32) {i j n : Nat}
+    (hin : n ≤ i) (hjn : n ≤ j) :
+    (swapElems l i j).take n = l.take n := by
+  unfold swapElems; rw [List.take_set, List.take_set]
+  have hlen : (List.take n l).length ≤ n := List.length_take_le n l
+  rw [List.set_eq_of_length_le (by rw [List.length_set]; exact Nat.le_trans hlen hjn),
+      List.set_eq_of_length_le (Nat.le_trans hlen hin)]
+
+theorem swapElems_drop_of_lt (l : List UInt32) {i j n : Nat}
+    (hin : i < n) (hjn : j < n) :
+    (swapElems l i j).drop n = l.drop n := by
+  unfold swapElems
+  rw [List.drop_set_of_lt hjn, List.drop_set_of_lt hin]
+
+theorem swapElems_perm (l : List UInt32) {i j : Nat}
+    (hi : i < l.length) (hj : j < l.length) :
+    (swapElems l i j).Perm l := by
+  rw [List.perm_iff_count]; intro b; simp only [swapElems]
+  have hi_eq : l[i]! = l[i] := getElem!_pos l i hi
+  have hj_eq : l[j]! = l[j] := getElem!_pos l j hj
+  rw [hi_eq, hj_eq]
+  have hlen1 : (l.set i l[j]).length = l.length := List.length_set
+  rw [List.count_set (hlen1 ▸ hj), List.count_set hi]
+  have hset_j : ((l.set i l[j])[j] == b) = (l[j] == b) := by
+    congr 1; simp [List.getElem_set]
+  rw [hset_j]
+  have hle : (if l[i] == b then 1 else 0) ≤ l.count b := by
+    split_ifs with h
+    · exact List.count_pos_iff.mpr ((beq_iff_eq.mp h) ▸ List.getElem_mem hi)
+    · exact Nat.zero_le _
+  omega
+
+private theorem take_segment_drop {values : List UInt32} {start stop : Nat}
+    (hstart : start ≤ stop) :
+    values.take start ++ segment values start stop ++ values.drop stop = values := by
+  have hstop : start + (stop - start) = stop := Nat.add_sub_of_le hstart
+  rw [segment, ← List.take_add, hstop]
+  exact List.take_append_drop stop values
+
+private theorem segment_append {values : List UInt32} {start mid stop : Nat}
+    (hstart : start ≤ mid) (hmid : mid ≤ stop) :
+    segment values start mid ++ segment values mid stop = segment values start stop := by
+  simp only [segment]
+  have hdrop : values.drop mid = (values.drop start).drop (mid - start) := by
+    rw [List.drop_drop]; congr 1; omega
+  rw [hdrop, ← List.take_add]; congr 1; omega
+
+private theorem sorted_of_length_le_one {values : List UInt32}
+    (h : values.length ≤ 1) : values.Pairwise (· ≤ ·) := by
+  match values, h with
+  | [], _ => exact List.Pairwise.nil
+  | [_], _ => exact List.pairwise_singleton _ _
+
+private theorem segment_cons_pivot {values : List UInt32} {p hi : Nat}
+    (hphi : p < hi) (hhilen : hi ≤ values.length) :
+    segment values p hi = values[p]! :: segment values (p + 1) hi := by
+  simp only [segment]
+  have hp : p < values.length := Nat.lt_of_lt_of_le hphi hhilen
+  rw [List.drop_eq_getElem_cons hp, show hi - p = (hi - p - 1) + 1 from by omega,
+      List.take_succ_cons, getElem!_pos values p hp]
+  congr 1
+
+private theorem mem_segment {output : List UInt32} {lo hi : Nat} {x : UInt32}
+    (hhi : hi ≤ output.length) (hx : x ∈ segment output lo hi) :
+    ∃ k, lo ≤ k ∧ k < hi ∧ output[k]! = x := by
+  simp only [segment] at hx
+  rw [List.mem_iff_getElem] at hx
+  obtain ⟨k, hklen, hkval⟩ := hx
+  have hkdiff : k < hi - lo := Nat.lt_of_lt_of_le hklen (List.length_take_le _ _)
+  refine ⟨lo + k, Nat.le_add_right lo k, by omega, ?_⟩
+  rw [getElem!_pos output (lo + k) (by omega)]
+  rw [List.getElem_take] at hkval
+  rw [List.getElem_drop' (by omega)]
+  exact hkval
+
+private theorem uint32_le_of_lt {a b : UInt32} (h : a < b) : a ≤ b := by
+  change a.toNat < b.toNat at h; change a.toNat ≤ b.toNat; exact Nat.le_of_lt h
+
+private theorem uint32_le_trans {a b c : UInt32} (h1 : a ≤ b) (h2 : b ≤ c) : a ≤ c := by
+  change a.toNat ≤ b.toNat at h1; change b.toNat ≤ c.toNat at h2
+  change a.toNat ≤ c.toNat; exact Nat.le_trans h1 h2
+
+private theorem compose_sorted (output : List UInt32) (lo hi p : Nat)
+    (hlo : lo ≤ p) (hp : p < hi) (hhi : hi ≤ output.length)
+    (hleft : List.Pairwise (· ≤ ·) (segment output lo p))
+    (hright : List.Pairwise (· ≤ ·) (segment output (p + 1) hi))
+    (hleft_cond : ∀ x ∈ segment output lo p, x ≤ output[p]!)
+    (hright_cond : ∀ x ∈ segment output (p + 1) hi, x > output[p]!) :
+    List.Pairwise (· ≤ ·) (segment output lo hi) := by
+  rw [show segment output lo hi = segment output lo p ++ output[p]! :: segment output (p + 1) hi
+      from by rw [← segment_cons_pivot hp hhi, segment_append hlo (by omega)]]
+  rw [List.pairwise_append, List.pairwise_cons]
+  refine ⟨hleft, ⟨?_, hright⟩, ?_⟩
+  · intro y hy; exact uint32_le_of_lt (hright_cond y hy)
+  · intro x hx y hy
+    rw [List.mem_cons] at hy
+    rcases hy with rfl | hy
+    · exact hleft_cond x hx
+    · exact uint32_le_trans (hleft_cond x hx) (uint32_le_of_lt (hright_cond y hy))
+
+/-- loop invariant for the lomuto partition scan:
+    [lo, i) ≤ pivot, [i, j) > pivot, arr[hi-1] = pivot -/
+def PartitionLoopInvariant
+    (input current : List UInt32) (lo hi i j : Nat) (pivot : UInt32) : Prop :=
+  lo ≤ i ∧ i ≤ j ∧ j ≤ hi - 1 ∧ hi ≤ input.length ∧
+  current.length = input.length ∧
+  current.take lo = input.take lo ∧
+  current.drop hi = input.drop hi ∧
+  current[hi - 1]! = pivot ∧
+  List.Perm (segment input lo hi) (segment current lo hi) ∧
+  (∀ k, lo ≤ k → k < i → current[k]! ≤ pivot) ∧
+  (∀ k, i ≤ k → k < j → pivot < current[k]!)
+
+theorem partitionLoopInvariant_start
+    (input : List UInt32) (lo hi : Nat) (pivot : UInt32)
+    (hbounds : lo < hi ∧ hi ≤ input.length)
+    (hpivot : input[hi - 1]! = pivot) :
+    PartitionLoopInvariant input input lo hi lo lo pivot := by
+  obtain ⟨hlohi, hilen⟩ := hbounds
+  refine ⟨le_refl lo, le_refl lo, by omega, hilen, rfl, rfl, rfl, hpivot,
+    List.Perm.refl _,
+    fun k hk hlt => by omega,
+    fun k hk hlt => by omega⟩
+
+theorem PartitionLoopInvariant.skipStep
+    {input current : List UInt32} {lo hi i j : Nat} {pivot : UInt32}
+    (h : PartitionLoopInvariant input current lo hi i j pivot)
+    (hj : j < hi - 1)
+    (hgt : pivot < current[j]!) :
+    PartitionLoopInvariant input current lo hi i (j + 1) pivot := by
+  unfold PartitionLoopInvariant at h ⊢
+  obtain ⟨hli, hij, hjh, hilen, hlen, htake, hdrop, hpiv, hperm, hle, hgt'⟩ := h
+  refine ⟨hli, by omega, by omega, hilen, hlen, htake, hdrop, hpiv, hperm, hle,
+    fun k hik hkj1 => ?_⟩
+  by_cases hkj : k = j
+  · subst hkj; exact hgt
+  · exact hgt' k hik (by omega)
+
+theorem PartitionLoopInvariant.swapStep
+    {input current : List UInt32} {lo hi i j : Nat} {pivot : UInt32}
+    (h : PartitionLoopInvariant input current lo hi i j pivot)
+    (hj : j < hi - 1)
+    (hle : ¬ pivot < current[j]!) :
+    PartitionLoopInvariant input (swapElems current i j) lo hi (i + 1) (j + 1) pivot := by
+  unfold PartitionLoopInvariant at h ⊢
+  rcases h with ⟨hli, hij, hjhi, hhilen, hlen, htake_lo, hdrop_hi, hpivot, hperm,
+    hle_zone, hgt_zone⟩
+  have hilen : i < current.length := by omega
+  have hjlen : j < current.length := by omega
+  refine ⟨by omega, by omega, by omega, hhilen,
+    ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [swapElems_length]; exact hlen
+  · rw [swapElems_take_of_le (hin := by omega) (hjn := by omega)]; exact htake_lo
+  · rw [swapElems_drop_of_lt (hin := by omega) (hjn := by omega)]; exact hdrop_hi
+  · rw [swapElems_get_other (hki := by omega) (hkj := by omega)]; exact hpivot
+  · -- permutation
+    have hlo_hi : lo ≤ hi := by omega
+    have htake : (swapElems current i j).take lo = current.take lo :=
+      swapElems_take_of_le current (hin := by omega) (hjn := by omega)
+    have hdrop : (swapElems current i j).drop hi = current.drop hi :=
+      swapElems_drop_of_lt current (hin := by omega) (hjn := by omega)
+    have hswap_perm := swapElems_perm current hilen hjlen
+    have heq1 : current.take lo ++ segment (swapElems current i j) lo hi ++ current.drop hi
+        = swapElems current i j := by
+      have h := take_segment_drop (values := swapElems current i j) hlo_hi
+      rwa [htake, hdrop] at h
+    have heq2 : current.take lo ++ segment current lo hi ++ current.drop hi = current :=
+      take_segment_drop hlo_hi
+    have hperm_full :
+        (current.take lo ++ segment (swapElems current i j) lo hi ++ current.drop hi).Perm
+        (current.take lo ++ segment current lo hi ++ current.drop hi) := by
+      rw [heq1, heq2]; exact hswap_perm
+    have hseg_perm : (segment (swapElems current i j) lo hi).Perm (segment current lo hi) :=
+      List.perm_append_left_iff (current.take lo) |>.mp
+        (List.perm_append_right_iff (current.drop hi) |>.mp hperm_full)
+    exact hperm.trans hseg_perm.symm
+  · intro k hlo hki1
+    by_cases hki : k = i
+    · subst hki
+      rw [swapElems_get_i current hilen hjlen]
+      exact UInt32.not_lt.mp hle
+    · rw [swapElems_get_other (hki := hki) (hkj := by omega)]
+      exact hle_zone k hlo (by omega)
+  · intro k hik hkj1
+    by_cases hkj : k = j
+    · subst hkj
+      rw [swapElems_get_j current hilen hjlen]
+      exact hgt_zone i (Nat.le_refl i) (by omega)
+    · rw [swapElems_get_other (hki := by omega) (hkj := hkj)]
+      exact hgt_zone k (by omega) (by omega)
+
+theorem PartitionLoopInvariant.placePivot
+    {input current : List UInt32} {lo hi i : Nat} {pivot : UInt32}
+    (h : PartitionLoopInvariant input current lo hi i (hi - 1) pivot)
+    (hhi_pos : 0 < hi) :
+    PartitionRange input (swapElems current i (hi - 1)) lo hi i := by
+  rcases h with ⟨hli, hij, _, hhilen, hlen, htake_lo, hdrop_hi, hpivot, hperm,
+    hle_zone, hgt_zone⟩
+  have hilen : i < current.length := by omega
+  have hhm1len : hi - 1 < current.length := by omega
+  have hswaplen := swapElems_length current i (hi - 1)
+  have hlo_hi : lo ≤ hi := by omega
+  -- permutation field (same take_segment_drop cancellation as swapStep)
+  have htake : (swapElems current i (hi - 1)).take lo = current.take lo :=
+    swapElems_take_of_le current (hin := by omega) (hjn := by omega)
+  have hdrop : (swapElems current i (hi - 1)).drop hi = current.drop hi :=
+    swapElems_drop_of_lt current (hin := by omega) (hjn := by omega)
+  have hswap_perm := swapElems_perm current hilen hhm1len
+  have heq1 : current.take lo ++ segment (swapElems current i (hi - 1)) lo hi ++ current.drop hi
+      = swapElems current i (hi - 1) := by
+    have h := take_segment_drop (values := swapElems current i (hi - 1)) hlo_hi
+    rwa [htake, hdrop] at h
+  have heq2 : current.take lo ++ segment current lo hi ++ current.drop hi = current :=
+    take_segment_drop hlo_hi
+  have hperm_full :
+      (current.take lo ++ segment (swapElems current i (hi - 1)) lo hi ++ current.drop hi).Perm
+      (current.take lo ++ segment current lo hi ++ current.drop hi) := by
+    rw [heq1, heq2]; exact hswap_perm
+  have hseg_perm : (segment (swapElems current i (hi - 1)) lo hi).Perm (segment current lo hi) :=
+    List.perm_append_left_iff (current.take lo) |>.mp
+      (List.perm_append_right_iff (current.drop hi) |>.mp hperm_full)
+  have hpiv_at_i : (swapElems current i (hi - 1))[i]! = pivot := by
+    rw [swapElems_get_i current hilen hhm1len]; exact hpivot
+  refine ⟨hli, by omega, hhilen,
+    by rw [hswaplen]; exact hlen,
+    by rw [htake]; exact htake_lo,
+    by rw [hdrop]; exact hdrop_hi,
+    hperm.trans hseg_perm.symm,
+    ?_, ?_⟩
+  · -- left: ∀ x ∈ segment output lo i, x ≤ output[i]!
+    intro x hx
+    rw [hpiv_at_i]
+    obtain ⟨k, hlo, hki, hkval⟩ := mem_segment (hi := i) (by omega) hx
+    rw [← hkval, swapElems_get_other (hki := by omega) (hkj := by omega)]
+    exact hle_zone k hlo hki
+  · -- right: ∀ x ∈ segment output (i+1) hi, x > output[i]!
+    intro x hx
+    rw [hpiv_at_i]
+    obtain ⟨k, hki1, hkhi, hkval⟩ := mem_segment (hi := hi) (by omega) hx
+    rw [← hkval]
+    by_cases hkhim1 : k = hi - 1
+    · rw [hkhim1, swapElems_get_j current hilen hhm1len]
+      exact hgt_zone i (le_refl i) (by omega)
+    · rw [swapElems_get_other (hki := by omega) (hkj := hkhim1)]
+      exact hgt_zone k (by omega) (by omega)
+
+theorem quicksort_base
+    (input : List UInt32) (lo hi : Nat)
+    (_ : hi ≤ input.length)
+    (hbase : hi - lo < 2) :
+    Sorted (segment input lo hi) := by
+  apply sorted_of_length_le_one
+  simp [segment, List.length_drop]
+  omega
+
+theorem quicksort_compose
+    (input output : List UInt32) (lo hi p : Nat)
+    (hpartition : PartitionRange input output lo hi p)
+    (hleft : Sorted (segment output lo p))
+    (hright : Sorted (segment output (p + 1) hi)) :
+    Sorted (segment output lo hi) ∧
+    List.Perm (segment input lo hi) (segment output lo hi) := by
+  obtain ⟨hlo, hp, hhi, hlen, htake, hdrop, hperm, hleft_cond, hright_cond⟩ := hpartition
+  exact ⟨compose_sorted output lo hi p hlo hp (hlen.symm ▸ hhi) hleft hright
+           hleft_cond hright_cond,
+         hperm⟩
+
+end Wasm.Examples.Quicksort

--- a/codelib/CodeLib/Examples/quicksort.wat
+++ b/codelib/CodeLib/Examples/quicksort.wat
@@ -1,0 +1,135 @@
+;; quicksort.wat
+;; Lomuto partition quicksort — hand-matched to Quicksort.lean.
+;; String-inlined copy lives in Quicksort.lean (quicksortWat); keep in sync.
+(module
+  (memory 1)
+
+  ;; func 0: partition arr lo hi -> pivotIdx
+  ;; locals: arr=0 lo=1 hi=2 pivot=3 i=4 j=5 hiMinusOne=6 tmp=7
+  (func (param i32 i32 i32) (result i32) (local i32 i32 i32 i32 i32)
+    local.get 2
+    i32.const 1
+    i32.sub
+    local.set 6
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    local.set 3
+    local.get 1
+    local.set 4
+    local.get 1
+    local.set 5
+    block
+      loop
+        local.get 5
+        local.get 6
+        i32.lt_u
+        i32.eqz
+        br_if 1
+        local.get 3
+        local.get 0
+        local.get 5
+        i32.const 4
+        i32.mul
+        i32.add
+        i32.load
+        i32.lt_u
+        if
+        else
+          local.get 0
+          local.get 4
+          i32.const 4
+          i32.mul
+          i32.add
+          i32.load
+          local.set 7
+          local.get 0
+          local.get 4
+          i32.const 4
+          i32.mul
+          i32.add
+          local.get 0
+          local.get 5
+          i32.const 4
+          i32.mul
+          i32.add
+          i32.load
+          i32.store
+          local.get 0
+          local.get 5
+          i32.const 4
+          i32.mul
+          i32.add
+          local.get 7
+          i32.store
+          local.get 4
+          i32.const 1
+          i32.add
+          local.set 4
+        end
+        local.get 5
+        i32.const 1
+        i32.add
+        local.set 5
+        br 0
+      end
+    end
+    local.get 0
+    local.get 4
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    local.set 7
+    local.get 0
+    local.get 4
+    i32.const 4
+    i32.mul
+    i32.add
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    i32.load
+    i32.store
+    local.get 0
+    local.get 6
+    i32.const 4
+    i32.mul
+    i32.add
+    local.get 7
+    i32.store
+    local.get 4
+    return)
+
+  ;; func 1: quicksort arr lo hi
+  ;; locals: arr=0 lo=1 hi=2 pivotIdx=3
+  (func (param i32 i32 i32) (local i32)
+    local.get 2
+    local.get 1
+    i32.sub
+    i32.const 2
+    i32.lt_u
+    if
+      return
+    end
+    local.get 0
+    local.get 1
+    local.get 2
+    call 0
+    local.set 3
+    local.get 0
+    local.get 1
+    local.get 3
+    call 1
+    local.get 0
+    local.get 3
+    i32.const 1
+    i32.add
+    local.get 2
+    call 1
+    return))

--- a/codelib/lakefile.toml
+++ b/codelib/lakefile.toml
@@ -16,3 +16,4 @@ git.rev = "3d9ecf13c89946a877fceb048a389e1596808157"
 
 [[lean_lib]]
 name = "CodeLib"
+roots = ["CodeLib", "CodeLib.Examples.Quicksort.Proof"]


### PR DESCRIPTION
Quicksort proved using iris-lean over the small-step (M7 item 7).

## Overview

Two Wasm functions (partition and recursive quicksort), one memory page, no imports. Handwritten Lean module with a matching .wat source, a native_decide test confirms the WAT decoder produces the same output as the handwritten module.

The partition uses the Lomuto scheme: a single pointer scans left to right, swapping elements ≤ the pivot into a growing prefix at the front. After the scan, the pivot is placed between the small and
large sections. The quicksort function calls partition, then recurses on both halves excluding the pivot.

The proof delivers a `PartiallyMeets` theorem that works for any base address and any input array: 
if execution completes under a valid memory layout, the physical memory contains a sorted permutation of the input, and everything outside the sorted range is unchanged.

## Recursion

Recursive self-calls use strong induction on `hi - lo` rather than Löb induction. Talos's `Language` instance is flat (no`EctxLanguage`, no `wp_bind`), so the Löb later guard cannot be consumed at `.call` sites. This matches `EvenOddRec.lean`, which also uses `Nat.strong_induction_on` for recursive Wasm calls.

Strong induction provides the explicit measure needed for total correctness via Total Weakest Preconditions, it proves recursion terminates via a strictly decreasing measure, which Löb does not (later modality is compatible with infinite traces, incompatible with TWP).  `EctxLanguage` can be implemented as a follow-up PR to unblock Löb (for partial correctness), it needs evaluation contexts for call frames that satisfy the required laws and may or may not be doable for Wasm's flat `Expr`.

## Evidence 

`native_decide` execution checks, `TerminatesWith` witnesses, old/new differential, mutation tests (comparison, index, bound, store), oracle agreement against `List.mergeSort`.

## Per-PR Checklist 
1. **Milestone:** M7 item 7.
2. **Oracle:** Legacy `Wasm.run` agrees on test inputs. `List.mergeSort` agrees as independent sorting oracle 
3. **Step/step?:** No new transitions. Consumer only.
4. **Soundness/completeness/determinism:** Not applicable,  no new transitions. WP proof builds on existing proved lifting rules.
5. **Nondeterminism:** No.
6. **Success/trap/boundary:** Successful sorting proved for arbitrary valid inputs via `PartiallyMeets`. Empty, singleton, duplicates, already sorted tested. Quicksort does not trap under `ValidQuicksortLayout`.
7. **Unrelated store:** `quicksortPost` guarantees `output.take lo = input.take lo` and `output.drop hi = input.drop hi`.
8. **Ported examples:** None. New example.
9. **Commands:** `lake build CodeLib --wfail` — zero errors, zero warnings, zero sorry. `lean_verify` on `wp_partition`, `wp_quicksort`, `quicksort_partiallyMeets` — standard kernel axioms only.
10. **Atomicity/ownership:** No changes.
11. **Open items:** proof of termination deferred ( partial correctness), measure is `hi - lo`. Shared WP helpers copied from merge sort due to namespace resolution, extracting to a shared file could be a follow-up. Both linked to M7/M9.

Generated with Claude Code