### PR TITLE
Add StdIO host and merge-sort stream example

### DIFF
--- a/codelib/CodeLib/Examples/MergeSort/Laws.lean
+++ b/codelib/CodeLib/Examples/MergeSort/Laws.lean
@@ -100,12 +100,12 @@ theorem wp_lessLocal
     ▷ WP (.running
       ⟨⟨params, localValues,
           .i32 (if lhs < rhs then 1 else 0) :: stack⟩,
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E {{ Φ }} ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         lessLocal lhsIndex rhsIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
         @ s; E {{ Φ }} := by
   iintro Hwp
   simp only [lessLocal, List.cons_append, List.nil_append]
@@ -130,12 +130,12 @@ theorem wp_address
       some (.i32 element)) :
     ▷ WP (.running
       ⟨⟨params, localValues, .i32 (4 * element + base) :: stack⟩,
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E {{ Φ }} ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         address baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
         @ s; E {{ Φ }} := by
   iintro Hwp
   simp only [address, List.cons_append, List.nil_append]
@@ -164,10 +164,10 @@ theorem wp_increment
       Locals).set? index (.i32 (1 + value)) = some updated) :
     ▷ WP (.running
       ⟨{ updated with values := stack }, code, arity, remainder,
-        controls, calls⟩ : Expr Unit) @ s; E {{ Φ }} ⊢
+        controls, calls⟩ : Expr α) @ s; E {{ Φ }} ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩, increment index ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit) @ s; E {{ Φ }} := by
+        arity, remainder, controls, calls⟩ : Expr α) @ s; E {{ Φ }} := by
   iintro Hwp
   simp only [increment, List.cons_append, List.nil_append]
   iapply Wasm.SmallStep.wp_localGet hget
@@ -193,10 +193,10 @@ theorem wp_increment_nil
       Locals).set? index (.i32 (1 + value)) = some updated) :
     ▷ WP (.running
       ⟨{ updated with values := stack }, [], arity, remainder,
-        controls, calls⟩ : Expr Unit) @ s; E {{ Φ }} ⊢
+        controls, calls⟩ : Expr α) @ s; E {{ Φ }} ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩, increment index,
-        arity, remainder, controls, calls⟩ : Expr Unit) @ s; E {{ Φ }} := by
+        arity, remainder, controls, calls⟩ : Expr α) @ s; E {{ Φ }} := by
   simpa only [List.append_nil] using
     (wp_increment (s := s) (E := E) (Φ := Φ)
       (code := []) hget hset)
@@ -215,17 +215,17 @@ theorem wp_loop_löb_family_from
     (body_closes : ∀ i,
       ⊢@{IProp WasmHeapGF} (iprop%
         ▷ (∀ (j : ι), I j -∗
-          WP (loopBodyExpr (α := Unit) (locals j)
+          WP (loopBodyExpr (α := α) (locals j)
             paramArity resultArity arity body code remainder belowStack
             controls calls) @ s; E {{ Φ }}) -∗
         I i -∗
-          WP (loopBodyExpr (α := Unit) (locals i)
+          WP (loopBodyExpr (α := α) (locals i)
             paramArity resultArity arity body code remainder belowStack
             controls calls) @ s; E {{ Φ }})) :
     I initial ⊢
       WP (.running
         ⟨initialLocals, .loop paramArity resultArity body :: code,
-          arity, remainder, controls, calls⟩ : Expr Unit)
+          arity, remainder, controls, calls⟩ : Expr α)
         @ s; E {{ Φ }} := by
   subst initialLocals
   exact wp_loop_löb_family locals I initial hbelow body_closes
@@ -250,12 +250,12 @@ theorem wp_loadAt_cell
       (pointsTo_u32 address word -∗
         WP (.running
           ⟨⟨params, localValues, .i32 word :: stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E {{ Φ }}) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         loadAt baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E {{ Φ }} := by
   have h1' : ((address + 0) + 1).toNat =
       (address + 0).toNat + 1 := by simpa using h1
@@ -301,12 +301,12 @@ theorem wp_loadAt
       (arrayAt base input -∗
         WP (.running
           ⟨⟨params, localValues, .i32 input[k] :: stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E {{ Φ }}) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         loadAt baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E {{ Φ }} := by
   have hslot :
       (base + 4 * UInt32.ofNat k).toNat = base.toNat + 4 * k := by
@@ -357,11 +357,11 @@ theorem wp_store32_cell
       (pointsTo_u32 address newWord -∗
         WP (.running
           ⟨⟨params, localValues, stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E {{ Φ }}) ⊢
     WP (.running
       ⟨⟨params, localValues, .i32 newWord :: .i32 address :: stack⟩,
-        .store32 0 :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        .store32 0 :: code, arity, remainder, controls, calls⟩ : Expr α)
       @ s; E {{ Φ }} := by
   have h1' : ((address + 0) + 1).toNat = (address + 0).toNat + 1 := by
     simpa using h1
@@ -417,13 +417,13 @@ theorem wp_copyAt
         arrayAt temporary (scratch.set k input[i]) -∗
         WP (.running
           ⟨⟨params, localValues, stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E {{ Φ }}) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         storeAt temporaryIndex temporaryElement
           (loadAt sourceIndex sourceElement) ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E {{ Φ }} := by
   let destination := 4 * UInt32.ofNat k + temporary
   have hslot :
@@ -503,12 +503,12 @@ theorem twp_lessLocal
     WP (.running
       ⟨⟨params, localValues,
           .i32 (if lhs < rhs then 1 else 0) :: stack⟩,
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         lessLocal lhsIndex rhsIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] := by
   iintro Hwp
   simp only [lessLocal, List.cons_append, List.nil_append]
@@ -531,12 +531,12 @@ theorem twp_address
       some (.i32 element)) :
     WP (.running
       ⟨⟨params, localValues, .i32 (4 * element + base) :: stack⟩,
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         address baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] := by
   iintro Hwp
   simp only [address, List.cons_append, List.nil_append]
@@ -561,10 +561,10 @@ theorem twp_increment
       Locals).set? index (.i32 (1 + value)) = some updated) :
     WP (.running
       ⟨{ updated with values := stack }, code, arity, remainder,
-        controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] ⊢
+        controls, calls⟩ : Expr α) @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩, increment index ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] := by
+        arity, remainder, controls, calls⟩ : Expr α) @ s; E [{ Φ }] := by
   iintro Hwp
   simp only [increment, List.cons_append, List.nil_append]
   iapply Wasm.SmallStep.twp_localGet hget
@@ -587,10 +587,10 @@ theorem twp_increment_nil
       Locals).set? index (.i32 (1 + value)) = some updated) :
     WP (.running
       ⟨{ updated with values := stack }, [], arity, remainder,
-        controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] ⊢
+        controls, calls⟩ : Expr α) @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩, increment index,
-        arity, remainder, controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] := by
+        arity, remainder, controls, calls⟩ : Expr α) @ s; E [{ Φ }] := by
   simpa only [List.append_nil] using
     (twp_increment (s := s) (E := E) (Φ := Φ)
       (code := []) hget hset)
