### PR TITLE
Fix 12 test skips due to improper parsing of signed ints

### DIFF
--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -2432,10 +2432,10 @@ private def parseDataSegment (ctx : Ctx)
   -- `Module.runActiveSegments`.
   let parsed ← match xs with
     | .list [.atom "offset", .list [.atom "i32.const", .atom n]] :: r =>
-      do .ok ((some (← parseU32 n) : Option UInt32), some .i32,
+      do .ok ((some (← parseI32 n) : Option UInt32), some .i32,
         false, ([] : Wasm.Program), r)
     | .list [.atom "i32.const", .atom n] :: r =>
-      do .ok ((some (← parseU32 n) : Option UInt32), some .i32,
+      do .ok ((some (← parseI32 n) : Option UInt32), some .i32,
         false, ([] : Wasm.Program), r)
     -- memory64: active offsets in a 64-bit memory are i64 constants. The
     -- segment offset field is 32 bits; active 64-bit segments in practice
@@ -2703,7 +2703,7 @@ private def parseElemSegment (ctx : Ctx)
   let mut offsetExpr : Wasm.Program := []
   match rest with
   | .list [.atom "offset", .list [.atom "i32.const", .atom n]] :: r =>
-    let v ← parseNat n; offset := some v; offsetType := some .i32; rest := r
+    let v ← parseI32 n; offset := some v.toNat; offsetType := some .i32; rest := r
   | .list [.atom "offset", .list [.atom "i64.const", .atom n]] :: r =>
     -- table64: active offsets in a 64-bit table are i64 constants.
     let v ← parseI64 n; offset := some v.toNat; offsetType := some .i64; rest := r
@@ -2715,7 +2715,7 @@ private def parseElemSegment (ctx : Ctx)
     offset := some 0; offsetExprPresent := true
     offsetExpr := (← parseInstrSeq ctx es); rest := r
   | .list [.atom "i32.const", .atom n] :: r =>
-    let v ← parseNat n; offset := some v; offsetType := some .i32; rest := r
+    let v ← parseI32 n; offset := some v.toNat; offsetType := some .i32; rest := r
   | .list [.atom "i64.const", .atom n] :: r =>
     let v ← parseI64 n; offset := some v.toNat; offsetType := some .i64; rest := r
   -- Bare (unwrapped) non-literal offset expression, e.g.

--- a/testsuite_report.txt
+++ b/testsuite_report.txt
@@ -4266,10 +4266,10 @@ data.wast:267 assert_uninstantiable pass
 data.wast:274 assert_uninstantiable pass
 data.wast:282 assert_uninstantiable pass
 data.wast:290 assert_uninstantiable pass
-data.wast:298 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-data.wast:305 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-data.wast:313 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -100
-data.wast:320 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -100
+data.wast:298 assert_uninstantiable pass
+data.wast:305 assert_uninstantiable pass
+data.wast:313 assert_uninstantiable pass
+data.wast:320 assert_uninstantiable pass
 data.wast:330 assert_invalid pass
 data.wast:338 assert_invalid pass
 data.wast:351 assert_invalid pass
@@ -4307,10 +4307,10 @@ data1.wast:72 assert_uninstantiable pass
 data1.wast:81 assert_uninstantiable pass
 data1.wast:89 assert_uninstantiable pass
 data1.wast:99 assert_uninstantiable pass
-data1.wast:109 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-data1.wast:118 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-data1.wast:128 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -100
-data1.wast:137 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -100
+data1.wast:109 assert_uninstantiable pass
+data1.wast:118 assert_uninstantiable pass
+data1.wast:128 assert_uninstantiable pass
+data1.wast:137 assert_uninstantiable pass
 data_drop0.wast:2 module pass
 data_drop0.wast:18 action pass
 data_drop0.wast:19 action pass
@@ -4397,10 +4397,10 @@ elem.wast:628 assert_uninstantiable pass
 elem.wast:636 assert_uninstantiable pass
 elem.wast:645 assert_uninstantiable pass
 elem.wast:653 assert_uninstantiable pass
-elem.wast:662 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-elem.wast:670 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -1
-elem.wast:679 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -10
-elem.wast:687 assert_uninstantiable skipped:assert_uninstantiable decode: decode: bad integer literal: -10
+elem.wast:662 assert_uninstantiable pass
+elem.wast:670 assert_uninstantiable pass
+elem.wast:679 assert_uninstantiable pass
+elem.wast:687 assert_uninstantiable pass
 elem.wast:698 module pass
 elem.wast:706 assert_trap pass
 elem.wast:708 module pass


### PR DESCRIPTION
12 tests in the suite were being skipped due to improper parsing of signed ints. 4 each under data.wast, data1.wast, and elem.wast. The problem was that parseDataSegment and parseElemSegment in the WAT decoder were forwarding what should have been a signed int through parseU32, which treated it as unsigned. The fix was just making sure the parseDataSegment and parseElemSegment forwarded to parseI32 rather than parseU32, when the branch indicated a signed integer.

I identified and fixed the errors using Claude.