@@ -615,12 +615,12 @@ theorem twp_loadAt_cell
       (pointsTo_u32 address word -∗
         WP (.running
           ⟨⟨params, localValues, .i32 word :: stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         loadAt baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   have h1' : ((address + 0) + 1).toNat =
       (address + 0).toNat + 1 := by simpa using h1
@@ -664,12 +664,12 @@ theorem twp_loadAt
       (arrayAt base input -∗
         WP (.running
           ⟨⟨params, localValues, .i32 input[k] :: stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         loadAt baseIndex elementIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   have hslot :
       (base + 4 * UInt32.ofNat k).toNat = base.toNat + 4 * k := by
@@ -720,11 +720,11 @@ theorem twp_store32_cell
       (pointsTo_u32 address newWord -∗
         WP (.running
           ⟨⟨params, localValues, stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨⟨params, localValues, .i32 newWord :: .i32 address :: stack⟩,
-        .store32 0 :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+        .store32 0 :: code, arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   have h1' : ((address + 0) + 1).toNat = (address + 0).toNat + 1 := by
     simpa using h1
@@ -779,13 +779,13 @@ theorem twp_copyAt
         arrayAt temporary (scratch.set k input[i]) -∗
         WP (.running
           ⟨⟨params, localValues, stack⟩,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨⟨params, localValues, stack⟩,
         storeAt temporaryIndex temporaryElement
           (loadAt sourceIndex sourceElement) ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let destination := 4 * UInt32.ofNat k + temporary
   have hslot :

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -865,7 +865,7 @@ theorem sortHeap_pointsTo [WasmHeapGS]
       rw [hscratchNat]
       simp only [UInt32.size]
       omega
-  simp only [sortHeap, sourceHeap]
+  simp only [sortHeap]
   iintro Hheap
   ihave HscratchSplit := Quicksort.quicksortHeapAux_pointsTo
     sourceHeap scratch (scratchValues input) hdisjoint hscratchFit $$ Hheap
@@ -970,6 +970,74 @@ private theorem mergeSortPost_elim [WasmHeapGS]
   iexact Hpost
 
 set_option maxHeartbeats 6000000 in
+theorem twp_sort [WasmSmallStepGS hlc]
+    (input : List UInt32) (hfit : Fits input) :
+    (([∗map] address ↦ value ∈ sortHeap input,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          address (DFrac.own 1) value) ∗
+      ([∗map] index ↦ value ∈ (∅ : WasmGlobalMap Value),
+        globalPointsTo index value) ∗
+      runtimeModuleOwn (sortConfig input).store.runtime.module) ⊢
+      WP (sortConfig input).expr @ Stuckness.NotStuck; ⊤
+        [{ values,
+          ∀ (store : MachineStore Unit) (_observations : List StepKind),
+            stateInterp (GF := WasmHeapGF) store 0 [] 0 -∗
+            ⌜SortPost input values store⌝ }] := by
+  iintro ⟨Hheap, _Hglobals, Hruntime⟩
+  ihave Harrays := sortHeap_pointsTo input hfit $$ Hheap
+  icases Harrays with ⟨Hsource, Hscratch⟩
+  simp only [sortConfig]
+  iapply twp_mergeSortBody (α := Unit) module 3
+    (by decide) (by rfl)
+    source scratch input (scratchValues input)
+  isplitl [Hruntime]
+  · iexact Hruntime
+  isplitl [Hsource Hscratch]
+  · unfold mergeSortPre
+    isplitl [Hsource]
+    · iexact Hsource
+    isplitl [Hscratch]
+    · iexact Hscratch
+    isplitr
+    · ipureintro
+      exact scratchValues_length input
+    · ipureintro
+      exact validLayout input hfit
+  · iintro %width %left %mid %right Hruntime Hpost
+    ihave Hpost' := mergeSortPost_elim source scratch input $$ Hpost
+    icases Hpost' with ⟨%output, %scratchFinal, %hsorted, %_hscratchLength,
+      Hsource, _Hscratch⟩
+    iapply Wasm.SmallStep.twp_returnFromFunction
+    iapply twp.value rfl
+    iintro %store %observations Hstate
+    imod Quicksort.arrayAt_readWordArray store 0 [] 0 source output
+      (by
+        have hlength := hsorted.2.length_eq
+        rw [← hlength]
+        rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+        change 4 * input.length ≤ 32768 at hfit
+        omega) $$ [$Hstate $Hsource] with
+      ⟨Hstate, Hsource, %hread⟩
+    have hread' : readWordArray store.wasm.mem source output.length = output := by
+      simpa only [quicksort_readWordArray_eq] using hread
+    imod arrayAt_capacity store 0 [] 0 source output
+      (by
+        have hlength := hsorted.2.length_eq
+        rw [← hlength]
+        rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+        change 4 * input.length ≤ 32768 at hfit
+        omega)
+      (by simp [source]) $$ [$Hstate $Hsource] with
+      ⟨_Hstate, _Hsource, %hcapacity⟩
+    ipureintro
+    exact ⟨output, hsorted, by
+      rw [hsorted.2.length_eq]
+      exact hread', by
+      rw [hsorted.2.length_eq]
+      simpa only [source, UInt32.reduceToNat, Nat.zero_add] using hcapacity⟩
+
 theorem sort_partiallyMeets (input : List UInt32) (hfit : Fits input) :
     SmallStep.PartiallyMeets (sortConfig input) (SortPost input) := by
   apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
@@ -978,61 +1046,43 @@ theorem sort_partiallyMeets (input : List UInt32) (hfit : Fits input) :
   · exact sortHeap_inBounds input hfit
   · exact globalHeapAgrees_empty _
   · intro _
-    iintro ⟨Hheap, _Hglobals, Hruntime⟩
-    ihave Harrays := sortHeap_pointsTo input hfit $$ Hheap
-    icases Harrays with ⟨Hsource, Hscratch⟩
-    simp only [sortConfig]
+    iintro Hresources
     iapply twp.to_wp
-    iapply twp_mergeSortBody (α := Unit) module 3
-      (by decide) (by rfl)
-      source scratch input (scratchValues input)
-    isplitl [Hruntime]
-    · iexact Hruntime
-    isplitl [Hsource Hscratch]
-    · unfold mergeSortPre
-      isplitl [Hsource]
-      · iexact Hsource
-      isplitl [Hscratch]
-      · iexact Hscratch
-      isplitr
-      · ipureintro
-        exact scratchValues_length input
-      · ipureintro
-        exact validLayout input hfit
-    · iintro %width %left %mid %right Hruntime Hpost
-      ihave Hpost' := mergeSortPost_elim source scratch input $$ Hpost
-      icases Hpost' with ⟨%output, %scratchFinal, %hsorted, %_hscratchLength,
-        Hsource, _Hscratch⟩
-      iapply Wasm.SmallStep.twp_returnFromFunction
-      iapply twp.value rfl
-      iintro %store %observations Hstate
-      imod Quicksort.arrayAt_readWordArray store 0 [] 0 source output
-        (by
-          have hlength := hsorted.2.length_eq
-          rw [← hlength]
-          rw [fits_iff] at hfit
-          simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
-          change 4 * input.length ≤ 32768 at hfit
-          omega) $$ [$Hstate $Hsource] with
-        ⟨Hstate, Hsource, %hread⟩
-      have hread' : readWordArray store.wasm.mem source output.length = output := by
-        simpa only [quicksort_readWordArray_eq] using hread
-      imod arrayAt_capacity store 0 [] 0 source output
-        (by
-          have hlength := hsorted.2.length_eq
-          rw [← hlength]
-          rw [fits_iff] at hfit
-          simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
-          change 4 * input.length ≤ 32768 at hfit
-          omega)
-        (by simp [source]) $$ [$Hstate $Hsource] with
-        ⟨_Hstate, _Hsource, %hcapacity⟩
-      ipureintro
-      exact ⟨output, hsorted, by
-        rw [hsorted.2.length_eq]
-        exact hread', by
-        rw [hsorted.2.length_eq]
-        simpa only [source, UInt32.reduceToNat, Nat.zero_add] using hcapacity⟩
+    iapply twp_sort input hfit
+    iexact Hresources
+
+theorem sort_stronglyNormalizing (input : List UInt32) (hfit : Fits input) :
+    Iris.ProgramLogic.StronglyNormalizing
+      (Iris.ProgramLogic.ExprErasedStep (Expr := Expr Unit)
+        (State := MachineStore Unit) (Obs := StepKind))
+      ((sortConfig input).expr, (sortConfig input).store) := by
+  apply Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_stronglyNormalizing.{0}
+    (sortConfig input) (sortHeap input) ∅
+    (fun _values => iprop(True))
+  · exact sortHeap_agrees input hfit
+  · exact sortHeap_inBounds input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    ihave Hsort := twp_sort input hfit $$ Hresources
+    iapply twp.mono (fun _values => ?_) $$ Hsort
+    iintro _Hpost
+    itrivial
+
+theorem sort_terminatesWith (input : List UInt32) (hfit : Fits input) :
+    SmallStep.TerminatesWith (sortConfig input) (SortPost input) := by
+  apply Wasm.SmallStep.stronglyNormalizing_adequate_terminates
+    (sortConfig input) (SortPost input) (sort_stronglyNormalizing input hfit)
+  apply wasm_smallStep_heap_globals_runtime_store_adequacy.{0}
+    (sortConfig input) (sortHeap input) ∅ (SortPost input)
+  · exact sortHeap_agrees input hfit
+  · exact sortHeap_inBounds input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    iapply twp.to_wp
+    iapply twp_sort input hfit
+    iexact Hresources
 
 theorem runSteps_sort_correct (fuel : Nat) (input : List UInt32)
     (hfit : Fits input) (values : List Value)
@@ -1073,6 +1123,22 @@ theorem execute_sort_correct (fuel : Nat) (input : List UInt32)
   | outOfFuel resultConfig => simp at hexecute
   | internalError error resultConfig => simp at hexecute
 
+theorem execute_sort_complete (input : List UInt32) (hfit : Fits input) :
+    ∃ fuel values store,
+      executeSort fuel (afterRead input)
+        (mergeSortArguments source scratch input.length []) =
+          some (values, store) ∧
+      SortPost input values
+        { runtime := { module, host := Wasm.StdIO.env }, wasm := store } := by
+  rcases sort_terminatesWith input hfit with
+    ⟨trace, values, finalStore, hsteps, hpost⟩
+  let store : Store Wasm.StdIO.State :=
+    replaceHost finalStore.wasm (afterRead input).host
+  refine ⟨trace.length, values, store, ?_, ?_⟩
+  · simp only [executeSort, initConfig_sort]
+    rw [runSteps_eq_success_of_steps hsteps]
+  · simpa only [SortPost, store, replaceHost] using hpost
+
 set_option maxRecDepth 10000 in
 theorem run_fits (fuel : Nat) (input : List UInt32) (hfit : Fits input) :
     run fuel (serialize input) =
@@ -1089,10 +1155,10 @@ theorem run_correct (fuel : Nat) (input : List UInt32) (bytes : List UInt8)
   rw [run_fits fuel input hfit] at hrun
   unfold runAfterRead at hrun
   rw [probe_afterRead input] at hrun
-  simp only [Option.bind_some, guard, decide_true, if_true] at hrun
+  simp only [guard] at hrun
   rw [encodedLength_words input hfit] at hrun
   simp only [Bind.bind, Option.bind] at hrun
-  simp only [if_true, Pure.pure, Bind.bind, Option.bind] at hrun
+  simp only [if_true, Pure.pure] at hrun
   generalize hsortResult : executeSort fuel (afterRead input)
       (mergeSortArguments source scratch input.length []) = sortResult at hrun
   cases sortResult with
@@ -1115,9 +1181,9 @@ theorem run_correct (fuel : Nat) (input : List UInt32) (bytes : List UInt8)
         exact hcapacity
       have hwrite := execute_write_bytes afterSort
         (UInt32.ofNat (serialize input).length) hwriteBound
-      simp only [Option.bind_some, Prod.fst, Prod.snd] at hrun
+      simp only [] at hrun
       rw [hwrite] at hrun
-      simp only [Bind.bind, Option.bind, Pure.pure] at hrun
+      simp only [] at hrun
       have houtput : afterSort.host.output = [] := by
         rw [hhost]
         rfl
@@ -1169,6 +1235,53 @@ output.  Keeping resource-bounded termination separate leaves `Correct` clean. -
 def Complete : Prop :=
   ∀ input, Fits input →
     ∃ output, RunsValues input output
+
+theorem complete : Complete := by
+  intro input hfit
+  rcases execute_sort_complete input hfit with
+    ⟨fuel, values, afterSort, hsort, hpost⟩
+  obtain ⟨output, hsorted, hread, hcapacity⟩ := hpost
+  have hhost := executeSort_host fuel (afterRead input) afterSort
+    (mergeSortArguments source scratch input.length []) values hsort
+  have hbyteLength :
+      (UInt32.ofNat (serialize input).length).toNat = 4 * input.length := by
+    rw [encodedLength_toNat input hfit, serialize_length]
+  have hwriteBound : source.toNat +
+      (UInt32.ofNat (serialize input).length).toNat ≤
+      Wasm.StdIO.byteCapacity afterSort := by
+    simp only [source, UInt32.reduceToNat, Nat.zero_add,
+      Wasm.StdIO.byteCapacity, hbyteLength]
+    exact hcapacity
+  have hwrite := execute_write_bytes afterSort
+    (UInt32.ofNat (serialize input).length) hwriteBound
+  have houtput : afterSort.host.output = [] := by
+    rw [hhost]
+    rfl
+  have hrun : run fuel (serialize input) =
+      some (afterSort.mem.readBytes source.toNat (4 * input.length)) := by
+    rw [run_fits fuel input hfit]
+    unfold runAfterRead
+    rw [probe_afterRead input]
+    simp only [guard]
+    rw [encodedLength_words input hfit]
+    simp only [Bind.bind, Option.bind]
+    simp only [if_true, Pure.pure]
+    rw [hsort]
+    simp only []
+    rw [hwrite]
+    simp only []
+    simp only [writtenStore, houtput,
+      List.nil_append, hbyteLength]
+  refine ⟨output, fuel, ?_⟩
+  unfold runValues
+  rw [hrun]
+  simp only [Option.bind_some]
+  rw [deserialize_readBytes]
+  · exact congrArg some hread
+  · rw [fits_iff] at hfit
+    simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+    change 4 * input.length ≤ 32768 at hfit
+    omega
 
 theorem exec_empty : run 100 (serialize []) = some (serialize []) := by
   native_decide

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -1,0 +1,128 @@
+import CodeLib.Examples.MergeSort
+import Interpreter.Wasm.Host.StdIO
+
+/-!
+# Merge sort as a `StdIO` program
+
+This layer turns the memory-oriented merge-sort implementation into a small
+byte-stream program.  Its input and output format is a packed sequence of
+little-endian `UInt32` values.  The entry point reads the input into the first
+half of its one-page memory, uses the second half as scratch space, sorts the
+words, and writes the sorted first half to the append-only output stream.
+-/
+
+namespace Wasm.Examples.MergeSort.StdIO
+
+open Wasm SmallStep
+
+/-- Each of the source and scratch arrays owns half of the 64-KiB page. -/
+def bufferBytes : Nat := 32768
+
+def source : UInt32 := 0
+def scratch : UInt32 := UInt32.ofNat bufferBytes
+
+/-- Packed little-endian serialization of a list of 32-bit words. -/
+def serialize (values : List UInt32) : List UInt8 :=
+  let memory := writeWordArray (Mem.empty 1) 0 values
+  memory.readBytes 0 (4 * values.length)
+
+/-- Decode a packed little-endian byte sequence.  A trailing partial word is
+rejected rather than silently ignored. -/
+def deserialize (bytes : List UInt8) : Option (List UInt32) :=
+  if bytes.length % 4 = 0 then
+    let memory := (Mem.empty 1).writeBytes 0 bytes
+    some (readWordArray memory 0 (bytes.length / 4))
+  else
+    none
+
+/-- The stream-facing wrapper.  Local `0` remembers the byte count returned
+by `read`; dividing it by four gives the number of words passed to merge sort.
+
+Unified function indices are: `0 = read`, `1 = write`, `2 = mergeSort`,
+`3 = merge`, and `4 = main`. -/
+def mainBody : Program :=
+  [ .const (UInt32.ofNat bufferBytes), .const source, .call 0, .localSet 0
+  , .const source, .const scratch, .localGet 0, .const 4, .divU, .call 2
+  , .localGet 0, .const source, .call 1
+  , .ret ]
+
+def mainFunction : Function :=
+  { locals := [.i32]
+    body := mainBody }
+
+/-- Merge sort linked against the two-function `StdIO` ABI. -/
+def module : Module :=
+  { imports := Wasm.StdIO.imports
+    funcs := [mergeSortFunction 3, mergeFunction, mainFunction]
+    memory := some { pagesMin := 1, pagesMax := some 1 } }
+
+def initialStore (input : List UInt8) : Store Wasm.StdIO.State :=
+  { (module.initialStore (α := Wasm.StdIO.State)) with
+      host := Wasm.StdIO.State.ofInput input }
+
+def config (input : List UInt8) : Config Wasm.StdIO.State :=
+  match SmallStep.initConfig
+      { module, host := Wasm.StdIO.env } 4 (initialStore input) [] with
+  | .ok result => result
+  | .error _ =>
+      -- Definitionally unreachable: local function index 4 is `mainFunction`.
+      { expr := .trapped (.host "invalid StdIO merge-sort entry")
+        store :=
+          { runtime := { module, host := Wasm.StdIO.env }
+            wasm := initialStore input } }
+
+/-- Execute the authoritative small-step machine and project the host output. -/
+def run (fuel : Nat) (input : List UInt8) : Option (List UInt8) :=
+  match (SmallStep.runSteps fuel (config input)).result with
+  | .success _ store => some store.wasm.host.output
+  | _ => none
+
+/-- A clean, host-level execution predicate.  Fuel is hidden existentially
+and neither linear memory nor Wasm machine state appears in client specs. -/
+def Runs (input output : List UInt8) : Prop :=
+  ∃ fuel, run fuel input = some output
+
+/-- Serialize the input, run the byte-stream program, and deserialize its
+output.  This is the convenient executable surface for clients. -/
+def runValues (fuel : Nat) (input : List UInt32) : Option (List UInt32) :=
+  (run fuel (serialize input)).bind deserialize
+
+/-- Fuel-free execution phrased entirely in terms of lists of words. -/
+def RunsValues (input output : List UInt32) : Prop :=
+  ∃ fuel, runValues fuel input = some output
+
+/-- Pure input-side condition imposed by the fixed one-page Wasm32 layout. -/
+def Fits (values : List UInt32) : Prop :=
+  (serialize values).length ≤ bufferBytes
+
+/-- Every value-level result successfully produced by the program is a sorted
+permutation of its input.  This safety statement is independent of Wasm's
+finite-memory resource limit. -/
+def Correct : Prop :=
+  ∀ input output,
+    RunsValues input output → SortedPermutation input output
+
+/-- Every input that fits the current fixed layout successfully produces an
+output.  Keeping resource-bounded termination separate leaves `Correct` clean. -/
+def Complete : Prop :=
+  ∀ input, Fits input →
+    ∃ output, RunsValues input output
+
+theorem exec_empty : run 100 (serialize []) = some (serialize []) := by
+  native_decide
+
+theorem exec_five :
+    run 12000 (serialize [5, 1, 4, 2, 3]) =
+      some (serialize [1, 2, 3, 4, 5]) := by
+  native_decide
+
+theorem exec_duplicates :
+    run 15000 (serialize [4, 1, 4, 2, 1, 3]) =
+      some (serialize [1, 1, 2, 3, 4, 4]) := by
+  native_decide
+
+theorem exec_values_five :
+    runValues 12000 [5, 1, 4, 2, 3] = some [1, 2, 3, 4, 5] := by
+  native_decide
+
+end Wasm.Examples.MergeSort.StdIO

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -1,4 +1,6 @@
 import CodeLib.Examples.MergeSort.TotalProof
+import CodeLib.Examples.Quicksort
+import CodeLib.RustStd.MemArray
 import Interpreter.Wasm.Host.StdIO
 
 /-!
@@ -13,7 +15,8 @@ words, and writes the sorted first half to the append-only output stream.
 
 namespace Wasm.Examples.MergeSort.StdIO
 
-open Wasm SmallStep
+open Wasm SepLogic SmallStep
+open Iris Iris.Std
 
 /-- Each of the source and scratch arrays owns half of the 64-KiB page. -/
 def bufferBytes : Nat := 32768
@@ -207,6 +210,81 @@ theorem writeWordArray_readWordArray (mem : Mem) (base : UInt32)
       simp only [readWordArray, writeWordArray]
       rw [write32_read32, ih]
 
+theorem quicksort_writeWordArray_eq (mem : Mem) (base : UInt32)
+    (values : List UInt32) :
+    Quicksort.writeWordArray mem base values = writeWordArray mem base values := by
+  induction values generalizing mem base with
+  | nil => rfl
+  | cons value values ih =>
+      simp only [Quicksort.writeWordArray, writeWordArray]
+      rw [ih]
+
+theorem quicksort_readWordArray_eq (mem : Mem) (base : UInt32)
+    (count : Nat) :
+    Quicksort.readWordArray mem base count = readWordArray mem base count := by
+  induction count generalizing base with
+  | zero => rfl
+  | succ count ih =>
+      simp only [Quicksort.readWordArray, readWordArray]
+      rw [ih]
+
+theorem quicksortHeapAux_addresses_lt
+    (σ : WasmHeapMap (Option UInt8)) (base : UInt32)
+    (values : List UInt32) (limit : Nat)
+    (hσ : ∀ address byte, get? σ address = some byte →
+      address.toNat < base.toNat)
+    (hfit : base.toNat + 4 * values.length ≤ limit)
+    (hlimit : limit < UInt32.size) :
+    ∀ address byte,
+      get? (Quicksort.quicksortHeapAux σ base values) address = some byte →
+      address.toNat < limit := by
+  induction values generalizing σ base with
+  | nil =>
+      intro address byte hget
+      exact Nat.lt_of_lt_of_le (hσ address byte hget) (by simpa using hfit)
+  | cons value values ih =>
+      simp only [Quicksort.quicksortHeapAux, List.length_cons] at *
+      have h4 : (base + 4 : UInt32).toNat = base.toNat + 4 :=
+        UInt32.add_ofNat_toNat_noWrap base 4 (by decide) (by
+          simp only [UInt32.size] at hlimit
+          omega)
+      have hn1 : (base + 1).toNat = base.toNat + 1 :=
+        UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by
+          simp only [UInt32.size] at hlimit
+          omega)
+      have hn2 : (base + 2).toNat = base.toNat + 2 :=
+        UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by
+          simp only [UInt32.size] at hlimit
+          omega)
+      have hn3 : (base + 3).toNat = base.toNat + 3 :=
+        UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by
+          simp only [UInt32.size] at hlimit
+          omega)
+      apply ih (store32Heap σ base value) (base + 4)
+      · intro address byte hget
+        rw [h4]
+        by_cases h3 : address = base + 3
+        · subst h3
+          rw [hn3]
+          omega
+        by_cases h2 : address = base + 2
+        · subst h2
+          rw [hn2]
+          omega
+        by_cases h1 : address = base + 1
+        · subst h1
+          rw [hn1]
+          omega
+        by_cases h0 : address = base
+        · subst h0
+          omega
+        · simp only [store32Heap,
+              get?_insert_ne (Ne.symm h3), get?_insert_ne (Ne.symm h2),
+              get?_insert_ne (Ne.symm h1), get?_insert_ne (Ne.symm h0)] at hget
+          exact Nat.lt_trans (hσ address byte hget) (by omega)
+      · rw [h4]
+        omega
+
 /-- The stream-facing wrapper.  Local `0` remembers the byte count returned
 by `read`; dividing it by four gives the number of words passed to merge sort.
 
@@ -257,6 +335,47 @@ def execute (fuel entry : Nat) (store : Store Wasm.StdIO.State)
       match (SmallStep.runSteps fuel phase).result with
       | .success values finalStore => some (values, finalStore.wasm)
       | _ => none
+
+/-- Change only the host-owned component of a Wasm store. This is a
+type-changing record update: all core Wasm resources remain identical. -/
+def replaceHost (store : Store α) (host : β) : Store β :=
+  { store with host := host }
+
+/-- Execute merge sort with an inert host environment, then reattach the
+unchanged StdIO buffers. The sort and merge functions have no path to an
+import, so this makes their host independence explicit. -/
+def executeSort (fuel : Nat) (store : Store Wasm.StdIO.State)
+    (args : List Value) : Option (List Value × Store Wasm.StdIO.State) :=
+  match SmallStep.initConfig
+      { module, host := ({} : HostEnv Unit) } 2 (replaceHost store ()) args with
+  | .error _ => none
+  | .ok phase =>
+      match (SmallStep.runSteps fuel phase).result with
+      | .success values finalStore =>
+          some (values, replaceHost finalStore.wasm store.host)
+      | _ => none
+
+theorem executeSort_host (fuel : Nat) (initial final : Store Wasm.StdIO.State)
+    (args : List Value) (values : List Value)
+    (hexecute : executeSort fuel initial args = some (values, final)) :
+    final.host = initial.host := by
+  unfold executeSort at hexecute
+  split at hexecute
+  · contradiction
+  · generalize hresult : (runSteps fuel _).result = result at hexecute
+    cases result <;> simp_all [replaceHost]
+    case success =>
+      have hhost := congrArg (fun concrete : Store Wasm.StdIO.State =>
+        concrete.host) hexecute.2
+      simpa [replaceHost] using hhost.symm
+
+def writtenStore (store : Store Wasm.StdIO.State) (length : UInt32) :
+    Store Wasm.StdIO.State :=
+  { store with
+    host :=
+      { input := store.host.input
+        output := store.host.output ++
+          store.mem.readBytes source.toNat length.toNat } }
 
 theorem execute_read (store wasm : Store Wasm.StdIO.State)
     (length pointer count : UInt32)
@@ -371,6 +490,17 @@ theorem execute_write (store wasm : Store Wasm.StdIO.State)
   rw [show (runSteps 2 initial).result =
       .success [] { machine with wasm } by simpa using hrun]
 
+theorem execute_write_bytes (store : Store Wasm.StdIO.State) (length : UInt32)
+    (hbound : source.toNat + length.toNat ≤ Wasm.StdIO.byteCapacity store) :
+    execute 2 1 store [.i32 source, .i32 length] =
+      some ([], writtenStore store length) := by
+  apply execute_write
+  simp only [Wasm.StdIO.writeHost, Wasm.StdIO.writeResult]
+  rw [if_pos]
+  · rfl
+  · simp only [Wasm.StdIO.rangeInBounds]
+    exact decide_eq_true hbound
+
 private theorem take_eq_self_of_length_le {β : Type} (xs : List β) (n : Nat)
     (h : xs.length ≤ n) : xs.take n = xs := by
   induction xs generalizing n with
@@ -386,7 +516,7 @@ private theorem take_eq_self_of_length_le {β : Type} (xs : List β) (n : Nat)
     (initialStore input).host = Wasm.StdIO.State.ofInput input := by
   rfl
 
-set_option maxRecDepth 10000 in
+set_option maxRecDepth 100000 in
 private theorem initial_byteCapacity (input : List UInt8) :
     Wasm.StdIO.byteCapacity (initialStore input) = 65536 := by
   change (module.initialStore (α := Wasm.StdIO.State)).mem.pages * 65536 = 65536
@@ -428,6 +558,22 @@ def afterRead (input : List UInt32) : Store Wasm.StdIO.State :=
     mem := (initialStore (serialize input)).mem.writeBytes
       source.toNat (serialize input)
     host := { input := [], output := [] } }
+
+/-- Exact authoritative configuration used by the merge-sort phase. -/
+def sortConfig (input : List UInt32) : Config Unit :=
+  { expr := .running
+      ⟨sortLocals source scratch input.length 0 0 0 0 [],
+        mergeSortBody 3, 0, [], [], []⟩
+    store :=
+      { runtime := { module, host := {} }
+        wasm := replaceHost (afterRead input) () } }
+
+theorem initConfig_sort (input : List UInt32) :
+    SmallStep.initConfig { module, host := ({} : HostEnv Unit) } 2
+      (replaceHost (afterRead input) ())
+      (mergeSortArguments source scratch input.length []) =
+      .ok (sortConfig input) := by
+  rfl
 
 set_option maxRecDepth 10000 in
 theorem read_fits (input : List UInt32)
@@ -486,6 +632,17 @@ theorem probe_traps_of_too_long (input : List UInt8)
   · rw [afterBoundedRead_byteCapacity]
     exact UInt32.toNat_ofNat_of_lt' (by decide)
 
+def runAfterRead (fuel : Nat) (byteLength : UInt32)
+    (afterRead : Store Wasm.StdIO.State) : Option (List UInt8) := do
+  let (probeValues, afterProbe) ← execute 2 0 afterRead
+    [.i32 (UInt32.ofNat 65536), .i32 1]
+  guard (probeValues = [.i32 0])
+  let (_, afterSort) ← executeSort fuel afterProbe
+    (mergeSortArguments source scratch (byteLength.toNat / 4) [])
+  let (_, afterWrite) ← execute 2 1 afterSort
+    [.i32 source, .i32 byteLength]
+  pure afterWrite.host.output
+
 /-- Execute the stream program in four explicit phases: read the source
 region, prove EOF with the one-past-memory probe, run merge sort, then append
 the sorted source region through `write`.  Every phase still executes through
@@ -496,26 +653,21 @@ def run (fuel : Nat) (input : List UInt8) : Option (List UInt8) := do
   let byteLength ← match readValues with
     | [.i32 length] => some length
     | _ => none
-  let (probeValues, afterProbe) ← execute 2 0 afterRead
-    [.i32 (UInt32.ofNat 65536), .i32 1]
-  guard (probeValues = [.i32 0])
-  let (_, afterSort) ← execute fuel 2 afterProbe
-    (mergeSortArguments source scratch (byteLength.toNat / 4) [])
-  let (_, afterWrite) ← execute 2 1 afterSort
-    [.i32 source, .i32 byteLength]
-  pure afterWrite.host.output
+  runAfterRead fuel byteLength afterRead
 
 theorem run_none_of_too_long (fuel : Nat) (input : List UInt8)
     (hlong : bufferBytes < input.length) :
     run fuel input = none := by
-  simp [run, read_bounded]
-  intro values store hprobe
   have hprobeNone : execute 2 0 (afterBoundedRead input)
-      [.i32 (65536 : UInt32), .i32 1] = none := by
-    simpa only [show (65536 : UInt32) = UInt32.ofNat 65536 by decide] using
-      probe_traps_of_too_long input hlong
-  rw [hprobeNone] at hprobe
-  contradiction
+      [.i32 (UInt32.ofNat 65536), .i32 1] = none :=
+    probe_traps_of_too_long input hlong
+  unfold run
+  rw [read_bounded]
+  change runAfterRead fuel (UInt32.ofNat (input.take bufferBytes).length)
+    (afterBoundedRead input) = none
+  unfold runAfterRead
+  rw [hprobeNone]
+  rfl
 
 /-- A clean, host-level execution predicate.  Fuel is hidden existentially
 and neither linear memory nor Wasm machine state appears in client specs. -/
@@ -535,9 +687,451 @@ def RunsValues (input output : List UInt32) : Prop :=
 def Fits (values : List UInt32) : Prop :=
   (serialize values).length ≤ bufferBytes
 
+/-- Scratch words are whatever is currently present in the reserved second
+half of memory. The merge-sort proof only requires scratch storage of the
+right length; it does not require a particular initial value. -/
+def scratchValues (input : List UInt32) : List UInt32 :=
+  readWordArray (afterRead input).mem scratch input.length
+
+/-- Authoritative ghost heap covering both arrays used by merge sort. -/
+def sortHeap (input : List UInt32) : WasmHeapMap (Option UInt8) :=
+  Quicksort.quicksortHeapAux
+    (Quicksort.quicksortHeapAux ∅ source input)
+    scratch (scratchValues input)
+
 theorem fits_iff (values : List UInt32) :
     Fits values ↔ 4 * values.length ≤ bufferBytes := by
   simp only [Fits, serialize_length]
+
+theorem encodedLength_toNat (input : List UInt32) (hfit : Fits input) :
+    (UInt32.ofNat (serialize input).length).toNat = (serialize input).length := by
+  apply UInt32.toNat_ofNat_of_lt'
+  rw [fits_iff] at hfit
+  change 4 * input.length ≤ 32768 at hfit
+  simp only [serialize_length, UInt32.size]
+  omega
+
+theorem encodedLength_words (input : List UInt32) (hfit : Fits input) :
+    (UInt32.ofNat (serialize input).length).toNat / 4 = input.length := by
+  rw [encodedLength_toNat input hfit, serialize_length]
+  omega
+
+theorem scratchValues_length (input : List UInt32) :
+    (scratchValues input).length = input.length := by
+  have aux (mem : Mem) (base : UInt32) (count : Nat) :
+      (readWordArray mem base count).length = count := by
+    induction count generalizing base with
+    | zero => rfl
+    | succ count ih =>
+        simp only [readWordArray, List.length_cons]
+        rw [ih]
+  exact aux _ _ _
+
+theorem afterRead_mem_eq (input : List UInt32) (hfit : Fits input) :
+    (afterRead input).mem =
+      writeWordArray (initialStore (serialize input)).mem source input := by
+  unfold afterRead
+  simp only
+  apply writeBytes_serialize
+  simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+  rw [fits_iff] at hfit
+  change 4 * input.length ≤ 32768 at hfit
+  omega
+
+theorem sortHeap_agrees (input : List UInt32) (hfit : Fits input) :
+    heapAgreesWithMem (sortHeap input) (afterRead input).mem := by
+  let initialMem := (initialStore (serialize input)).mem
+  let sourceHeap := Quicksort.quicksortHeapAux ∅ source input
+  have hempty : heapAgreesWithMem (∅ : WasmHeapMap (Option UInt8)) initialMem := by
+    intro address byte hget
+    have hemptyGet : Iris.Std.get? (∅ : WasmHeapMap (Option UInt8)) address = none :=
+      Iris.Std.get?_empty address
+    rw [hemptyGet] at hget
+    contradiction
+  have hsource : heapAgreesWithMem sourceHeap (afterRead input).mem := by
+    rw [afterRead_mem_eq input hfit]
+    simpa only [sourceHeap, initialMem, quicksort_writeWordArray_eq] using
+      Quicksort.quicksortHeapAux_agrees ∅ initialMem source input hempty
+      (by
+        rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+        change 4 * input.length ≤ 32768 at hfit
+        omega)
+  have hscratch := Quicksort.quicksortHeapAux_agrees sourceHeap
+    (afterRead input).mem scratch (scratchValues input) hsource
+    (by
+      rw [scratchValues_length]
+      rw [fits_iff] at hfit
+      have hscratchNat : scratch.toNat = 32768 := by decide
+      rw [hscratchNat]
+      simp only [UInt32.size]
+      change 4 * input.length ≤ 32768 at hfit
+      omega)
+  rw [quicksort_writeWordArray_eq] at hscratch
+  simpa only [sortHeap, sourceHeap, scratchValues,
+    writeWordArray_readWordArray] using hscratch
+
+theorem sortHeap_inBounds (input : List UInt32) (hfit : Fits input) :
+    heapAddressesInBounds (sortHeap input) (afterRead input).mem := by
+  let initialMem := (initialStore (serialize input)).mem
+  let sourceHeap := Quicksort.quicksortHeapAux ∅ source input
+  have hempty : heapAddressesInBounds
+      (∅ : WasmHeapMap (Option UInt8)) initialMem := by
+    intro address byte hget
+    have hemptyGet : Iris.Std.get? (∅ : WasmHeapMap (Option UInt8)) address = none :=
+      Iris.Std.get?_empty address
+    rw [hemptyGet] at hget
+    contradiction
+  have hsource : heapAddressesInBounds sourceHeap (afterRead input).mem := by
+    rw [afterRead_mem_eq input hfit]
+    simpa only [sourceHeap, initialMem, quicksort_writeWordArray_eq] using
+      Quicksort.quicksortHeapAux_inBounds ∅ initialMem source input hempty
+      (by
+        rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+        change 4 * input.length ≤ 32768 at hfit
+        omega)
+      (by
+        change source.toNat + 4 * input.length ≤
+          Wasm.StdIO.byteCapacity (initialStore (serialize input))
+        rw [initial_byteCapacity]
+        rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add]
+        change 4 * input.length ≤ 32768 at hfit
+        omega)
+  have hscratch := Quicksort.quicksortHeapAux_inBounds sourceHeap
+    (afterRead input).mem scratch (scratchValues input) hsource
+    (by
+      rw [scratchValues_length]
+      rw [fits_iff] at hfit
+      have hscratchNat : scratch.toNat = 32768 := by decide
+      rw [hscratchNat]
+      simp only [UInt32.size]
+      change 4 * input.length ≤ 32768 at hfit
+      omega)
+    (by
+      rw [scratchValues_length]
+      change scratch.toNat + 4 * input.length ≤
+        Wasm.StdIO.byteCapacity (afterRead input)
+      rw [afterRead_byteCapacity]
+      rw [fits_iff] at hfit
+      have hscratchNat : scratch.toNat = 32768 := by decide
+      rw [hscratchNat]
+      change 4 * input.length ≤ 32768 at hfit
+      omega)
+  rw [quicksort_writeWordArray_eq] at hscratch
+  simpa only [sortHeap, sourceHeap, scratchValues,
+    writeWordArray_readWordArray] using hscratch
+
+theorem sortHeap_pointsTo [WasmHeapGS]
+    (input : List UInt32) (hfit : Fits input) :
+    ([∗map] address ↦ value ∈ sortHeap input,
+      pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+        address (DFrac.own 1) value) ⊢
+      arrayAt source input ∗ arrayAt scratch (scratchValues input) := by
+  let sourceHeap := Quicksort.quicksortHeapAux ∅ source input
+  have hempty : ∀ address byte,
+      get? (∅ : WasmHeapMap (Option UInt8)) address = some byte →
+      address.toNat < source.toNat := by
+    intro address byte hget
+    have hemptyGet : get? (∅ : WasmHeapMap (Option UInt8)) address = none :=
+      get?_empty address
+    rw [hemptyGet] at hget
+    contradiction
+  have hsourceFit : source.toNat + 4 * input.length < UInt32.size := by
+    rw [fits_iff] at hfit
+    simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+    change 4 * input.length ≤ 32768 at hfit
+    omega
+  have hscratchFit :
+      scratch.toNat + 4 * (scratchValues input).length < UInt32.size := by
+    rw [scratchValues_length]
+    rw [fits_iff] at hfit
+    have hscratchNat : scratch.toNat = 32768 := by decide
+    rw [hscratchNat]
+    simp only [UInt32.size]
+    change 4 * input.length ≤ 32768 at hfit
+    omega
+  have hdisjoint : ∀ address byte, get? sourceHeap address = some byte →
+      address.toNat < scratch.toNat := by
+    apply quicksortHeapAux_addresses_lt ∅ source input scratch.toNat hempty
+    · rw [fits_iff] at hfit
+      have hscratchNat : scratch.toNat = 32768 := by decide
+      rw [hscratchNat]
+      simp only [source, UInt32.reduceToNat, Nat.zero_add]
+      change 4 * input.length ≤ 32768 at hfit
+      exact hfit
+    · have hscratchNat : scratch.toNat = 32768 := by decide
+      rw [hscratchNat]
+      simp only [UInt32.size]
+      omega
+  simp only [sortHeap, sourceHeap]
+  iintro Hheap
+  ihave HscratchSplit := Quicksort.quicksortHeapAux_pointsTo
+    sourceHeap scratch (scratchValues input) hdisjoint hscratchFit $$ Hheap
+  icases HscratchSplit with ⟨Hscratch, HsourceHeap⟩
+  ihave HsourceSplit := Quicksort.quicksortHeapAux_pointsTo
+    ∅ source input hempty hsourceFit $$ HsourceHeap
+  icases HsourceSplit with ⟨Hsource, _Hempty⟩
+  isplitl [Hsource]
+  · iexact Hsource
+  · iexact Hscratch
+
+theorem arrayAt_capacity [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat)
+    (observations : List StepKind) (threads : Nat)
+    (base : UInt32) (values : List UInt32)
+    (hfit : base.toNat + 4 * values.length < UInt32.size)
+    (hbaseBound : base.toNat ≤ store.wasm.mem.pages * 65536) :
+    stateInterp (GF := WasmHeapGF) store steps observations threads ∗
+      arrayAt base values ==∗
+    stateInterp (GF := WasmHeapGF) store steps observations threads ∗
+      arrayAt base values ∗
+      ⌜base.toNat + 4 * values.length ≤ store.wasm.mem.pages * 65536⌝ := by
+  by_cases hempty : values = []
+  · subst values
+    iintro ⟨Hstate, Harray⟩
+    imodintro
+    isplitl [Hstate]
+    · iexact Hstate
+    isplitl [Harray]
+    · iexact Harray
+    · ipureintro
+      simpa using hbaseBound
+  · have hlength : 0 < values.length := by
+      cases values with
+      | nil => contradiction
+      | cons value values => simp
+    let k := values.length - 1
+    have hk : k < values.length := by simp [k, hlength]
+    let address := base + 4 * UInt32.ofNat k
+    have haddress : address.toNat = base.toNat + 4 * k := by
+      exact Mem.words32_slotAddr_toNat base k (by
+        simp only [UInt32.size] at hfit
+        omega)
+    have h1 : (address + 1).toNat = address.toNat + 1 :=
+      UInt32.add_ofNat_toNat_noWrap address 1 (by decide) (by
+        simp only [UInt32.size] at hfit
+        rw [haddress]
+        omega)
+    have h2 : (address + 2).toNat = address.toNat + 2 :=
+      UInt32.add_ofNat_toNat_noWrap address 2 (by decide) (by
+        simp only [UInt32.size] at hfit
+        rw [haddress]
+        omega)
+    have h3 : (address + 3).toNat = address.toNat + 3 :=
+      UInt32.add_ofNat_toNat_noWrap address 3 (by decide) (by
+        simp only [UInt32.size] at hfit
+        rw [haddress]
+        omega)
+    iintro ⟨Hstate, Harray⟩
+    ihave Hfocus := arrayAt_get base values k hk $$ Harray
+    icases Hfocus with ⟨Hword, Hrestore⟩
+    imod stateInterp_pointsTo_u32_facts_frame store steps observations threads
+      address values[k] h1 h2 h3 $$ [$Hstate $Hword] with
+      ⟨Hstate, Hword, %hfacts⟩
+    imodintro
+    isplitl [Hstate]
+    · iexact Hstate
+    isplitl [Hrestore Hword]
+    · iapply Hrestore
+      iexact Hword
+    · ipureintro
+      rw [haddress] at hfacts
+      dsimp only [k] at hfacts
+      omega
+
+theorem validLayout (input : List UInt32) (hfit : Fits input) :
+    ValidLayout source scratch input.length := by
+  rw [fits_iff] at hfit
+  unfold ValidLayout arrayByteRange
+  simp only [source, UInt32.reduceToNat, Nat.zero_add]
+  have hscratchNat : scratch.toNat = 32768 := by decide
+  rw [hscratchNat]
+  simp only [UInt32.size]
+  change 4 * input.length ≤ 32768 at hfit
+  omega
+
+def SortPost (input : List UInt32)
+    (_values : List Value) (store : MachineStore α) : Prop :=
+  ∃ output, SortedPermutation input output ∧
+    readWordArray store.wasm.mem source input.length = output ∧
+    4 * input.length ≤ store.wasm.mem.pages * 65536
+
+private theorem mergeSortPost_elim [WasmHeapGS]
+    (source scratch : UInt32) (input : List UInt32) :
+    mergeSortPost source scratch input ⊢
+      (iprop% ∃ output scratchFinal : List UInt32,
+        ⌜SortedPermutation input output⌝ ∗
+        ⌜scratchFinal.length = input.length⌝ ∗
+        arrayAt source output ∗ arrayAt scratch scratchFinal) := by
+  unfold mergeSortPost
+  iintro Hpost
+  iexact Hpost
+
+set_option maxHeartbeats 6000000 in
+theorem sort_partiallyMeets (input : List UInt32) (hfit : Fits input) :
+    SmallStep.PartiallyMeets (sortConfig input) (SortPost input) := by
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+    (sortConfig input) (sortHeap input) ∅ (SortPost input)
+  · exact sortHeap_agrees input hfit
+  · exact sortHeap_inBounds input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro ⟨Hheap, _Hglobals, Hruntime⟩
+    ihave Harrays := sortHeap_pointsTo input hfit $$ Hheap
+    icases Harrays with ⟨Hsource, Hscratch⟩
+    simp only [sortConfig]
+    iapply twp.to_wp
+    iapply twp_mergeSortBody (α := Unit) module 3
+      (by decide) (by rfl)
+      source scratch input (scratchValues input)
+    isplitl [Hruntime]
+    · iexact Hruntime
+    isplitl [Hsource Hscratch]
+    · unfold mergeSortPre
+      isplitl [Hsource]
+      · iexact Hsource
+      isplitl [Hscratch]
+      · iexact Hscratch
+      isplitr
+      · ipureintro
+        exact scratchValues_length input
+      · ipureintro
+        exact validLayout input hfit
+    · iintro %width %left %mid %right Hruntime Hpost
+      ihave Hpost' := mergeSortPost_elim source scratch input $$ Hpost
+      icases Hpost' with ⟨%output, %scratchFinal, %hsorted, %_hscratchLength,
+        Hsource, _Hscratch⟩
+      iapply Wasm.SmallStep.twp_returnFromFunction
+      iapply twp.value rfl
+      iintro %store %observations Hstate
+      imod Quicksort.arrayAt_readWordArray store 0 [] 0 source output
+        (by
+          have hlength := hsorted.2.length_eq
+          rw [← hlength]
+          rw [fits_iff] at hfit
+          simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+          change 4 * input.length ≤ 32768 at hfit
+          omega) $$ [$Hstate $Hsource] with
+        ⟨Hstate, Hsource, %hread⟩
+      have hread' : readWordArray store.wasm.mem source output.length = output := by
+        simpa only [quicksort_readWordArray_eq] using hread
+      imod arrayAt_capacity store 0 [] 0 source output
+        (by
+          have hlength := hsorted.2.length_eq
+          rw [← hlength]
+          rw [fits_iff] at hfit
+          simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+          change 4 * input.length ≤ 32768 at hfit
+          omega)
+        (by simp [source]) $$ [$Hstate $Hsource] with
+        ⟨_Hstate, _Hsource, %hcapacity⟩
+      ipureintro
+      exact ⟨output, hsorted, by
+        rw [hsorted.2.length_eq]
+        exact hread', by
+        rw [hsorted.2.length_eq]
+        simpa only [source, UInt32.reduceToNat, Nat.zero_add] using hcapacity⟩
+
+theorem runSteps_sort_correct (fuel : Nat) (input : List UInt32)
+    (hfit : Fits input) (values : List Value)
+    (store : MachineStore Unit)
+    (hrun : (runSteps fuel (sortConfig input)).result =
+      .success values store) :
+    SortPost input values store := by
+  apply sort_partiallyMeets input hfit
+    (runSteps fuel (sortConfig input)).trace values store
+  apply runSteps_sound
+  simp [hrun, RunnerResult.finalConfig?]
+
+theorem execute_sort_correct (fuel : Nat) (input : List UInt32)
+    (hfit : Fits input) (values : List Value)
+    (store : Store Wasm.StdIO.State)
+    (hexecute : executeSort fuel (afterRead input)
+      (mergeSortArguments source scratch input.length []) =
+      some (values, store)) :
+    SortPost input values
+      { runtime := { module, host := Wasm.StdIO.env }, wasm := store } := by
+  simp only [executeSort, initConfig_sort] at hexecute
+  generalize hresult : (runSteps fuel (sortConfig input)).result = result at hexecute
+  cases result with
+  | success resultValues resultStore =>
+      simp only [Option.some.injEq, Prod.mk.injEq] at hexecute
+      rcases hexecute with ⟨hvalues, hstore⟩
+      subst values
+      have hpost := runSteps_sort_correct fuel input hfit resultValues
+        resultStore hresult
+      obtain ⟨output, hsorted, hread, hcapacity⟩ := hpost
+      have hmem : resultStore.wasm.mem = store.mem := by
+        have := congrArg (fun concrete : Store Wasm.StdIO.State => concrete.mem)
+          hstore
+        simpa [replaceHost] using this
+      exact ⟨output, hsorted, by simpa [hmem] using hread,
+        by simpa [hmem] using hcapacity⟩
+  | trapped reason resultStore => simp at hexecute
+  | outOfFuel resultConfig => simp at hexecute
+  | internalError error resultConfig => simp at hexecute
+
+set_option maxRecDepth 10000 in
+theorem run_fits (fuel : Nat) (input : List UInt32) (hfit : Fits input) :
+    run fuel (serialize input) =
+      runAfterRead fuel (UInt32.ofNat (serialize input).length) (afterRead input) := by
+  unfold run
+  rw [read_fits input hfit]
+  simp only [Bind.bind, Option.bind]
+
+set_option maxRecDepth 10000 in
+theorem run_correct (fuel : Nat) (input : List UInt32) (bytes : List UInt8)
+    (hfit : Fits input) (hrun : run fuel (serialize input) = some bytes) :
+    ∃ output, SortedPermutation input output ∧
+      deserialize bytes = some output := by
+  rw [run_fits fuel input hfit] at hrun
+  unfold runAfterRead at hrun
+  rw [probe_afterRead input] at hrun
+  simp only [Option.bind_some, guard, decide_true, if_true] at hrun
+  rw [encodedLength_words input hfit] at hrun
+  simp only [Bind.bind, Option.bind] at hrun
+  simp only [if_true, Pure.pure, Bind.bind, Option.bind] at hrun
+  generalize hsortResult : executeSort fuel (afterRead input)
+      (mergeSortArguments source scratch input.length []) = sortResult at hrun
+  cases sortResult with
+  | none => simp at hrun
+  | some sortPair =>
+      rcases sortPair with ⟨sortValues, afterSort⟩
+      have hpost := execute_sort_correct fuel input hfit sortValues afterSort
+        hsortResult
+      obtain ⟨output, hsorted, hread, hcapacity⟩ := hpost
+      have hhost := executeSort_host fuel (afterRead input) afterSort
+        (mergeSortArguments source scratch input.length []) sortValues hsortResult
+      have hbyteLength :
+          (UInt32.ofNat (serialize input).length).toNat = 4 * input.length := by
+        rw [encodedLength_toNat input hfit, serialize_length]
+      have hwriteBound : source.toNat +
+          (UInt32.ofNat (serialize input).length).toNat ≤
+          Wasm.StdIO.byteCapacity afterSort := by
+        simp only [source, UInt32.reduceToNat, Nat.zero_add,
+          Wasm.StdIO.byteCapacity, hbyteLength]
+        exact hcapacity
+      have hwrite := execute_write_bytes afterSort
+        (UInt32.ofNat (serialize input).length) hwriteBound
+      simp only [Option.bind_some, Prod.fst, Prod.snd] at hrun
+      rw [hwrite] at hrun
+      simp only [Bind.bind, Option.bind, Pure.pure] at hrun
+      have houtput : afterSort.host.output = [] := by
+        rw [hhost]
+        rfl
+      have hbytes : bytes = afterSort.mem.readBytes source.toNat
+          (UInt32.ofNat (serialize input).length).toNat := by
+        simpa [writtenStore, houtput] using hrun.symm
+      refine ⟨output, hsorted, ?_⟩
+      rw [hbytes, hbyteLength]
+      rw [deserialize_readBytes]
+      · exact congrArg some hread
+      · rw [fits_iff] at hfit
+        simp only [source, UInt32.reduceToNat, Nat.zero_add, UInt32.size]
+        change 4 * input.length ≤ 32768 at hfit
+        omega
 
 theorem RunsValues.fits {input output : List UInt32}
     (h : RunsValues input output) : Fits input := by
@@ -553,6 +1147,22 @@ finite-memory resource limit. -/
 def Correct : Prop :=
   ∀ input output,
     RunsValues input output → SortedPermutation input output
+
+theorem correct : Correct := by
+  intro input output hruns
+  have hfit := RunsValues.fits hruns
+  rcases hruns with ⟨fuel, hrunValues⟩
+  unfold runValues at hrunValues
+  cases hrun : run fuel (serialize input) with
+  | none => simp [hrun] at hrunValues
+  | some bytes =>
+      simp only [hrun, Option.bind_some] at hrunValues
+      obtain ⟨sorted, hsorted, hdeserialize⟩ :=
+        run_correct fuel input bytes hfit hrun
+      rw [hdeserialize] at hrunValues
+      simp only [Option.some.injEq] at hrunValues
+      subst output
+      exact hsorted
 
 /-- Every input that fits the current fixed layout successfully produces an
 output.  Keeping resource-bounded termination separate leaves `Correct` clean. -/

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -75,6 +75,138 @@ def deserialize : List UInt8 → Option (List UInt32)
         List.nil_append, List.length_cons, Nat.mul_add]
       omega
 
+theorem writeBytes_encodeWord (mem : Mem) (base value : UInt32) :
+    mem.writeBytes base.toNat (encodeWord value) = mem.write32 base value := by
+  cases mem with
+  | mk pages bytes =>
+    simp only [Mem.writeBytes, encodeWord, List.length_cons, List.length_nil,
+      Mem.write32]
+    congr
+    funext i
+    by_cases h0 : i = base.toNat
+    · subst i
+      simp
+    by_cases h1 : i = base.toNat + 1
+    · subst i
+      simp
+    by_cases h2 : i = base.toNat + 2
+    · subst i
+      simp
+    by_cases h3 : i = base.toNat + 3
+    · subst i
+      simp
+    rw [dif_neg (by omega)]
+    simp [h0, h1, h2, h3]
+
+/-- Packed stream serialization and the word-array model used by the
+merge-sort proof describe exactly the same memory update. -/
+theorem writeBytes_serialize (mem : Mem) (base : UInt32)
+    (values : List UInt32)
+    (hfit : base.toNat + 4 * values.length < UInt32.size) :
+    mem.writeBytes base.toNat (serialize values) =
+      writeWordArray mem base values := by
+  induction values generalizing mem base with
+  | nil =>
+      simp only [serialize, List.flatMap_nil, writeWordArray]
+      cases mem
+      simp only [Mem.writeBytes, List.length_nil, Nat.add_zero]
+      congr
+      funext i
+      rw [dif_neg (by omega)]
+  | cons value values ih =>
+      simp only [serialize, List.flatMap_cons, writeWordArray]
+      rw [Mem.writeBytes_append, writeBytes_encodeWord]
+      simp only [List.length_cons, Nat.mul_add] at hfit
+      have hbase : (base + 4).toNat = base.toNat + 4 := by
+        simp only [UInt32.toNat_add, UInt32.reduceToNat]
+        rw [Nat.mod_eq_of_lt]
+        change base.toNat + 4 < 4294967296
+        change base.toNat + (4 * values.length + 4) < 4294967296 at hfit
+        omega
+      rw [show base.toNat + (encodeWord value).length =
+          (base + 4).toNat by simp [encodeWord, hbase]]
+      apply ih
+      rw [hbase]
+      change base.toNat + 4 + 4 * values.length < 4294967296
+      change base.toNat + (4 * values.length + 4) < 4294967296 at hfit
+      omega
+
+private theorem readBytes_four_add (mem : Mem) (offset n : Nat) :
+    mem.readBytes offset (4 + n) =
+      [mem.bytes offset, mem.bytes (offset + 1), mem.bytes (offset + 2),
+       mem.bytes (offset + 3)] ++ mem.readBytes (offset + 4) n := by
+  unfold Mem.readBytes
+  rw [List.range_add]
+  simp only [List.map_append, List.range_succ, List.range_zero,
+    List.map_cons, List.map_nil, List.nil_append]
+  congr 1
+  simp [Nat.add_assoc]
+
+/-- Deserializing a byte slice of complete words is the same observation as
+the word-array reader used in merge sort's postcondition. -/
+theorem deserialize_readBytes (mem : Mem) (base : UInt32) (count : Nat)
+    (hfit : base.toNat + 4 * count < UInt32.size) :
+    deserialize (mem.readBytes base.toNat (4 * count)) =
+      some (readWordArray mem base count) := by
+  induction count generalizing base with
+  | zero =>
+      rfl
+  | succ count ih =>
+      rw [show 4 * (count + 1) = 4 + 4 * count by omega]
+      rw [readBytes_four_add]
+      simp only [List.cons_append, List.nil_append, deserialize]
+      have hbase : (base + 4).toNat = base.toNat + 4 := by
+        simp only [UInt32.toNat_add, UInt32.reduceToNat]
+        rw [Nat.mod_eq_of_lt]
+        change base.toNat + 4 < 4294967296
+        change base.toNat + 4 * (count + 1) < 4294967296 at hfit
+        omega
+      change (deserialize (mem.readBytes (base.toNat + 4) (4 * count))).map
+          (mem.read32 base :: ·) =
+        some (mem.read32 base :: readWordArray mem (base + 4) count)
+      rw [← hbase, ih]
+      · rfl
+      · rw [hbase]
+        change base.toNat + 4 + 4 * count < 4294967296
+        change base.toNat + 4 * (count + 1) < 4294967296 at hfit
+        omega
+
+theorem write32_read32 (mem : Mem) (base : UInt32) :
+    mem.write32 base (mem.read32 base) = mem := by
+  cases mem with
+  | mk pages bytes =>
+    simp only [Mem.write32, Mem.read32]
+    congr
+    funext i
+    by_cases h0 : i = base.toNat
+    · subst i
+      simp only [if_pos]
+      bv_decide
+    by_cases h1 : i = base.toNat + 1
+    · subst i
+      simp only [if_neg h0, if_pos]
+      bv_decide
+    by_cases h2 : i = base.toNat + 2
+    · subst i
+      simp only [if_neg h0, if_neg h1, if_pos]
+      bv_decide
+    by_cases h3 : i = base.toNat + 3
+    · subst i
+      simp only [if_neg h0, if_neg h1, if_neg h2, if_pos]
+      bv_decide
+    simp [h0, h1, h2, h3]
+
+/-- Owning the words currently present in memory can be represented by the
+same `writeWordArray` model without changing the concrete memory. -/
+theorem writeWordArray_readWordArray (mem : Mem) (base : UInt32)
+    (count : Nat) :
+    writeWordArray mem base (readWordArray mem base count) = mem := by
+  induction count generalizing base with
+  | zero => rfl
+  | succ count ih =>
+      simp only [readWordArray, writeWordArray]
+      rw [write32_read32, ih]
+
 /-- The stream-facing wrapper.  Local `0` remembers the byte count returned
 by `read`; dividing it by four gives the number of words passed to merge sort.
 
@@ -82,12 +214,16 @@ Unified function indices are: `0 = read`, `1 = write`, `2 = mergeSort`,
 `3 = merge`, and `4 = main`. -/
 def mainBody : Program :=
   [ .const (UInt32.ofNat bufferBytes), .const source, .call 0, .localSet 0
+  -- Probe for one more input byte at the byte immediately after memory.  EOF
+  -- is a valid zero-length access there; any remaining byte traps, so a
+  -- successful execution cannot have silently truncated its input.
+  , .const 1, .const (UInt32.ofNat 65536), .call 0, .localSet 1
   , .const source, .const scratch, .localGet 0, .const 4, .divU, .call 2
   , .localGet 0, .const source, .call 1
   , .ret ]
 
 def mainFunction : Function :=
-  { locals := [.i32]
+  { locals := [.i32, .i32]
     body := mainBody }
 
 /-- Merge sort linked against the two-function `StdIO` ABI. -/
@@ -111,11 +247,275 @@ def config (input : List UInt8) : Config Wasm.StdIO.State :=
           { runtime := { module, host := Wasm.StdIO.env }
             wasm := initialStore input } }
 
-/-- Execute the authoritative small-step machine and project the host output. -/
-def run (fuel : Nat) (input : List UInt8) : Option (List UInt8) :=
-  match (SmallStep.runSteps fuel (config input)).result with
-  | .success _ store => some store.wasm.host.output
-  | _ => none
+/-- Execute one exported or imported function with the authoritative
+small-step machine, retaining the mutated Wasm/host store for the next phase. -/
+def execute (fuel entry : Nat) (store : Store Wasm.StdIO.State)
+    (args : List Value) : Option (List Value × Store Wasm.StdIO.State) :=
+  match SmallStep.initConfig { module, host := Wasm.StdIO.env } entry store args with
+  | .error _ => none
+  | .ok phase =>
+      match (SmallStep.runSteps fuel phase).result with
+      | .success values finalStore => some (values, finalStore.wasm)
+      | _ => none
+
+theorem execute_read (store wasm : Store Wasm.StdIO.State)
+    (length pointer count : UInt32)
+    (hinvoke : Wasm.StdIO.readHost.invoke store
+      [.i32 length, .i32 pointer] = .Return [.i32 count] wasm) :
+    execute 2 0 store [.i32 pointer, .i32 length] =
+      some ([.i32 count], wasm) := by
+  let machine : MachineStore Wasm.StdIO.State :=
+    { runtime := { module, host := Wasm.StdIO.env }, wasm := store }
+  let initial : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 pointer, .i32 length]⟩, [.call 0], 1, [], [], []⟩
+      store := machine }
+  let middle : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 count]⟩, [], 1, [], [], []⟩
+      store := { machine with wasm } }
+  have hcallRaw := Step.callHostReturn
+    (store := machine) (functionIndex := 0)
+    (imp := Wasm.StdIO.imports[0])
+    (hostFunction := Wasm.StdIO.readHost)
+    (params := []) (localValues := [])
+    (values := [.i32 pointer, .i32 length])
+    (results := [.i32 count]) (wasm := wasm)
+    (code := []) (arity := 1) (remainder := [])
+    (controls := []) (calls := [])
+    (by simp [machine, module, Wasm.StdIO.imports]) rfl rfl hinvoke
+  have hcall : Step initial (.host 0) middle := by
+    simpa [initial, middle, machine, module, Wasm.StdIO.imports,
+      Wasm.StdIO.env] using hcallRaw
+  have hfinish : Step middle (.administrative .finish)
+      ⟨.done [.i32 count], { machine with wasm }⟩ := Step.finish
+  have hrun := runSteps_eq_success_of_steps
+    (Steps.cons hcall (Steps.single hfinish))
+  have hinit : SmallStep.initConfig
+      { module, host := Wasm.StdIO.env } 0 store
+        [.i32 pointer, .i32 length] = .ok initial := by
+    rfl
+  simp only [execute, hinit]
+  rw [show (runSteps 2 initial).result =
+      .success [.i32 count] { machine with wasm } by simpa using hrun]
+
+theorem execute_read_trap (store wasm : Store Wasm.StdIO.State)
+    (length pointer : UInt32) (message : String)
+    (hinvoke : Wasm.StdIO.readHost.invoke store
+      [.i32 length, .i32 pointer] = .Trap wasm message) :
+    execute 2 0 store [.i32 pointer, .i32 length] = none := by
+  let machine : MachineStore Wasm.StdIO.State :=
+    { runtime := { module, host := Wasm.StdIO.env }, wasm := store }
+  let initial : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 pointer, .i32 length]⟩, [.call 0], 1, [], [], []⟩
+      store := machine }
+  let trapped : Config Wasm.StdIO.State :=
+    { expr := .trapped (.host message)
+      store := { machine with wasm } }
+  have hcallRaw := Step.callHostTrap
+    (store := machine) (functionIndex := 0)
+    (imp := Wasm.StdIO.imports[0])
+    (hostFunction := Wasm.StdIO.readHost)
+    (params := []) (localValues := [])
+    (values := [.i32 pointer, .i32 length])
+    (wasm := wasm) (message := message)
+    (code := []) (arity := 1) (remainder := [])
+    (controls := []) (calls := [])
+    (by simp [machine, module, Wasm.StdIO.imports]) rfl rfl hinvoke
+  have hcall : Step initial (.host 0) trapped := by
+    simpa [initial, trapped, machine, module, Wasm.StdIO.imports,
+      Wasm.StdIO.env] using hcallRaw
+  have hinit : SmallStep.initConfig
+      { module, host := Wasm.StdIO.env } 0 store
+        [.i32 pointer, .i32 length] = .ok initial := by
+    rfl
+  simp [execute, hinit, runSteps, stepChecked?_complete hcall, trapped]
+
+theorem execute_write (store wasm : Store Wasm.StdIO.State)
+    (length pointer : UInt32)
+    (hinvoke : Wasm.StdIO.writeHost.invoke store
+      [.i32 length, .i32 pointer] = .Return [] wasm) :
+    execute 2 1 store [.i32 pointer, .i32 length] = some ([], wasm) := by
+  let machine : MachineStore Wasm.StdIO.State :=
+    { runtime := { module, host := Wasm.StdIO.env }, wasm := store }
+  let initial : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 pointer, .i32 length]⟩, [.call 1], 0, [], [], []⟩
+      store := machine }
+  let middle : Config Wasm.StdIO.State :=
+    { expr := .running ⟨⟨[], [], []⟩, [], 0, [], [], []⟩
+      store := { machine with wasm } }
+  have hcallRaw := Step.callHostReturn
+    (store := machine) (functionIndex := 1)
+    (imp := Wasm.StdIO.imports[1])
+    (hostFunction := Wasm.StdIO.writeHost)
+    (params := []) (localValues := [])
+    (values := [.i32 pointer, .i32 length])
+    (results := []) (wasm := wasm)
+    (code := []) (arity := 0) (remainder := [])
+    (controls := []) (calls := [])
+    (by simp [machine, module, Wasm.StdIO.imports]) rfl rfl hinvoke
+  have hcall : Step initial (.host 1) middle := by
+    simpa [initial, middle, machine, module, Wasm.StdIO.imports,
+      Wasm.StdIO.env] using hcallRaw
+  have hfinish : Step middle (.administrative .finish)
+      ⟨.done [], { machine with wasm }⟩ := Step.finish
+  have hrun := runSteps_eq_success_of_steps
+    (Steps.cons hcall (Steps.single hfinish))
+  have hinit : SmallStep.initConfig
+      { module, host := Wasm.StdIO.env } 1 store
+        [.i32 pointer, .i32 length] = .ok initial := by
+    rfl
+  simp only [execute, hinit]
+  rw [show (runSteps 2 initial).result =
+      .success [] { machine with wasm } by simpa using hrun]
+
+private theorem take_eq_self_of_length_le {β : Type} (xs : List β) (n : Nat)
+    (h : xs.length ≤ n) : xs.take n = xs := by
+  induction xs generalizing n with
+  | nil => simp
+  | cons x xs ih =>
+      cases n with
+      | zero => simp at h
+      | succ n =>
+          simp only [List.take_succ_cons, List.length_cons] at h ⊢
+          rw [ih n (Nat.le_of_succ_le_succ h)]
+
+@[simp] private theorem initialStore_host (input : List UInt8) :
+    (initialStore input).host = Wasm.StdIO.State.ofInput input := by
+  rfl
+
+set_option maxRecDepth 10000 in
+private theorem initial_byteCapacity (input : List UInt8) :
+    Wasm.StdIO.byteCapacity (initialStore input) = 65536 := by
+  change (module.initialStore (α := Wasm.StdIO.State)).mem.pages * 65536 = 65536
+  have hpages : (module.initialStore (α := Wasm.StdIO.State)).mem.pages = 1 := by
+    decide
+  rw [hpages]
+
+/-- Concrete store after the first read, before the EOF probe. -/
+def afterBoundedRead (input : List UInt8) : Store Wasm.StdIO.State :=
+  let bytes := input.take bufferBytes
+  { initialStore input with
+    mem := (initialStore input).mem.writeBytes source.toNat bytes
+    host := { input := input.drop bytes.length, output := [] } }
+
+theorem read_bounded (input : List UInt8) :
+    execute 2 0 (initialStore input)
+      [.i32 source, .i32 (UInt32.ofNat bufferBytes)] =
+      some ([.i32 (UInt32.ofNat (input.take bufferBytes).length)],
+        afterBoundedRead input) := by
+  apply execute_read
+  simp only [Wasm.StdIO.readHost, Wasm.StdIO.readResult, initialStore_host,
+    Wasm.StdIO.State.ofInput]
+  have hbuffer : (UInt32.ofNat bufferBytes).toNat = bufferBytes :=
+    UInt32.toNat_ofNat_of_lt' (by decide)
+  rw [hbuffer]
+  rw [if_pos (by
+    simp only [Wasm.StdIO.rangeInBounds, source, initial_byteCapacity]
+    apply decide_eq_true
+    have htake : (input.take bufferBytes).length ≤ bufferBytes :=
+      List.length_take_le bufferBytes input
+    simpa only [show (0 : UInt32).toNat = 0 by decide, Nat.zero_add] using
+      Nat.le_trans htake (by decide : bufferBytes ≤ 65536))]
+  simp [afterBoundedRead, source]
+
+/-- Concrete store after the bounded source read has consumed all serialized
+input. -/
+def afterRead (input : List UInt32) : Store Wasm.StdIO.State :=
+  { initialStore (serialize input) with
+    mem := (initialStore (serialize input)).mem.writeBytes
+      source.toNat (serialize input)
+    host := { input := [], output := [] } }
+
+set_option maxRecDepth 10000 in
+theorem read_fits (input : List UInt32)
+    (hfit : (serialize input).length ≤ bufferBytes) :
+    execute 2 0 (initialStore (serialize input))
+      [.i32 source, .i32 (UInt32.ofNat bufferBytes)] =
+      some ([.i32 (UInt32.ofNat (serialize input).length)], afterRead input) := by
+  apply execute_read
+  simp only [Wasm.StdIO.readHost, Wasm.StdIO.readResult]
+  simp only [initialStore_host, Wasm.StdIO.State.ofInput]
+  have hbuffer : (UInt32.ofNat bufferBytes).toNat = bufferBytes :=
+    UInt32.toNat_ofNat_of_lt' (by decide)
+  rw [hbuffer]
+  rw [take_eq_self_of_length_le _ _ hfit]
+  simp only [serialize_length] at hfit
+  rw [if_pos (by
+    simp only [Wasm.StdIO.rangeInBounds, source, initial_byteCapacity]
+    apply decide_eq_true
+    simpa only [serialize_length, show (0 : UInt32).toNat = 0 by decide,
+      Nat.zero_add] using
+      Nat.le_trans hfit (by decide : bufferBytes ≤ 65536))]
+  simp [afterRead, source]
+
+private theorem afterRead_byteCapacity (input : List UInt32) :
+    Wasm.StdIO.byteCapacity (afterRead input) = 65536 := by
+  simpa only [afterRead, Wasm.StdIO.byteCapacity, Mem.writeBytes] using
+    initial_byteCapacity (serialize input)
+
+theorem probe_afterRead (input : List UInt32) :
+    execute 2 0 (afterRead input)
+      [.i32 (UInt32.ofNat 65536), .i32 1] =
+      some ([.i32 0], afterRead input) := by
+  apply execute_read
+  apply Wasm.StdIO.read_empty
+  · rfl
+  · rw [afterRead_byteCapacity]
+    decide
+
+private theorem afterBoundedRead_byteCapacity (input : List UInt8) :
+    Wasm.StdIO.byteCapacity (afterBoundedRead input) = 65536 := by
+  simpa only [afterBoundedRead, Wasm.StdIO.byteCapacity, Mem.writeBytes] using
+    initial_byteCapacity input
+
+theorem probe_traps_of_too_long (input : List UInt8)
+    (hlong : bufferBytes < input.length) :
+    execute 2 0 (afterBoundedRead input)
+      [.i32 (UInt32.ofNat 65536), .i32 1] = none := by
+  apply execute_read_trap
+  apply Wasm.StdIO.read_one_past_traps
+  · simp only [afterBoundedRead]
+    intro hempty
+    have hlength := congrArg List.length hempty
+    simp only [List.length_drop, List.length_nil] at hlength
+    rw [List.length_take, Nat.min_eq_left (Nat.le_of_lt hlong)] at hlength
+    omega
+  · rw [afterBoundedRead_byteCapacity]
+    exact UInt32.toNat_ofNat_of_lt' (by decide)
+
+/-- Execute the stream program in four explicit phases: read the source
+region, prove EOF with the one-past-memory probe, run merge sort, then append
+the sorted source region through `write`.  Every phase still executes through
+the authoritative Wasm small-step semantics. -/
+def run (fuel : Nat) (input : List UInt8) : Option (List UInt8) := do
+  let (readValues, afterRead) ← execute 2 0 (initialStore input)
+    [.i32 source, .i32 (UInt32.ofNat bufferBytes)]
+  let byteLength ← match readValues with
+    | [.i32 length] => some length
+    | _ => none
+  let (probeValues, afterProbe) ← execute 2 0 afterRead
+    [.i32 (UInt32.ofNat 65536), .i32 1]
+  guard (probeValues = [.i32 0])
+  let (_, afterSort) ← execute fuel 2 afterProbe
+    (mergeSortArguments source scratch (byteLength.toNat / 4) [])
+  let (_, afterWrite) ← execute 2 1 afterSort
+    [.i32 source, .i32 byteLength]
+  pure afterWrite.host.output
+
+theorem run_none_of_too_long (fuel : Nat) (input : List UInt8)
+    (hlong : bufferBytes < input.length) :
+    run fuel input = none := by
+  simp [run, read_bounded]
+  intro values store hprobe
+  have hprobeNone : execute 2 0 (afterBoundedRead input)
+      [.i32 (65536 : UInt32), .i32 1] = none := by
+    simpa only [show (65536 : UInt32) = UInt32.ofNat 65536 by decide] using
+      probe_traps_of_too_long input hlong
+  rw [hprobeNone] at hprobe
+  contradiction
 
 /-- A clean, host-level execution predicate.  Fuel is hidden existentially
 and neither linear memory nor Wasm machine state appears in client specs. -/
@@ -134,6 +534,18 @@ def RunsValues (input output : List UInt32) : Prop :=
 /-- Pure input-side condition imposed by the fixed one-page Wasm32 layout. -/
 def Fits (values : List UInt32) : Prop :=
   (serialize values).length ≤ bufferBytes
+
+theorem fits_iff (values : List UInt32) :
+    Fits values ↔ 4 * values.length ≤ bufferBytes := by
+  simp only [Fits, serialize_length]
+
+theorem RunsValues.fits {input output : List UInt32}
+    (h : RunsValues input output) : Fits input := by
+  rcases h with ⟨fuel, hrun⟩
+  by_contra hfit
+  have hlong : bufferBytes < (serialize input).length := by
+    exact Nat.lt_of_not_ge hfit
+  simp [runValues, run_none_of_too_long fuel (serialize input) hlong] at hrun
 
 /-- Every value-level result successfully produced by the program is a sorted
 permutation of its input.  This safety statement is independent of Wasm's

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -1,4 +1,4 @@
-import CodeLib.Examples.MergeSort
+import CodeLib.Examples.MergeSort.TotalProof
 import Interpreter.Wasm.Host.StdIO
 
 /-!
@@ -21,19 +21,59 @@ def bufferBytes : Nat := 32768
 def source : UInt32 := 0
 def scratch : UInt32 := UInt32.ofNat bufferBytes
 
+/-- The four little-endian bytes of a 32-bit word. -/
+def encodeWord (value : UInt32) : List UInt8 :=
+  [ (value &&& 0xff).toUInt8
+  , ((value >>> 8) &&& 0xff).toUInt8
+  , ((value >>> 16) &&& 0xff).toUInt8
+  , ((value >>> 24) &&& 0xff).toUInt8 ]
+
+/-- Reassemble a 32-bit word from its four little-endian bytes. -/
+def decodeWord (b₀ b₁ b₂ b₃ : UInt8) : UInt32 :=
+  b₀.toUInt32 ||| (b₁.toUInt32 <<< 8) |||
+    (b₂.toUInt32 <<< 16) ||| (b₃.toUInt32 <<< 24)
+
 /-- Packed little-endian serialization of a list of 32-bit words. -/
 def serialize (values : List UInt32) : List UInt8 :=
-  let memory := writeWordArray (Mem.empty 1) 0 values
-  memory.readBytes 0 (4 * values.length)
+  values.flatMap encodeWord
 
-/-- Decode a packed little-endian byte sequence.  A trailing partial word is
+/-- Decode a packed little-endian byte sequence. A trailing partial word is
 rejected rather than silently ignored. -/
-def deserialize (bytes : List UInt8) : Option (List UInt32) :=
-  if bytes.length % 4 = 0 then
-    let memory := (Mem.empty 1).writeBytes 0 bytes
-    some (readWordArray memory 0 (bytes.length / 4))
-  else
-    none
+def deserialize : List UInt8 → Option (List UInt32)
+  | [] => some []
+  | b₀ :: b₁ :: b₂ :: b₃ :: rest =>
+      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ :: ·)
+  | _ => none
+
+@[simp] theorem decode_encode (value : UInt32) :
+    decodeWord
+      (value &&& 0xff).toUInt8
+      (((value >>> 8) &&& 0xff).toUInt8)
+      (((value >>> 16) &&& 0xff).toUInt8)
+      (((value >>> 24) &&& 0xff).toUInt8) = value := by
+  simp only [decodeWord]
+  bv_decide
+
+@[simp] theorem deserialize_serialize (values : List UInt32) :
+    deserialize (serialize values) = some values := by
+  induction values with
+  | nil => rfl
+  | cons value values ih =>
+      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
+        List.nil_append, deserialize, decode_encode]
+      change (deserialize (serialize values)).map (value :: ·) = some (value :: values)
+      rw [ih]
+      rfl
+
+@[simp] theorem serialize_length (values : List UInt32) :
+    (serialize values).length = 4 * values.length := by
+  induction values with
+  | nil => rfl
+  | cons value values ih =>
+      change (List.flatMap encodeWord values).length = 4 * values.length at ih
+      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
+        List.nil_append, List.length_cons, Nat.mul_add]
+      omega
 
 /-- The stream-facing wrapper.  Local `0` remembers the byte count returned
 by `read`; dividing it by four gives the number of words passed to merge sort.

--- a/codelib/CodeLib/Examples/MergeSort/TotalProof.lean
+++ b/codelib/CodeLib/Examples/MergeSort/TotalProof.lean
@@ -34,21 +34,21 @@ theorem twp_loop_wf_family_from
     (body_closes : ∀ i,
       ⊢@{IProp WasmHeapGF} (iprop%
         (∀ (j : ι), ⌜measure j < measure i⌝ -∗ I j -∗
-          WP (loopBodyExpr (α := Unit) (locals j)
+          WP (loopBodyExpr (α := α) (locals j)
             paramArity resultArity arity body code remainder belowStack
             controls calls) @ s; E [{ Φ }]) -∗
         I i -∗
-          WP (loopBodyExpr (α := Unit) (locals i)
+          WP (loopBodyExpr (α := α) (locals i)
             paramArity resultArity arity body code remainder belowStack
             controls calls) @ s; E [{ Φ }])) :
     I initial ⊢
       WP (.running
         ⟨initialLocals, .loop paramArity resultArity body :: code,
-          arity, remainder, controls, calls⟩ : Expr Unit)
+          arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] := by
   have closes : ∀ i,
       I i ⊢
-        WP (loopBodyExpr (α := Unit) (locals i)
+        WP (loopBodyExpr (α := α) (locals i)
           paramArity resultArity arity body code remainder belowStack
           controls calls) @ s; E [{ Φ }] := by
     intro current
@@ -65,7 +65,7 @@ theorem twp_loop_wf_family_from
   simp only [loopBodyExpr] at closes
   subst initialLocals
   iintro HI
-  iapply twp_loop
+  iapply twp_loop (α := α)
   rw [← hbelow]
   ihave Hbody := closes initial $$ HI
   iexact Hbody
@@ -92,7 +92,7 @@ theorem twp_mergeMainStep
           WP (.running
             ⟨mergeLocals source temporary left mid right
                 (i + 1) j (k + 1) stack,
-              code, arity, remainder, controls, calls⟩ : Expr Unit)
+              code, arity, remainder, controls, calls⟩ : Expr α)
             @ s; E [{ Φ }]) ∧
        (⌜¬input[i]'hiLen < input[j]'hjLen⌝ ∗
           arrayAt source input ∗
@@ -100,30 +100,30 @@ theorem twp_mergeMainStep
           WP (.running
             ⟨mergeLocals source temporary left mid right
                 i (j + 1) (k + 1) stack,
-              code, arity, remainder, controls, calls⟩ : Expr Unit)
+              code, arity, remainder, controls, calls⟩ : Expr α)
             @ s; E [{ Φ }])) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right i j k stack,
         mergeMainStep ++ code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hsource, Htemporary, Hbranches⟩
   simp only [mergeMainStep, List.append_assoc]
-  iapply twp_loadAt hiLen hlayout.source_fits rfl rfl
+  iapply twp_loadAt (α := α) hiLen hlayout.source_fits rfl rfl
   isplitl [Hsource]
   · iexact Hsource
   iintro Hsource
-  iapply twp_loadAt hjLen hlayout.source_fits rfl rfl
+  iapply twp_loadAt (α := α) hjLen hlayout.source_fits rfl rfl
   isplitl [Hsource]
   · iexact Hsource
   iintro Hsource
   simp only [List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_ltU rfl
+  iapply Wasm.SmallStep.twp_ltU (α := α) rfl
   by_cases hxy : input[i]'hiLen < input[j]'hjLen
   · simp only [if_pos hxy]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
     ihave Hthen := BI.and_elim_l $$ Hbranches
-    iapply twp_copyAt hiLen hkLen hlayout.source_fits
+    iapply twp_copyAt (α := α) hiLen hkLen hlayout.source_fits
       (by simpa [hinv.2.2.2.2.2] using hlayout.temporary_fits)
       rfl rfl rfl rfl
     isplitl [Hsource]
@@ -154,8 +154,8 @@ theorem twp_mergeMainStep
       rw [hiValue]
       rfl
     simp only [mergeLocals, List.drop_zero]
-    iapply twp_increment_nil rfl hsetI
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply twp_increment_nil (α := α) rfl hsetI
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [mergeLocals, List.take_zero, List.nil_append]
     have hsetK :
         (mergeLocals source temporary left mid right
@@ -167,7 +167,7 @@ theorem twp_mergeMainStep
             (.i32 (1 + UInt32.ofNat k) :: stack)) := by
       rw [hkValue]
       rfl
-    iapply twp_increment rfl hsetK
+    iapply twp_increment (α := α) rfl hsetK
     simp only [mergeLocals]
     iapply Hthen
     isplitr
@@ -175,10 +175,10 @@ theorem twp_mergeMainStep
       exact hxy
     iframe
   · simp only [if_neg hxy]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
     ihave Helse := BI.and_elim_r $$ Hbranches
-    iapply twp_copyAt hjLen hkLen hlayout.source_fits
+    iapply twp_copyAt (α := α) hjLen hkLen hlayout.source_fits
       (by simpa [hinv.2.2.2.2.2] using hlayout.temporary_fits)
       rfl rfl rfl rfl
     isplitl [Hsource]
@@ -209,8 +209,8 @@ theorem twp_mergeMainStep
       rw [hjValue]
       rfl
     simp only [mergeLocals, List.drop_zero]
-    iapply twp_increment_nil rfl hsetJ
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply twp_increment_nil (α := α) rfl hsetJ
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [mergeLocals, List.take_zero, List.nil_append]
     have hsetK :
         (mergeLocals source temporary left mid right
@@ -222,7 +222,7 @@ theorem twp_mergeMainStep
             (.i32 (1 + UInt32.ofNat k) :: stack)) := by
       rw [hkValue]
       rfl
-    iapply twp_increment rfl hsetK
+    iapply twp_increment (α := α) rfl hsetK
     simp only [mergeLocals]
     iapply Helse
     isplitr
@@ -252,12 +252,12 @@ theorem twp_mergeMainLoop
         WP (.running
           ⟨mergeLocals source temporary left mid right
               i' j' k' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right i j k stack,
         whileDo mergeMainCondition mergeMainStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ (scratch' : List UInt32) (i' j' k' : Nat)
@@ -269,7 +269,7 @@ theorem twp_mergeMainLoop
       WP (.running
         ⟨mergeLocals source temporary left mid right
             i' j' k' stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : MergeLoopState → IProp WasmHeapGF := fun state => iprop%
     ⌜MergeLoopInvariant input state.scratch left mid right
@@ -285,8 +285,8 @@ theorem twp_mergeMainLoop
       belowStack := stack }
   iintro ⟨Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := MergeLoopState)
     (measure := fun state =>
       (mid - state.i) + (right - state.j))
@@ -334,11 +334,11 @@ theorem twp_mergeMainLoop
       rw [UInt32.toNat_ofNat_of_lt' hjSize,
         UInt32.toNat_ofNat_of_lt' hrightSize]
     simp only [whileLoopCode, mergeMainCondition, List.append_assoc]
-    iapply twp_lessLocal rfl rfl
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_mul
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_mul (α := α)
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hi : state.i < mid
     · by_cases hj : state.j < right
       · simp only [hiCmp, hjCmp, if_pos hi, if_pos hj]
@@ -351,8 +351,8 @@ theorem twp_mergeMainLoop
           exact hkInput
         simp only [UInt32.mul_one,
           if_neg (by decide : (1 : UInt32) ≠ 0)]
-        iapply Wasm.SmallStep.twp_brIfZero
-        iapply twp_mergeMainStep source temporary input state.scratch
+        iapply Wasm.SmallStep.twp_brIfZero (α := α)
+        iapply twp_mergeMainStep (α := α) source temporary input state.scratch
           left mid right state.i state.j state.k state.emitted
           hstate hi hj hiLen hjLen hkLen hlayout
         isplitl [Hsource]
@@ -361,7 +361,7 @@ theorem twp_mergeMainLoop
         · iexact Htemporary
         isplit
         · iintro ⟨%hxy, Hsource, Htemporary⟩
-          iapply Wasm.SmallStep.twp_br rfl
+          iapply Wasm.SmallStep.twp_br (α := α) rfl
           simp only [mergeLocals, List.take_zero, List.nil_append]
           ispecialize Hrec $$
             %(⟨state.scratch.set state.k input[state.i],
@@ -380,7 +380,7 @@ theorem twp_mergeMainLoop
               (List.getElem?_eq_getElem hjLen) hxy
           iframe
         · iintro ⟨%hxy, Hsource, Htemporary⟩
-          iapply Wasm.SmallStep.twp_br rfl
+          iapply Wasm.SmallStep.twp_br (α := α) rfl
           simp only [mergeLocals, List.take_zero, List.nil_append]
           ispecialize Hrec $$
             %(⟨state.scratch.set state.k input[state.j],
@@ -402,29 +402,29 @@ theorem twp_mergeMainLoop
         have hjEq : state.j = right := by omega
         subst right
         simp only [UInt32.zero_mul]
-        iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+        iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
         simp only [List.take_zero, List.nil_append,
           List.drop_zero]
         ihave Hdone := Hfinish $$ %state.scratch %state.i %state.j
           %state.k %state.emitted %hstate %(Or.inr rfl)
           Hsource Htemporary
-        isimp only [mergeLocals] in Hdone
+        isimp only [mergeLocals] at Hdone
         isimp only [mergeLocals]
         iexact Hdone
     · simp only [hiCmp, if_neg hi]
       have hiEq : state.i = mid := by omega
       subst mid
       simp only [UInt32.mul_zero]
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.scratch %state.i %state.j
         %state.k %state.emitted %hstate %(Or.inl rfl)
         Hsource Htemporary
-      isimp only [mergeLocals] in Hdone
+      isimp only [mergeLocals] at Hdone
       isimp only [mergeLocals]
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hinv
@@ -454,14 +454,14 @@ theorem twp_mergeMainLoop_from
         WP (.running
           ⟨mergeLocals source temporary left mid right
               i' j' k' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨actualLocals, whileDo mergeMainCondition mergeMainStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   subst actualLocals
-  exact twp_mergeMainLoop source temporary input scratch
+  exact twp_mergeMainLoop (α := α) source temporary input scratch
     left mid right i j k emitted hinv hlayout
 
 set_option maxHeartbeats 3000000 in
@@ -483,15 +483,15 @@ theorem twp_mergeLeftStep
         WP (.running
           ⟨mergeLocals source temporary left mid right
               (i + 1) j (k + 1) stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right i j k stack,
         mergeLeftStep ++ code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hsource, Htemporary, Hcont⟩
   simp only [mergeLeftStep, List.append_assoc]
-  iapply twp_copyAt hiLen hkLen hlayout.source_fits
+  iapply twp_copyAt (α := α) hiLen hkLen hlayout.source_fits
     (by simpa [hscratchLength] using hlayout.temporary_fits)
     rfl rfl rfl rfl
   isplitl [Hsource]
@@ -522,7 +522,7 @@ theorem twp_mergeLeftStep
     rw [hiValue]
     rfl
   simp only [mergeLocals]
-  iapply twp_increment rfl hsetI
+  iapply twp_increment (α := α) rfl hsetI
   simp only [mergeLocals]
   have hsetK :
       (mergeLocals source temporary left mid right
@@ -534,7 +534,7 @@ theorem twp_mergeLeftStep
           (.i32 (1 + UInt32.ofNat k) :: stack)) := by
     rw [hkValue]
     rfl
-  iapply twp_increment rfl hsetK
+  iapply twp_increment (α := α) rfl hsetK
   simp only [mergeLocals]
   iapply Hcont
   iframe
@@ -558,15 +558,15 @@ theorem twp_mergeRightStep
         WP (.running
           ⟨mergeLocals source temporary left mid right
               i (j + 1) (k + 1) stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right i j k stack,
         mergeRightStep ++ code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hsource, Htemporary, Hcont⟩
   simp only [mergeRightStep, List.append_assoc]
-  iapply twp_copyAt hjLen hkLen hlayout.source_fits
+  iapply twp_copyAt (α := α) hjLen hkLen hlayout.source_fits
     (by simpa [hscratchLength] using hlayout.temporary_fits)
     rfl rfl rfl rfl
   isplitl [Hsource]
@@ -597,7 +597,7 @@ theorem twp_mergeRightStep
     rw [hjValue]
     rfl
   simp only [mergeLocals]
-  iapply twp_increment rfl hsetJ
+  iapply twp_increment (α := α) rfl hsetJ
   simp only [mergeLocals]
   have hsetK :
       (mergeLocals source temporary left mid right
@@ -609,7 +609,7 @@ theorem twp_mergeRightStep
           (.i32 (1 + UInt32.ofNat k) :: stack)) := by
     rw [hkValue]
     rfl
-  iapply twp_increment rfl hsetK
+  iapply twp_increment (α := α) rfl hsetK
   simp only [mergeLocals]
   iapply Hcont
   iframe
@@ -636,12 +636,12 @@ theorem twp_mergeLeftLoop
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid j' k' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right i j k stack,
         whileDo mergeLeftCondition mergeLeftStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ (scratch' : List UInt32) (j' k' : Nat)
@@ -652,7 +652,7 @@ theorem twp_mergeLeftLoop
       WP (.running
         ⟨mergeLocals source temporary left mid right
             mid j' k' stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : MergeLoopState → IProp WasmHeapGF := fun state => iprop%
     ⌜MergeLoopInvariant input state.scratch left mid right
@@ -661,8 +661,8 @@ theorem twp_mergeLeftLoop
     arrayAt source input ∗ arrayAt temporary state.scratch ∗ Finish
   iintro ⟨Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := MergeLoopState)
     (measure := fun state => mid - state.i)
     (locals := fun state =>
@@ -697,9 +697,9 @@ theorem twp_mergeLeftLoop
       rw [UInt32.toNat_ofNat_of_lt' hiSize,
         UInt32.toNat_ofNat_of_lt' hmidSize]
     simp only [whileLoopCode, mergeLeftCondition, List.append_assoc]
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hi : state.i < mid
     · simp only [hiCmp, if_pos hi]
       have hjEq : state.j = right := by
@@ -717,8 +717,8 @@ theorem twp_mergeLeftLoop
         rw [hdata.2.2.2.2.2.1]
         exact hkInput
       simp only [if_neg (by decide : (1 : UInt32) ≠ 0)]
-      iapply Wasm.SmallStep.twp_brIfZero
-      iapply twp_mergeLeftStep source temporary input state.scratch
+      iapply Wasm.SmallStep.twp_brIfZero (α := α)
+      iapply twp_mergeLeftStep (α := α) source temporary input state.scratch
         left mid right state.i state.j state.k
         hiLen hkLen hdata.2.2.2.2.2.1 hlayout
       isplitl [Hsource]
@@ -726,7 +726,7 @@ theorem twp_mergeLeftLoop
       isplitl [Htemporary]
       · iexact Htemporary
       iintro ⟨Hsource, Htemporary⟩
-      iapply Wasm.SmallStep.twp_br rfl
+      iapply Wasm.SmallStep.twp_br (α := α) rfl
       simp only [mergeLocals, List.take_zero, List.nil_append]
       ispecialize Hrec $$
         %(⟨state.scratch.set state.k input[state.i],
@@ -747,15 +747,15 @@ theorem twp_mergeLeftLoop
     · simp only [hiCmp, if_neg hi]
       have hiEq : state.i = mid := by omega
       subst mid
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.scratch %state.j %state.k
         %state.emitted %hstate Hsource Htemporary
-      isimp only [mergeLocals] in Hdone
+      isimp only [mergeLocals] at Hdone
       isimp only [mergeLocals]
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hinv
@@ -786,12 +786,12 @@ theorem twp_mergeRightLoop
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right k' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right mid j k stack,
         whileDo mergeRightCondition mergeRightStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ (scratch' : List UInt32) (k' : Nat)
@@ -802,7 +802,7 @@ theorem twp_mergeRightLoop
       WP (.running
         ⟨mergeLocals source temporary left mid right
             mid right k' stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : MergeLoopState → IProp WasmHeapGF := fun state => iprop%
     ⌜MergeLoopInvariant input state.scratch left mid right
@@ -810,8 +810,8 @@ theorem twp_mergeRightLoop
     arrayAt source input ∗ arrayAt temporary state.scratch ∗ Finish
   iintro ⟨Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := MergeLoopState)
     (measure := fun state => right - state.j)
     (locals := fun state =>
@@ -846,9 +846,9 @@ theorem twp_mergeRightLoop
       rw [UInt32.toNat_ofNat_of_lt' hjSize,
         UInt32.toNat_ofNat_of_lt' hrightSize]
     simp only [whileLoopCode, mergeRightCondition, List.append_assoc]
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hj : state.j < right
     · simp only [hjCmp, if_pos hj,
         if_neg (by decide : (1 : UInt32) ≠ 0)]
@@ -857,8 +857,8 @@ theorem twp_mergeRightLoop
       have hkLen : state.k < state.scratch.length := by
         rw [hdata.2.2.2.2.2.1]
         exact hkInput
-      iapply Wasm.SmallStep.twp_brIfZero
-      iapply twp_mergeRightStep source temporary input state.scratch
+      iapply Wasm.SmallStep.twp_brIfZero (α := α)
+      iapply twp_mergeRightStep (α := α) source temporary input state.scratch
         left mid right mid state.j state.k
         hjLen hkLen hdata.2.2.2.2.2.1 hlayout
       isplitl [Hsource]
@@ -866,7 +866,7 @@ theorem twp_mergeRightLoop
       isplitl [Htemporary]
       · iexact Htemporary
       iintro ⟨Hsource, Htemporary⟩
-      iapply Wasm.SmallStep.twp_br rfl
+      iapply Wasm.SmallStep.twp_br (α := α) rfl
       simp only [mergeLocals, List.take_zero, List.nil_append]
       ispecialize Hrec $$
         %(⟨state.scratch.set state.k input[state.j],
@@ -884,15 +884,15 @@ theorem twp_mergeRightLoop
     · simp only [hjCmp, if_neg hj]
       have hjEq : state.j = right := by omega
       subst right
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.scratch %state.k
         %state.emitted %hstate Hsource Htemporary
-      isimp only [mergeLocals] in Hdone
+      isimp only [mergeLocals] at Hdone
       isimp only [mergeLocals]
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hinv
@@ -917,15 +917,15 @@ theorem twp_mergeCopyStep
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right (k + 1) stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right mid right k stack,
         mergeCopyStep ++ code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hsource, Htemporary, Hcont⟩
   simp only [mergeCopyStep, List.append_assoc]
-  iapply twp_copyAt hkScratch hkCurrent
+  iapply twp_copyAt (α := α) hkScratch hkCurrent
     (by simpa [hscratchLength] using hlayout.temporary_fits)
     hlayout.source_fits
     rfl rfl rfl rfl
@@ -950,7 +950,7 @@ theorem twp_mergeCopyStep
     rw [hkValue]
     rfl
   simp only [mergeLocals]
-  iapply twp_increment rfl hsetK
+  iapply twp_increment (α := α) rfl hsetK
   simp only [mergeLocals]
   iapply Hcont
   isplitl [Hsource]
@@ -981,12 +981,12 @@ theorem twp_mergeCopyLoop
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right right stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right mid right k stack,
         whileDo mergeCopyCondition mergeCopyStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ output : List UInt32,
@@ -995,7 +995,7 @@ theorem twp_mergeCopyLoop
       WP (.running
         ⟨mergeLocals source temporary left mid right
             mid right right stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : CopyLoopState → IProp WasmHeapGF := fun state => iprop%
     ⌜CopyLoopInvariant input state.current left right
@@ -1004,8 +1004,8 @@ theorem twp_mergeCopyLoop
     arrayAt source state.current ∗ arrayAt temporary scratch ∗ Finish
   iintro ⟨Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := CopyLoopState)
     (measure := fun state => right - state.k)
     (locals := fun state =>
@@ -1041,9 +1041,9 @@ theorem twp_mergeCopyLoop
       rw [UInt32.toNat_ofNat_of_lt' hkSize,
         UInt32.toNat_ofNat_of_lt' hrightSize]
     simp only [whileLoopCode, mergeCopyCondition, List.append_assoc]
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hk : state.k < right
     · simp only [hkCmp, if_pos hk,
         if_neg (by decide : (1 : UInt32) ≠ 0)]
@@ -1067,8 +1067,8 @@ theorem twp_mergeCopyLoop
           List.getElem?_eq_getElem hkScratch
         rw [hactual] at hlookup
         exact Option.some.inj hlookup
-      iapply Wasm.SmallStep.twp_brIfZero
-      iapply twp_mergeCopyStep source temporary
+      iapply Wasm.SmallStep.twp_brIfZero (α := α)
+      iapply twp_mergeCopyStep (α := α) source temporary
         state.current scratch left mid right state.k
         hkCurrent hkScratch
         (by simpa [hcopyData.2.2.2.1] using hscratchLength)
@@ -1078,7 +1078,7 @@ theorem twp_mergeCopyLoop
       isplitl [Htemporary]
       · iexact Htemporary
       iintro ⟨Hsource, Htemporary⟩
-      iapply Wasm.SmallStep.twp_br rfl
+      iapply Wasm.SmallStep.twp_br (α := α) rfl
       simp only [mergeLocals, List.take_zero, List.nil_append]
       ispecialize Hrec $$
         %(⟨state.current.set state.k scratch[state.k],
@@ -1106,15 +1106,15 @@ theorem twp_mergeCopyLoop
           CopyLoopInvariant input state.current left right right merged := by
         simpa [hkEq, hcopiedEq] using hcopyState
       subst right
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.current %hcopyFinished
         Hsource Htemporary
-      isimp only [mergeLocals] in Hdone
+      isimp only [mergeLocals] at Hdone
       isimp only [mergeLocals]
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hcopy
@@ -1149,14 +1149,14 @@ theorem twp_mergeCopyLoop_from
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right right stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨actualLocals, whileDo mergeCopyCondition mergeCopyStep ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   subst actualLocals
-  exact twp_mergeCopyLoop source temporary input current scratch
+  exact twp_mergeCopyLoop (α := α) source temporary input current scratch
     merged copied left mid right k hcopy hcopied hscratchLength
     htemporary hmergedLength hlayout
 
@@ -1176,29 +1176,29 @@ theorem twp_mergeBody
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right right [],
-            [.ret], 0, [], [], calls⟩ : Expr Unit)
+            [.ret], 0, [], [], calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨mergeLocals source temporary left mid right 0 0 0 [],
-        mergeBody, 0, [], [], calls⟩ : Expr Unit)
+        mergeBody, 0, [], [], calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   simp only [mergePre]
   iintro ⟨Hpre, Hfinish⟩
   icases Hpre with
     ⟨Hsource, Htemporary, %hscratchLength, %hlayout, %hbounds⟩
   simp only [mergeBody, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localSet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localSet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [mergeLocals, List.set]
   have hinvStart :
       MergeLoopInvariant input scratch left mid right
         left mid left [] :=
     mergeLoopInvariant_start hbounds hscratchLength
-  iapply twp_mergeMainLoop_from
+  iapply twp_mergeMainLoop_from (α := α)
     (⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat left),
         .i32 (UInt32.ofNat mid), .i32 (UInt32.ofNat right)],
       [.i32 (UInt32.ofNat left), .i32 (UInt32.ofNat mid),
@@ -1211,7 +1211,7 @@ theorem twp_mergeBody
   · iexact Htemporary
   iintro %scratch' %i' %j' %k' %emitted'
     %hinv' %hexhausted Hsource Htemporary
-  iapply twp_mergeLeftLoop source temporary input scratch'
+  iapply twp_mergeLeftLoop (α := α) source temporary input scratch'
     left mid right i' j' k' emitted' hinv' hexhausted hlayout
   isplitl [Hsource]
   · iexact Hsource
@@ -1219,7 +1219,7 @@ theorem twp_mergeBody
   · iexact Htemporary
   iintro %scratch'' %j'' %k'' %emitted''
     %hinv'' Hsource Htemporary
-  iapply twp_mergeRightLoop source temporary input scratch''
+  iapply twp_mergeRightLoop (α := α) source temporary input scratch''
     left mid right j'' k'' emitted'' hinv'' hlayout
   isplitl [Hsource]
   · iexact Hsource
@@ -1237,14 +1237,14 @@ theorem twp_mergeBody
     have hlength := (perm_of_mergeRel hmerge).length_eq
     simp [segment, List.length_take, List.length_drop] at hlength
     omega
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [mergeLocals, List.set]
   have hcopyStart :
       CopyLoopInvariant input input left right left [] :=
     copyLoopInvariant_start
       (Nat.le_trans hbounds.1 hbounds.2.1) hbounds.2.2
-  iapply twp_mergeCopyLoop_from
+  iapply twp_mergeCopyLoop_from (α := α)
     (⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat left),
         .i32 (UInt32.ofNat mid), .i32 (UInt32.ofNat right)],
       [.i32 (UInt32.ofNat mid), .i32 (UInt32.ofNat right),
@@ -1283,13 +1283,13 @@ theorem twp_mergeBody_from
         WP (.running
           ⟨mergeLocals source temporary left mid right
               mid right right [],
-            [.ret], 0, [], [], calls⟩ : Expr Unit)
+            [.ret], 0, [], [], calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
-      ⟨actualLocals, mergeBody, 0, [], [], calls⟩ : Expr Unit)
+      ⟨actualLocals, mergeBody, 0, [], [], calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   subst actualLocals
-  exact twp_mergeBody source temporary input scratch left mid right
+  exact twp_mergeBody (α := α) source temporary input scratch left mid right
 
 set_option maxHeartbeats 4000000 in
 theorem twp_merge
@@ -1313,24 +1313,24 @@ theorem twp_merge
         mergePost source temporary input left mid right -∗
         WP (.running
           ⟨{ callerLocals with values := stack },
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨{ callerLocals with
           values :=
             mergeArguments source temporary left mid right stack },
         .call mergeIndex :: code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hruntime, Hpre, Hcont⟩
   ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
   ·
     iexact Hruntime
-  iapply Wasm.SmallStep.twp_call runtimeModule mergeIndex mergeFunction
+  iapply Wasm.SmallStep.twp_call (α := α) runtimeModule mergeIndex mergeFunction
     himports hfunction $$ HruntimeLater
   iintro Hruntime
   simp [mergeFunction, mergeArguments, Function.toLocals,
     Function.numParams, ValueType.zero]
-  iapply twp_mergeBody_from
+  iapply twp_mergeBody_from (α := α)
     (⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat left),
         .i32 (UInt32.ofNat mid), .i32 (UInt32.ofNat right)],
       [.i32 0, .i32 0, .i32 0], []⟩ : Locals)
@@ -1339,7 +1339,7 @@ theorem twp_merge
   · iexact Hpre
   iintro %output %scratch' %hmergeRange %hscratchLength
     Hsource Htemporary
-  iapply Wasm.SmallStep.twp_returnFromCallExplicit
+  iapply Wasm.SmallStep.twp_returnFromCallExplicit (α := α)
   simp only [mergeLocals, List.take_zero, List.nil_append,
     List.drop_eq_nil_of_le (by simp : 5 ≤
       (mergeArguments source temporary left mid right stack).length)]
@@ -1373,42 +1373,42 @@ theorem twp_mergeSortPrepareRight
             .i32 (UInt32.ofNat mid),
             .i32 (UInt32.ofNat (min (left + width * 2) count))],
           stack⟩ : Locals),
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] ⊢
   WP (.running
       ⟨sortLocals source temporary count width left mid oldRight stack,
         [.localGet 4, .localGet 3, .const 2, .mul, .add, .localSet 6,
          .localGet 6, .localGet 2, .ltU,
          .iff 0 0 [] [.localGet 2, .localSet 6]] ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   iintro Hcont
   simp only [List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_const
-  iapply Wasm.SmallStep.twp_mul
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_const (α := α)
+  iapply Wasm.SmallStep.twp_mul (α := α)
   have hmul :
       (2 : UInt32) * UInt32.ofNat width =
         UInt32.ofNat (width * 2) := by
     rw [UInt32.mul_comm]
     exact u32_ofNat_mul (a := width) (b := 2) _htwoWidth
   rw [hmul]
-  iapply Wasm.SmallStep.twp_add
+  iapply Wasm.SmallStep.twp_add (α := α)
   have hrightValue :
       UInt32.ofNat (width * 2) + UInt32.ofNat left =
         UInt32.ofNat (left + width * 2) := by
     rw [UInt32.add_comm, u32_ofNat_add hrightCandidate]
   rw [hrightValue]
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [sortLocals, List.set]
   have hmul' :
       UInt32.ofNat width * 2 = UInt32.ofNat (width * 2) := by
     exact u32_ofNat_mul (a := width) (b := 2) _htwoWidth
   rw [hmul', u32_ofNat_add hrightCandidate]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_ltU rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_ltU (α := α) rfl
   have hcandidateCmp :
       (UInt32.ofNat (left + width * 2) < UInt32.ofNat count) ↔
         left + width * 2 < count := by
@@ -1418,21 +1418,21 @@ theorem twp_mergeSortPrepareRight
       UInt32.toNat_ofNat_of_lt' hcountSize]
   by_cases hright : left + width * 2 < count
   · simp only [hcandidateCmp, if_pos hright]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [List.take_zero, List.nil_append,
       Nat.min_eq_left (Nat.le_of_lt hright)]
     simp only [List.drop_zero]
     iexact Hcont
   · simp only [hcandidateCmp, if_neg hright]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
-    iapply Wasm.SmallStep.twp_localGet rfl
-    iapply Wasm.SmallStep.twp_localSet rfl
+    iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+    iapply Wasm.SmallStep.twp_localSet (α := α) rfl
     simp only [
       Nat.min_eq_right (by omega : count ≤ left + width * 2)]
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [List.take_zero, List.nil_append]
     simp [List.set, List.drop_zero]
     iexact Hcont
@@ -1458,18 +1458,18 @@ theorem twp_mergeSortPrepareRight_from
             .i32 (UInt32.ofNat mid),
             .i32 (UInt32.ofNat (min (left + width * 2) count))],
           stack⟩ : Locals),
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨actualLocals,
         .localGet 4 :: .localGet 3 :: .const 2 :: .mul :: .add ::
           .localSet 6 :: .localGet 6 :: .localGet 2 :: .ltU ::
           .iff 0 0 [] [.localGet 2, .localSet 6] :: code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   subst actualLocals
   simpa only [List.cons_append, List.nil_append] using
-    (twp_mergeSortPrepareRight source temporary count width left
+    (twp_mergeSortPrepareRight (α := α) source temporary count width left
       mid oldRight htwoWidth hrightCandidate hcountSize :
       WP (.running
         ⟨(⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat count)],
@@ -1477,14 +1477,14 @@ theorem twp_mergeSortPrepareRight_from
               .i32 (UInt32.ofNat mid),
               .i32 (UInt32.ofNat (min (left + width * 2) count))],
             stack⟩ : Locals),
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }] ⊢
       WP (.running
         ⟨sortLocals source temporary count width left mid oldRight stack,
           [.localGet 4, .localGet 3, .const 2, .mul, .add, .localSet 6,
            .localGet 6, .localGet 2, .ltU,
            .iff 0 0 [] [.localGet 2, .localSet 6]] ++ code,
-          arity, remainder, controls, calls⟩ : Expr Unit)
+          arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }])
 
 set_option maxHeartbeats 5000000 in
@@ -1507,29 +1507,29 @@ theorem twp_mergeSortPrepare
             .i32 (UInt32.ofNat (min (left + width) count)),
             .i32 (UInt32.ofNat (min (left + width * 2) count))],
           stack⟩ : Locals),
-        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        code, arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] ⊢
     WP (.running
       ⟨sortLocals source temporary count width left oldMid oldRight stack,
         mergeSortPrepare ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   iintro Hcont
   simp only [mergeSortPrepare, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_add
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_add (α := α)
   have hleftValue :
       UInt32.ofNat width + UInt32.ofNat left =
         UInt32.ofNat (left + width) := by
     rw [UInt32.add_comm, u32_ofNat_add hleftWidth]
   rw [hleftValue]
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [sortLocals, List.set]
   rw [u32_ofNat_add hleftWidth]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_ltU rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_ltU (α := α) rfl
   have hcandidateCmp :
       (UInt32.ofNat (left + width) < UInt32.ofNat count) ↔
         left + width < count := by
@@ -1539,13 +1539,13 @@ theorem twp_mergeSortPrepare
       UInt32.toNat_ofNat_of_lt' hcountSize]
   by_cases hmid : left + width < count
   · simp only [hcandidateCmp, if_pos hmid]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [List.take_zero, List.nil_append,
       Nat.min_eq_left (Nat.le_of_lt hmid)]
     simp only [List.drop_zero]
-    iapply twp_mergeSortPrepareRight_from
+    iapply twp_mergeSortPrepareRight_from (α := α)
       (⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat count)],
         [.i32 (UInt32.ofNat width), .i32 (UInt32.ofNat left),
           .i32 (UInt32.ofNat (left + width)),
@@ -1555,15 +1555,15 @@ theorem twp_mergeSortPrepare
       htwoWidth hrightCandidate hcountSize rfl
     iexact Hcont
   · simp only [hcandidateCmp, if_neg hmid]
-    iapply Wasm.SmallStep.twp_iff rfl
+    iapply Wasm.SmallStep.twp_iff (α := α) rfl
     simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
-    iapply Wasm.SmallStep.twp_localGet rfl
-    iapply Wasm.SmallStep.twp_localSet rfl
+    iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+    iapply Wasm.SmallStep.twp_localSet (α := α) rfl
     simp only [Nat.min_eq_right (by omega : count ≤ left + width)]
-    iapply Wasm.SmallStep.twp_exitControl rfl
+    iapply Wasm.SmallStep.twp_exitControl (α := α) rfl
     simp only [List.take_zero, List.nil_append]
     simp [List.set]
-    iapply twp_mergeSortPrepareRight_from
+    iapply twp_mergeSortPrepareRight_from (α := α)
       (⟨[.i32 source, .i32 temporary, .i32 (UInt32.ofNat count)],
         [.i32 (UInt32.ofNat width), .i32 (UInt32.ofNat left),
           .i32 (UInt32.ofNat count),
@@ -1596,22 +1596,22 @@ theorem twp_mergeSortCallAdvance
         WP (.running
           ⟨sortLocals source temporary count width
               (left + width * 2) mid right stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨sortLocals source temporary count width left mid right stack,
         mergeSortCallAdvance mergeIndex ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   iintro ⟨Hruntime, Hpre, Hcont⟩
   simp only [mergeSortCallAdvance, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
   simp only [sortLocals]
-  have HmergeCall := twp_merge runtimeModule mergeIndex himports hfunction
+  have HmergeCall := twp_merge (α := α) runtimeModule mergeIndex himports hfunction
     source temporary input scratch left mid right
     (s := s) (E := E) (Φ := Φ)
     (callerLocals :=
@@ -1633,23 +1633,23 @@ theorem twp_mergeSortCallAdvance
   isplitl [Hpre]
   · iexact Hpre
   iintro Hruntime Hpost
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_localGet rfl
-  iapply Wasm.SmallStep.twp_const
-  iapply Wasm.SmallStep.twp_mul
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+  iapply Wasm.SmallStep.twp_const (α := α)
+  iapply Wasm.SmallStep.twp_mul (α := α)
   have hmul :
       (2 : UInt32) * UInt32.ofNat width =
         UInt32.ofNat (width * 2) := by
     rw [UInt32.mul_comm]
     exact u32_ofNat_mul (a := width) (b := 2) (by omega)
   rw [hmul]
-  iapply Wasm.SmallStep.twp_add
+  iapply Wasm.SmallStep.twp_add (α := α)
   have hadd :
       UInt32.ofNat (width * 2) + UInt32.ofNat left =
         UInt32.ofNat (left + width * 2) := by
     rw [UInt32.add_comm, u32_ofNat_add hrightCandidate]
   rw [hadd]
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [List.set]
   iapply Hcont $$ Hruntime Hpost
 
@@ -1687,14 +1687,14 @@ theorem twp_mergeSortInnerLoop
         WP (.running
           ⟨sortLocals source temporary count width
               (pass' * (2 * width)) mid' right' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨sortLocals source temporary count width
           (pass * (2 * width)) mid right stack,
         whileDo mergeSortInnerCondition
           (mergeSortInnerStep mergeIndex) ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ (output scratch' : List UInt32) (pass' mid' right' : Nat),
@@ -1707,7 +1707,7 @@ theorem twp_mergeSortInnerLoop
       WP (.running
         ⟨sortLocals source temporary count width
             (pass' * (2 * width)) mid' right' stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : SortInnerState → IProp WasmHeapGF := fun state => iprop%
     ⌜MergePassInvariant original state.current width state.pass⌝ ∗
@@ -1737,8 +1737,8 @@ theorem twp_mergeSortInnerLoop
       belowStack := stack }
   iintro ⟨Hruntime, Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := SortInnerState)
     (measure := fun state => count - state.pass * (2 * width))
     (locals := fun state =>
@@ -1770,9 +1770,9 @@ theorem twp_mergeSortInnerLoop
         UInt32.toNat_ofNat_of_lt' hcountSize]
     simp only [whileLoopCode, mergeSortInnerCondition,
       List.append_assoc]
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [sortLocals, List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hleftCount : left < count
     · have hcmp :
           UInt32.ofNat (state.pass * (2 * width)) <
@@ -1780,7 +1780,7 @@ theorem twp_mergeSortInnerLoop
         simpa only [left] using hleftCmp.mpr hleftCount
       simp only [if_pos hcmp,
         if_neg (by decide : (1 : UInt32) ≠ 0)]
-      iapply Wasm.SmallStep.twp_brIfZero
+      iapply Wasm.SmallStep.twp_brIfZero (α := α)
       have hfourCount := hlayout.source_fits
       have hleftWidth : left + width < UInt32.size := by omega
       have htwoWidth : width * 2 < UInt32.size := by omega
@@ -1789,7 +1789,7 @@ theorem twp_mergeSortInnerLoop
       let newMid := min (left + width) count
       let newRight := min (left + width * 2) count
       simp only [mergeSortInnerStep, List.append_assoc]
-      have Hprepare := twp_mergeSortPrepare source temporary count width left
+      have Hprepare := twp_mergeSortPrepare (α := α) source temporary count width left
         state.mid state.right hleftWidth htwoWidth hrightCandidate
         hcountSize
         (s := s) (E := E) (Φ := Φ)
@@ -1804,7 +1804,7 @@ theorem twp_mergeSortInnerLoop
           left ≤ newMid ∧ newMid ≤ newRight ∧ newRight ≤ count := by
         dsimp only [newMid, newRight]
         omega
-      have Hadvance := twp_mergeSortCallAdvance
+      have Hadvance := twp_mergeSortCallAdvance (α := α)
         runtimeModule mergeIndex himports hfunction source temporary
         state.current state.scratch count width left newMid newRight
         hrightCandidate
@@ -1835,7 +1835,7 @@ theorem twp_mergeSortInnerLoop
       icases Hpost' with
         ⟨%output, %nextScratch, %hmergeRange,
           %hnextScratchLength, Hsource, Htemporary⟩
-      iapply Wasm.SmallStep.twp_br rfl
+      iapply Wasm.SmallStep.twp_br (α := α) rfl
       simp only [List.take_zero, List.nil_append]
       have hnextPass :
           left + width * 2 = (state.pass + 1) * (2 * width) := by
@@ -1877,7 +1877,7 @@ theorem twp_mergeSortInnerLoop
             UInt32.ofNat count := by
         simpa only [left] using (mt hleftCmp.mp hleftCount)
       simp only [if_neg hcmp]
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.current %state.scratch %state.pass
@@ -1885,9 +1885,9 @@ theorem twp_mergeSortInnerLoop
         %hscratchLength %(by
           simpa only [left] using Nat.le_of_not_gt hleftCount)
         Hruntime Hsource Htemporary
-      isimp only [sortLocals] in Hdone
+      isimp only [sortLocals] at Hdone
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hinv
@@ -1939,13 +1939,13 @@ theorem twp_mergeSortOuterLoop
         WP (.running
           ⟨sortLocals source temporary count width'
               left' mid' right' stack,
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨sortLocals source temporary count width left mid right stack,
         whileDo mergeSortOuterCondition
           (mergeSortOuterStep mergeIndex) ++ code,
-        arity, remainder, controls, calls⟩ : Expr Unit)
+        arity, remainder, controls, calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   let Finish : IProp WasmHeapGF := iprop%
     ∀ (output scratch' : List UInt32)
@@ -1960,7 +1960,7 @@ theorem twp_mergeSortOuterLoop
       WP (.running
         ⟨sortLocals source temporary count width'
             left' mid' right' stack,
-          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          code, arity, remainder, controls, calls⟩ : Expr α)
         @ s; E [{ Φ }]
   let Inv : SortOuterState → IProp WasmHeapGF := fun state => iprop%
     ⌜SortedRuns state.current state.width⌝ ∗
@@ -1996,8 +1996,8 @@ theorem twp_mergeSortOuterLoop
       belowStack := stack }
   iintro ⟨Hruntime, Hsource, Htemporary, Hfinish⟩
   simp only [whileDo, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_block
-  iapply twp_loop_wf_family_from
+  iapply Wasm.SmallStep.twp_block (α := α)
+  iapply twp_loop_wf_family_from (α := α)
     (ι := SortOuterState)
     (measure := fun state => count - state.width)
     (locals := fun state =>
@@ -2027,27 +2027,27 @@ theorem twp_mergeSortOuterLoop
         UInt32.toNat_ofNat_of_lt' hcountSize]
     simp only [whileLoopCode, mergeSortOuterCondition,
       List.append_assoc]
-    iapply twp_lessLocal rfl rfl
+    iapply twp_lessLocal (α := α) rfl rfl
     simp only [sortLocals, List.cons_append, List.nil_append]
-    iapply Wasm.SmallStep.twp_eqz rfl
+    iapply Wasm.SmallStep.twp_eqz (α := α) rfl
     by_cases hwidthCount' : state.width < count
     · have hcmp :
           UInt32.ofNat state.width < UInt32.ofNat count :=
         hwidthCmp.mpr hwidthCount'
       simp only [if_pos hcmp,
         if_neg (by decide : (1 : UInt32) ≠ 0)]
-      iapply Wasm.SmallStep.twp_brIfZero
+      iapply Wasm.SmallStep.twp_brIfZero (α := α)
       simp only [mergeSortOuterStep, List.cons_append,
         List.nil_append, List.append_assoc]
-      iapply Wasm.SmallStep.twp_const
-      iapply Wasm.SmallStep.twp_localSet rfl
+      iapply Wasm.SmallStep.twp_const (α := α)
+      iapply Wasm.SmallStep.twp_localSet (α := α) rfl
       simp [List.set]
       have hpassStart :
           MergePassInvariant state.current state.current
             state.width 0 :=
         mergePassInvariant_start hwidthPositive'
           (List.Perm.refl _) hruns'
-      have Hinner := twp_mergeSortInnerLoop
+      have Hinner := twp_mergeSortInnerLoop (α := α)
         runtimeModule mergeIndex himports hfunction
         source temporary state.current state.current state.scratch
         count state.width 0 state.mid state.right hpassStart
@@ -2080,18 +2080,18 @@ theorem twp_mergeSortOuterLoop
       have hdoubleSize : state.width * 2 < UInt32.size := by
         have hfourCount := hlayout.source_fits
         omega
-      iapply Wasm.SmallStep.twp_localGet rfl
-      iapply Wasm.SmallStep.twp_const
-      iapply Wasm.SmallStep.twp_mul
+      iapply Wasm.SmallStep.twp_localGet (α := α) rfl
+      iapply Wasm.SmallStep.twp_const (α := α)
+      iapply Wasm.SmallStep.twp_mul (α := α)
       have hmul :
           (2 : UInt32) * UInt32.ofNat state.width =
             UInt32.ofNat (state.width * 2) := by
         rw [UInt32.mul_comm]
         exact u32_ofNat_mul hdoubleSize
       rw [hmul]
-      iapply Wasm.SmallStep.twp_localSet rfl
+      iapply Wasm.SmallStep.twp_localSet (α := α) rfl
       simp
-      iapply Wasm.SmallStep.twp_br rfl
+      iapply Wasm.SmallStep.twp_br (α := α) rfl
       simp only [List.take_zero, List.nil_append]
       ispecialize Hrec $$
         %(⟨output, nextScratch, state.width * 2,
@@ -2124,7 +2124,7 @@ theorem twp_mergeSortOuterLoop
           ¬UInt32.ofNat state.width < UInt32.ofNat count :=
         mt hwidthCmp.mp hwidthCount'
       simp only [if_neg hcmp]
-      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      iapply Wasm.SmallStep.twp_brIf (α := α) (by decide) rfl
       simp only [List.take_zero, List.nil_append,
         List.drop_zero]
       ihave Hdone := Hfinish $$ %state.current %state.scratch %state.width
@@ -2132,9 +2132,9 @@ theorem twp_mergeSortOuterLoop
         %hvaluesLength %hscratchLength
         %(Nat.le_of_not_gt hwidthCount')
         Hruntime Hsource Htemporary
-      isimp only [sortLocals] in Hdone
+      isimp only [sortLocals] at Hdone
       iexact Hdone
-  · simp only [Inv]
+  · simp only [Inv, Finish]
     isplitr
     · ipureintro
       exact hruns
@@ -2175,22 +2175,22 @@ theorem twp_mergeSortBody
         WP (.running
           ⟨sortLocals source temporary input.length
               width left mid right [],
-            [.ret], 0, [], [], calls⟩ : Expr Unit)
+            [.ret], 0, [], [], calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨sortLocals source temporary input.length
           0 0 0 0 [],
-        mergeSortBody mergeIndex, 0, [], [], calls⟩ : Expr Unit)
+        mergeSortBody mergeIndex, 0, [], [], calls⟩ : Expr α)
       @ s; E [{ Φ }] := by
   iintro ⟨Hruntime, Hpre, Hcont⟩
   simp only [mergeSortBody, List.cons_append, List.nil_append]
-  iapply Wasm.SmallStep.twp_const
-  iapply Wasm.SmallStep.twp_localSet rfl
+  iapply Wasm.SmallStep.twp_const (α := α)
+  iapply Wasm.SmallStep.twp_localSet (α := α) rfl
   simp [sortLocals]
   ihave Hpre' := mergeSortPre_elim source temporary input scratch $$ Hpre
   icases Hpre' with
     ⟨Hsource, Htemporary, %hscratchLength, %hlayout⟩
-  have Houter := twp_mergeSortOuterLoop runtimeModule mergeIndex
+  have Houter := twp_mergeSortOuterLoop (α := α) runtimeModule mergeIndex
     himports hfunction source temporary input input scratch
     input.length 1 0 0 0
     (sortedRuns_one input) (List.Perm.refl input) rfl
@@ -2249,25 +2249,25 @@ theorem twp_mergeSort
         mergeSortPost source temporary input -∗
         WP (.running
           ⟨{ callerLocals with values := stack },
-            code, arity, remainder, controls, calls⟩ : Expr Unit)
+            code, arity, remainder, controls, calls⟩ : Expr α)
           @ s; E [{ Φ }]) ⊢
     WP (.running
       ⟨{ callerLocals with
           values :=
             mergeSortArguments source temporary input.length stack },
         .call sortIndex :: code, arity, remainder, controls, calls⟩ :
-        Expr Unit) @ s; E [{ Φ }] := by
+        Expr α) @ s; E [{ Φ }] := by
   iintro ⟨Hruntime, Hpre, Hcont⟩
   ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
   ·
     iexact Hruntime
-  iapply Wasm.SmallStep.twp_call runtimeModule sortIndex
+  iapply Wasm.SmallStep.twp_call (α := α) runtimeModule sortIndex
     (mergeSortFunction mergeIndex) hsortImports hsortFunction $$
       HruntimeLater
   iintro Hruntime
   simp [mergeSortFunction, mergeSortArguments, Function.toLocals,
     Function.numParams, ValueType.zero]
-  have Hbody := twp_mergeSortBody runtimeModule mergeIndex
+  have Hbody := twp_mergeSortBody (α := α) runtimeModule mergeIndex
     hmergeImports hmergeFunction source temporary input scratch
     (s := s) (E := E) (Φ := Φ)
     (calls :=
@@ -2284,7 +2284,7 @@ theorem twp_mergeSort
   isplitl [Hpre]
   · iexact Hpre
   iintro %width %left %mid %right Hruntime Hpost
-  iapply Wasm.SmallStep.twp_returnFromCallExplicit
+  iapply Wasm.SmallStep.twp_returnFromCallExplicit (α := α)
   simp only [List.take_zero, List.nil_append,
     List.drop_eq_nil_of_le (by simp : 3 ≤
       (mergeSortArguments source temporary input.length stack).length)]
@@ -2302,10 +2302,10 @@ theorem twp_mergeSort_total
     WP (.running
       ⟨({ values :=
           mergeSortArguments source temporary input.length [] } : Locals),
-        [.call 0], 0, [], [], []⟩ : Expr Unit)
+        [.call 0], 0, [], [], []⟩ : Expr α)
       @ s; E [{ _values, mergeSortPost source temporary input }] := by
   iintro ⟨Hruntime, Hpre⟩
-  iapply twp_mergeSort mergeSortModule 0 1
+  iapply twp_mergeSort (α := α) mergeSortModule 0 1
     (by simp [mergeSortModule])
     (by simp [mergeSortModule])
     (by simp [mergeSortModule])
@@ -2319,7 +2319,7 @@ theorem twp_mergeSort_total
   isplitl [Hpre]
   · iexact Hpre
   iintro Hruntime Hpost
-  iapply Wasm.SmallStep.twp_finish
+  iapply Wasm.SmallStep.twp_finish (α := α)
   iapply twp.value rfl
   iexact Hpost
 

--- a/codelib/CodeLib/Examples/Quicksort.lean
+++ b/codelib/CodeLib/Examples/Quicksort.lean
@@ -415,7 +415,7 @@ theorem quicksort_oracle_sorted :
 
 /-! ## Adequacy infrastructure -/
 
-private def quicksortHeapAux (σ : WasmHeapMap (Option UInt8)) (base : UInt32) :
+def quicksortHeapAux (σ : WasmHeapMap (Option UInt8)) (base : UInt32) :
     List UInt32 → WasmHeapMap (Option UInt8)
   | [] => σ
   | x :: xs => quicksortHeapAux (store32Heap σ base x) (base + 4) xs
@@ -433,7 +433,7 @@ def quicksortConfig (arr : UInt32) (input : List UInt32) : Config Unit :=
       { runtime := { module := quicksortModule, host := {} }
         wasm := { initial with mem := writeWordArray initial.mem arr input } } }
 
-private theorem quicksortHeapAux_agrees
+theorem quicksortHeapAux_agrees
     (σ : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32) (xs : List UInt32)
     (hagree : heapAgreesWithMem σ mem)
     (hfit : base.toNat + 4 * xs.length ≤ UInt32.size) :
@@ -464,7 +464,7 @@ theorem quicksortHeap_agrees (arr : UInt32) (input : List UInt32)
   · intro addr byte hget; simp [get?_empty] at hget
   · exact hfit
 
-private theorem quicksortHeapAux_inBounds
+theorem quicksortHeapAux_inBounds
     (σ : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32) (xs : List UInt32)
     (hinBounds : heapAddressesInBounds σ mem)
     (hfit : base.toNat + 4 * xs.length ≤ UInt32.size)
@@ -503,7 +503,7 @@ theorem quicksortHeap_inBounds (arr : UInt32) (input : List UInt32)
     simp only [hpages]
     exact hmem
 
-private theorem quicksortHeapAux_pointsTo [WasmHeapGS]
+theorem quicksortHeapAux_pointsTo [WasmHeapGS]
     (σ : WasmHeapMap (Option UInt8)) (base : UInt32) (xs : List UInt32)
     (hdisjoint : ∀ a b, get? σ a = some b → a.toNat < base.toNat)
     (hfit : base.toNat + 4 * xs.length < UInt32.size) :

--- a/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
@@ -342,6 +342,138 @@ theorem wasm_smallStep_stronglyNormalizing
   · iintro _
     exact htwp
 
+/-- Total-WP strong normalization with authoritative initial memory, globals,
+and runtime-module ownership. This is the termination counterpart of
+`wasm_smallStep_heap_globals_runtime_store_adequacy`. -/
+theorem wasm_smallStep_heap_globals_runtime_stronglyNormalizing
+    [WasmSmallStepGpreS]
+    (config : Config α)
+    (σ : WasmHeapMap (Option UInt8))
+    (globalσ : WasmGlobalMap Value)
+    (Φ : List Value → IProp WasmHeapGF)
+    (hagree : heapAgreesWithMem σ config.store.wasm.mem)
+    (hinBounds : heapAddressesInBounds σ config.store.wasm.mem)
+    (hglobals : globalHeapAgrees globalσ config.store.wasm.globals)
+    (htwp : ∀ [WasmSmallStepGS .hasNoLC],
+      (([∗map] address ↦ value ∈ σ,
+          pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+            address (DFrac.own 1) value) ∗
+        ([∗map] index ↦ value ∈ globalσ,
+          globalPointsTo index value) ∗
+        runtimeModuleOwn config.store.runtime.module) ⊢
+        WP config.expr @ Stuckness.NotStuck; ⊤
+          [{ Φ }]) :
+    StronglyNormalizing
+      (ExprErasedStep (Expr := Expr α)
+        (State := MachineStore α) (Obs := StepKind))
+      (config.expr, config.store) := by
+  apply stronglyNormalizing_expr_of_threadPool
+  apply twp_total (hlc := .hasNoLC) (GF := WasmHeapGF)
+    Stuckness.NotStuck config.expr config.store
+    Φ 0 0
+  intro inv
+  imod genHeap_init (L := UInt32) (V := Option UInt8)
+      (GF := WasmHeapGF) (H := WasmHeapMap) σ with
+    ⟨%heapGS, Hheap, Hpoints, Hmeta⟩
+  letI globalMapG : GhostMapG WasmHeapGF Nat Value WasmGlobalMap := by
+    constructor
+    exists 7
+  imod (ghost_map_alloc (GF := WasmHeapGF) (K := Nat)
+      (V := Value) (H := WasmGlobalMap) globalσ) with
+    ⟨%globalName, Hglobals, HglobalPoints⟩
+  letI dataSegmentMapG :
+      GhostMapG WasmHeapGF Nat (Option (List UInt8))
+        WasmDataSegmentMap := by
+    constructor
+    exists 9
+  imod (ghost_map_alloc_empty (GF := WasmHeapGF) (K := Nat)
+      (V := Option (List UInt8)) (H := WasmDataSegmentMap)) with
+    ⟨%dataSegmentName, Hsegments⟩
+  letI tableMapG : GhostMapG WasmHeapGF Nat TableInst WasmTableMap := by
+    constructor
+    exists 10
+  imod (ghost_map_alloc_empty (GF := WasmHeapGF) (K := Nat)
+      (V := TableInst) (H := WasmTableMap)) with
+    ⟨%tableName, Htables⟩
+  letI elementSegmentMapG :
+      GhostMapG WasmHeapGF Nat (Option (List (Option Nat)))
+        WasmElementSegmentMap := by
+    constructor
+    exists 11
+  imod (ghost_map_alloc_empty (GF := WasmHeapGF) (K := Nat)
+      (V := Option (List (Option Nat))) (H := WasmElementSegmentMap)) with
+    ⟨%elementSegmentName, HelementSegments⟩
+  letI wasmHeapGS : WasmHeapGS :=
+    { togenHeapGS := heapGS }
+  letI wasmGlobalGS : WasmGlobalGS :=
+    { toGhostMapG := globalMapG
+      globalName := globalName }
+  letI wasmDataSegmentGS : WasmDataSegmentGS :=
+    { toGhostMapG := dataSegmentMapG
+      dataSegmentName := dataSegmentName }
+  letI wasmTableGS : WasmTableGS :=
+    { toGhostMapG := tableMapG
+      tableName := tableName }
+  letI wasmElementSegmentGS : WasmElementSegmentGS :=
+    { toGhostMapG := elementSegmentMapG
+      elementSegmentName := elementSegmentName }
+  letI runtimeElem :
+      ElemG WasmHeapGF (constOF (Agree (DiscreteO Module))) := by
+    exists 8
+  let runtimeValue : Agree (DiscreteO Module) :=
+    toAgree ⟨config.store.runtime.module⟩
+  imod (iOwn_alloc (E := runtimeElem)
+      (runtimeValue • runtimeValue) (fun n =>
+        CMRA.valid_iff_validN.mp
+          (toAgree_op_valid_iff_eq.mpr rfl) n)) with
+    ⟨%runtimeName, Hruntime⟩
+  letI runtimeGS : WasmRuntimeModuleGS :=
+    { runtimeElem
+      runtimeName }
+  letI gs : WasmSmallStepGS .hasNoLC :=
+    { toInvGS_gen := inv
+      toWasmHeapGS := wasmHeapGS
+      global := wasmGlobalGS
+      dataSegment := wasmDataSegmentGS
+      table := wasmTableGS
+      elementSegment := wasmElementSegmentGS
+      runtime := runtimeGS }
+  iclear Hmeta
+  ihave HruntimePair := iOwn_op.mp $$ Hruntime
+  icases HruntimePair with ⟨HruntimeState, HruntimeWP⟩
+  imodintro
+  iexists
+    (fun store (_ : Nat) (observations : List StepKind) (_ : Nat) =>
+      stateInterp (GF := WasmHeapGF) store 0 observations 0),
+    (fun _ => 0), (fun _ => iprop(True)),
+    (fun _ _ _ _ => by
+      iintro Hstate
+      imodintro
+      iexact Hstate)
+  dsimp only
+  isplitl [Hheap Hglobals Hsegments Htables HelementSegments HruntimeState]
+  · iapply (stateInterp_eq config.store 0 [] 0).mpr
+    iexists σ
+    iexists globalσ
+    iexists (∅ : WasmDataSegmentMap (Option (List UInt8)))
+    iexists (∅ : WasmTableMap TableInst)
+    iexists (∅ : WasmElementSegmentMap (Option (List (Option Nat))))
+    unfold runtimeModuleOwn
+    iframe Hheap Hglobals Hsegments Htables HelementSegments HruntimeState
+    ipureintro
+    exact ⟨hagree, hinBounds, hglobals,
+      dataSegmentHeapAgrees_empty _,
+      ⟨tableHeapAgrees_empty _, elementSegmentHeapAgrees_empty _⟩⟩
+  · iintro _
+    iapply htwp
+    isplitl [Hpoints]
+    · iexact Hpoints
+    isplitl [HglobalPoints]
+    · unfold globalPointsTo
+      iexact HglobalPoints
+    · unfold runtimeModuleOwn
+      iexact HruntimeWP
+
 private theorem stronglyNormalizing_reaches_irreducible
     {β : Type _} {step : β → β → Prop} {start : β}
     (hsn : StronglyNormalizing step start) :

--- a/codelib/CodeLib/SepLogic/SmallStepState.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepState.lean
@@ -140,6 +140,34 @@ theorem stateInterp_pointsTo_facts [WasmSmallStepGS hlc]
   ipureintro
   exact ⟨Hfacts.1 address value hlookup, Hfacts.2.1 address value hlookup⟩
 
+/-- Host-local state is deliberately absent from the Iris physical resources.
+Changing only `Store.host` therefore preserves the complete state
+interpretation.  This is the frame lemma used by host functions, such as
+`stdio.write`, whose effects do not modify Wasm-owned runtime resources. -/
+theorem stateInterp_host_set [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat)
+    (observations : List StepKind) (threads : Nat) (host : α) :
+    stateInterp (GF := WasmHeapGF) store steps observations threads ==∗
+      stateInterp (GF := WasmHeapGF)
+        { store with wasm := { store.wasm with host } }
+        steps observations threads := by
+  iintro Hstate
+  icases (stateInterp_eq store steps observations threads).mp $$ Hstate with
+    ⟨%σ, %globalσ, %dataSegmentσ, %tableσ, %elementSegmentσ,
+      Hheap, Hglobals, Hsegments, Htables, HelementSegments, Hruntime, %Hfacts⟩
+  imodintro
+  iapply (stateInterp_eq
+    { store with wasm := { store.wasm with host } }
+    steps observations threads).mpr
+  iexists σ
+  iexists globalσ
+  iexists dataSegmentσ
+  iexists tableσ
+  iexists elementSegmentσ
+  iframe Hheap Hglobals Hsegments Htables HelementSegments Hruntime
+  ipureintro
+  exact Hfacts
+
 /-- Owned global state determines the corresponding physical instantiated
 global. -/
 theorem stateInterp_global_facts [WasmSmallStepGS hlc]

--- a/interpreter/Interpreter/Wasm.lean
+++ b/interpreter/Interpreter/Wasm.lean
@@ -5,6 +5,7 @@ import Interpreter.Wasm.Continuation
 import Interpreter.Wasm.Semantics
 import Interpreter.Wasm.Semantics.Lemmas
 import Interpreter.Wasm.SmallStep
+import Interpreter.Wasm.Host.StdIO
 import Interpreter.Wasm.MeasureTermination
 import Interpreter.Wasm.Wp.Defs
 import Interpreter.Wasm.Wp.Atomic

--- a/interpreter/Interpreter/Wasm/Host/StdIO.lean
+++ b/interpreter/Interpreter/Wasm/Host/StdIO.lean
@@ -36,7 +36,7 @@ def byteCapacity (st : Store State) : Nat := st.mem.pages * 65536
 def rangeInBounds (st : Store State) (pointer length : Nat) : Bool :=
   pointer + length ≤ byteCapacity st
 
-private def readResult (st : Store State) (args : List Value) : HostResult State :=
+def readResult (st : Store State) (args : List Value) : HostResult State :=
   match args with
   | [.i32 length, .i32 pointer] =>
       let bytes := st.host.input.take length.toNat
@@ -51,7 +51,7 @@ private def readResult (st : Store State) (args : List Value) : HostResult State
         .Trap st "stdio.read: out of bounds memory access"
   | _ => .Trap st "stdio.read: expected (length, pointer)"
 
-private def writeResult (st : Store State) (args : List Value) : HostResult State :=
+def writeResult (st : Store State) (args : List Value) : HostResult State :=
   match args with
   | [.i32 length, .i32 pointer] =>
       if rangeInBounds st pointer.toNat length.toNat then
@@ -70,6 +70,51 @@ def readHost : HostFn State :=
   { params := [.i32, .i32]
     results := [.i32]
     invoke := readResult }
+
+/-- Reading from an empty input succeeds with zero bytes whenever the empty
+half-open range at `pointer` is valid, and leaves the store unchanged. -/
+theorem read_empty (st : Store State) (length pointer : UInt32)
+    (hinput : st.host.input = [])
+    (hptr : pointer.toNat ≤ byteCapacity st) :
+    readHost.invoke st [.i32 length, .i32 pointer] = .Return [.i32 0] st := by
+  simp only [readHost, readResult]
+  rw [hinput]
+  simp only [List.take_nil, List.length_nil]
+  rw [if_pos]
+  · cases st with
+    | mk globals globalIds functionIds mem extraMems memoryCaps memoryIds
+        dataSegments tables tableIds elementSegments elementValues tagIds exns
+        gcHeap host =>
+      cases host
+      simp only at hinput
+      subst_vars
+      cases mem
+      simp only [Mem.writeBytes, List.length_nil, Nat.add_zero, List.drop_zero]
+      congr
+      funext i
+      rw [dif_neg (by omega)]
+  · simp only [rangeInBounds, Nat.add_zero]
+    exact decide_eq_true hptr
+
+/-- A one-byte EOF probe placed exactly one past memory traps whenever input
+remains.  Together with `read_empty`, this distinguishes EOF from truncation
+without adding a third host function. -/
+theorem read_one_past_traps (st : Store State) (pointer : UInt32)
+    (hinput : st.host.input ≠ [])
+    (hptr : pointer.toNat = byteCapacity st) :
+    readHost.invoke st [.i32 1, .i32 pointer] =
+      .Trap st "stdio.read: out of bounds memory access" := by
+  simp only [readHost, readResult]
+  cases hi : st.host.input with
+  | nil => exact False.elim (hinput hi)
+  | cons byte bytes =>
+      simp only [show (1 : UInt32).toNat = 1 by decide,
+        List.take_succ_cons, List.take_zero, List.length_cons, List.length_nil]
+      rw [if_neg (by
+        simp only [rangeInBounds]
+        intro h
+        have := of_decide_eq_true h
+        omega)]
 
 /-- Concrete implementation of the `write(length, pointer)` import. -/
 def writeHost : HostFn State :=

--- a/interpreter/Interpreter/Wasm/Host/StdIO.lean
+++ b/interpreter/Interpreter/Wasm/Host/StdIO.lean
@@ -1,0 +1,119 @@
+import Interpreter.Wasm.SmallStep
+
+/-!
+# A byte-buffer standard-I/O host
+
+`StdIO` is a deliberately small deterministic host environment.  Its mutable
+state consists of an unread input buffer and an append-only output buffer.  It
+provides two imports, both using `(length, pointer)` argument order:
+
+* `read : (i32, i32) -> i32` copies up to `length` unread input bytes into
+  linear memory at `pointer`, consumes exactly those bytes, and returns the
+  number copied;
+* `write : (i32, i32) -> ()` appends exactly `length` bytes from linear memory
+  at `pointer` to the output buffer.
+
+An out-of-bounds memory range or malformed argument list traps without making
+any state change.  Zero-length accesses are valid even at the byte immediately
+after the end of memory, matching the usual half-open-range convention.
+-/
+
+namespace Wasm.StdIO
+
+/-- Mutable state owned by the `StdIO` host. -/
+structure State where
+  input : List UInt8
+  output : List UInt8 := []
+deriving Repr, Inhabited, DecidableEq
+
+/-- Start a fresh host run with `input` available and an empty output. -/
+def State.ofInput (input : List UInt8) : State := { input }
+
+/-- The number of addressable bytes in the primary linear memory. -/
+def byteCapacity (st : Store State) : Nat := st.mem.pages * 65536
+
+/-- Whether the half-open range `[pointer, pointer + length)` is in memory. -/
+def rangeInBounds (st : Store State) (pointer length : Nat) : Bool :=
+  pointer + length ≤ byteCapacity st
+
+private def readResult (st : Store State) (args : List Value) : HostResult State :=
+  match args with
+  | [.i32 length, .i32 pointer] =>
+      let bytes := st.host.input.take length.toNat
+      if rangeInBounds st pointer.toNat bytes.length then
+        .Return [.i32 (UInt32.ofNat bytes.length)]
+          { st with
+            mem := st.mem.writeBytes pointer.toNat bytes
+            host :=
+              { input := st.host.input.drop bytes.length
+                output := st.host.output } }
+      else
+        .Trap st "stdio.read: out of bounds memory access"
+  | _ => .Trap st "stdio.read: expected (length, pointer)"
+
+private def writeResult (st : Store State) (args : List Value) : HostResult State :=
+  match args with
+  | [.i32 length, .i32 pointer] =>
+      if rangeInBounds st pointer.toNat length.toNat then
+        let bytes := st.mem.readBytes pointer.toNat length.toNat
+        .Return []
+          { st with
+            host :=
+              { input := st.host.input
+                output := st.host.output ++ bytes } }
+      else
+        .Trap st "stdio.write: out of bounds memory access"
+  | _ => .Trap st "stdio.write: expected (length, pointer)"
+
+/-- Concrete implementation of the `read(length, pointer) -> length` import. -/
+def readHost : HostFn State :=
+  { params := [.i32, .i32]
+    results := [.i32]
+    invoke := readResult }
+
+/-- Concrete implementation of the `write(length, pointer)` import. -/
+def writeHost : HostFn State :=
+  { params := [.i32, .i32]
+    results := []
+    invoke := writeResult }
+
+/-- The two imports expected by a module using `StdIO`. -/
+def imports : List ImportDecl :=
+  [ { «module» := "stdio", name := "read",
+      params := [.i32, .i32], results := [.i32] }
+  , { «module» := "stdio", name := "write",
+      params := [.i32, .i32], results := [] } ]
+
+/-- The executable `StdIO` host environment. -/
+def env : HostEnv State := { funcs := [readHost, writeHost] }
+
+/-- Exact relational contract for `read`.  Keeping the contract named lets
+program proofs hide the concrete resolver behind `HostEnv.Satisfies`. -/
+def readContract : HostContract State :=
+  fun st args result => result = readResult st args
+
+/-- Exact relational contract for `write`. -/
+def writeContract : HostContract State :=
+  fun st args result => result = writeResult st args
+
+/-- Relational specification corresponding to `StdIO.imports`. -/
+def spec : HostSpec State :=
+  { contracts := [readContract, writeContract] }
+
+/-- The concrete environment satisfies the `StdIO` specification for every
+module whose import list is exactly `StdIO.imports`. -/
+theorem env_satisfies (m : Module) (himports : m.imports = imports) :
+    env.Satisfies m spec := by
+  intro i hi
+  rw [himports] at hi
+  rcases i with _ | _ | i
+  · refine ⟨readHost, readContract, rfl, rfl, ?_⟩
+    intro st args
+    rfl
+  · refine ⟨writeHost, writeContract, rfl, rfl, ?_⟩
+    intro st args
+    rfl
+  · simp [imports] at hi
+    omega
+
+end Wasm.StdIO

--- a/interpreter/Interpreter/Wasm/Mem.lean
+++ b/interpreter/Interpreter/Wasm/Mem.lean
@@ -159,6 +159,38 @@ def Mem.writeBytes (m : Mem) (offset : Nat) (data : List UInt8) : Mem :=
           exact this)
       else m.bytes i }
 
+/-- Writing concatenated byte strings is the same as writing the first string
+and then the second one immediately after it. -/
+theorem Mem.writeBytes_append (m : Mem) (offset : Nat) (xs ys : List UInt8) :
+    m.writeBytes offset (xs ++ ys) =
+      (m.writeBytes offset xs).writeBytes (offset + xs.length) ys := by
+  cases m with
+  | mk pages bytes =>
+    simp only [Mem.writeBytes]
+    congr
+    funext i
+    simp only [List.length_append]
+    by_cases hy : offset + xs.length ≤ i ∧
+        i < offset + xs.length + ys.length
+    · rw [dif_pos hy]
+      have hall : offset ≤ i ∧ i < offset + (xs.length + ys.length) := by
+        omega
+      rw [dif_pos hall]
+      rw [List.getElem_append_right (by omega)]
+      congr 1
+      omega
+    · rw [dif_neg hy]
+      by_cases hx : offset ≤ i ∧ i < offset + xs.length
+      · rw [dif_pos hx]
+        have hall : offset ≤ i ∧ i < offset + (xs.length + ys.length) := by
+          omega
+        rw [dif_pos hall]
+        rw [List.getElem_append_left (by omega)]
+      · rw [dif_neg hx]
+        have hall : ¬(offset ≤ i ∧ i < offset + (xs.length + ys.length)) := by
+          omega
+        rw [dif_neg hall]
+
 /-- Read `len` bytes starting at byte offset `offset`. Used by the
 cross-memory `memory.copy`; the caller checks bounds. -/
 def Mem.readBytes (m : Mem) (offset len : Nat) : List UInt8 :=


### PR DESCRIPTION
## Summary

- add a deterministic `StdIO` host with byte-buffer input and append-only output
- expose `stdio.read(length, pointer) -> length` and `stdio.write(length, pointer)`
- specify the imports with exact relational host contracts and prove the executable environment satisfies them
- add a serialized `UInt32` merge-sort program and executable regression examples
- prove unconditional result safety through `Correct`
- prove successful execution for every fitting input through `Complete`
- generalize the Iris merge-sort laws and total proof to arbitrary host state
- add an authoritative-memory total-WP adequacy bridge for strong normalization
- add memory-independent little-endian codec round-trip and length lemmas

## Why

This provides a small host-level interface for stating program behavior in terms of input and output values, without exposing Wasm memory or execution fuel in client specifications.

## Correctness statements

- `Correct`: every successfully produced output is a sorted permutation of the input, with no `Fits` premise
- `Complete`: every input satisfying the fixed one-page source/scratch layout has some successful output

Dynamic `memory.grow` support remains separate follow-up work.

## Validation

- `lake build` in `interpreter/`
- `lake build` in `codelib/` (3235 jobs)
- `lake build CodeLib.Examples.MergeSort.StdIO` (3203 jobs)
- Lean theorem verification for `correct` and `complete`, with no suspicious source patterns
- `git diff --check`
