### PR TITLE
Add probabilistic random host

### DIFF
--- a/interpreter/Interpreter/Wasm.lean
+++ b/interpreter/Interpreter/Wasm.lean
@@ -6,6 +6,7 @@ import Interpreter.Wasm.Semantics
 import Interpreter.Wasm.Semantics.Lemmas
 import Interpreter.Wasm.SmallStep
 import Interpreter.Wasm.Host.StdIO
+import Interpreter.Wasm.Host.Random.Probability
 import Interpreter.Wasm.MeasureTermination
 import Interpreter.Wasm.Wp.Defs
 import Interpreter.Wasm.Wp.Atomic

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -27,6 +27,7 @@ import Interpreter.Wasm.Examples.MultiValue
 import Interpreter.Wasm.Examples.ClzPopcnt
 import Interpreter.Wasm.Examples.HostDispatch
 import Interpreter.Wasm.Examples.Counter
+import Interpreter.Wasm.Examples.Random
 import Interpreter.Wasm.Examples.DecoderImport
 import Interpreter.Wasm.Examples.DecoderImportedGlobal
 import Interpreter.Wasm.Examples.FloatOps

--- a/interpreter/Interpreter/Wasm/Examples/Random.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Random.lean
@@ -1,0 +1,89 @@
+import Interpreter.Wasm.Host.Random.Probability
+
+/-!
+# A probabilistic Wasm coin
+
+This example connects the two proof layers.  The pathwise theorem computes the
+Wasm program for every fixed oracle.  The probability theorem then samples its
+first oracle byte uniformly and proves that the program accepts with
+probability exactly one half.
+-/
+
+namespace Wasm.Examples.Random
+
+open Wasm.Random
+open Wasm.SmallStep
+open scoped ENNReal
+
+/-- Read one random byte into address zero and return it as an `i32`. -/
+def module : Module :=
+  { imports := Wasm.Random.imports
+    funcs := [{
+      body := [
+        .const 0, .const 1, .call 0,
+        .const 0, .load8U 0]
+      results := [.i32] }]
+    memory := some { pagesMin := 1 } }
+
+def initialStore (oracle : Oracle) : Store State :=
+  { (module.initialStore (α := State)) with
+    host := State.ofOracle oracle }
+
+def config (oracle : Oracle) : Config State :=
+  match initConfig { module, host := Wasm.Random.env }
+      1 (initialStore oracle) [] with
+  | .ok result => result
+  | .error error =>
+      { expr := .trapped (.host error.message)
+        store :=
+          { runtime := { module, host := Wasm.Random.env }
+            wasm := initialStore oracle } }
+
+/-- Functional, pathwise semantics: for any fixed oracle, the returned value
+is exactly its first byte. -/
+theorem returns_first_oracle_byte (oracle : Oracle) :
+    (runSteps 6 (config oracle)).result.values? =
+      some [.i32 (UInt8.ofFin (oracle 0)).toUInt32] := by
+  rfl
+
+def finalCursor? : RunnerResult State → Option Nat
+  | .success _ store => some store.wasm.host.cursor
+  | _ => none
+
+/-- The pathwise run uses exactly the single byte supplied by the probability
+model below, so its zero fallback is never observed. -/
+theorem consumes_exactly_one_byte (oracle : Oracle) :
+    finalCursor? (runSteps 6 (config oracle)).result = some 1 := by
+  rfl
+
+/-- The program's threshold branch, projected as an executable Boolean. -/
+def accepts (oracle : Oracle) : Bool :=
+  match (runSteps 6 (config oracle)).result.values? with
+  | some [.i32 value] => decide (value.toNat < 128)
+  | _ => false
+
+theorem accepts_iff_first_byte_low (oracle : Oracle) :
+    accepts oracle = decide ((oracle 0).val < 128) := by
+  rw [accepts, returns_first_oracle_byte]
+  simp
+
+/-- Complete a single sampled byte to the oracle used by the executable
+machine.  The program consumes exactly that one-byte prefix. -/
+def oneByteOracle (byte : Byte) : Oracle :=
+  Oracle.ofPrefix (count := 1) (fun _ => byte)
+
+def acceptanceEvent : Set Byte :=
+  { byte | accepts (oneByteOracle byte) = true }
+
+theorem acceptanceEvent_eq :
+    acceptanceEvent = { byte | byte.val < 128 } := by
+  ext byte
+  simp [acceptanceEvent, oneByteOracle, accepts_iff_first_byte_low]
+
+/-- End-to-end probabilistic correctness of the Wasm program. -/
+theorem accepts_with_probability_one_half :
+    probability uniformByte acceptanceEvent = (1 / 2 : ℝ≥0∞) := by
+  rw [acceptanceEvent_eq]
+  exact uniformByte_lowHalf_probability
+
+end Wasm.Examples.Random

--- a/interpreter/Interpreter/Wasm/Examples/Random.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Random.lean
@@ -15,13 +15,15 @@ open Wasm.Random
 open Wasm.SmallStep
 open scoped ENNReal
 
-/-- Read one random byte into address zero and return it as an `i32`. -/
+/-- Read one random byte into address zero and use Wasm's unsigned comparison
+to return `1` when it is below 128 and `0` otherwise. -/
 def module : Module :=
   { imports := Wasm.Random.imports
     funcs := [{
       body := [
         .const 0, .const 1, .call 0,
-        .const 0, .load8U 0]
+        .const 0, .load8U 0,
+        .const 128, .ltU]
       results := [.i32] }]
     memory := some { pagesMin := 1 } }
 
@@ -39,11 +41,11 @@ def config (oracle : Oracle) : Config State :=
           { runtime := { module, host := Wasm.Random.env }
             wasm := initialStore oracle } }
 
-/-- Functional, pathwise semantics: for any fixed oracle, the returned value
-is exactly its first byte. -/
-theorem returns_first_oracle_byte (oracle : Oracle) :
-    (runSteps 6 (config oracle)).result.values? =
-      some [.i32 (UInt8.ofFin (oracle 0)).toUInt32] := by
+/-- Functional, pathwise semantics: for any fixed oracle, the Wasm function
+returns its threshold comparison on the first oracle byte. -/
+theorem returns_threshold_result (oracle : Oracle) :
+    (runSteps 8 (config oracle)).result.values? =
+      some [.i32 (if (UInt8.ofFin (oracle 0)).toUInt32 < 128 then 1 else 0)] := by
   rfl
 
 def finalCursor? : RunnerResult State → Option Nat
@@ -53,19 +55,27 @@ def finalCursor? : RunnerResult State → Option Nat
 /-- The pathwise run uses exactly the single byte supplied by the probability
 model below, so its zero fallback is never observed. -/
 theorem consumes_exactly_one_byte (oracle : Oracle) :
-    finalCursor? (runSteps 6 (config oracle)).result = some 1 := by
+    finalCursor? (runSteps 8 (config oracle)).result = some 1 := by
   rfl
 
-/-- The program's threshold branch, projected as an executable Boolean. -/
+/-- Observe whether the Wasm function returned its accepting value. -/
 def accepts (oracle : Oracle) : Bool :=
-  match (runSteps 6 (config oracle)).result.values? with
-  | some [.i32 value] => decide (value.toNat < 128)
+  match (runSteps 8 (config oracle)).result.values? with
+  | some [.i32 value] => value == 1
   | _ => false
 
 theorem accepts_iff_first_byte_low (oracle : Oracle) :
     accepts oracle = decide ((oracle 0).val < 128) := by
-  rw [accepts, returns_first_oracle_byte]
-  simp
+  rw [accepts, returns_threshold_result]
+  by_cases h : (oracle 0).val < 128
+  · have h' : (UInt8.ofFin (oracle 0)).toUInt32 < 128 := by
+      change (UInt8.ofFin (oracle 0)).toNat < 128
+      simpa using h
+    simp [h, h']
+  · have h' : ¬(UInt8.ofFin (oracle 0)).toUInt32 < 128 := by
+      change ¬(UInt8.ofFin (oracle 0)).toNat < 128
+      simpa using h
+    simp [h, h']
 
 /-- Complete a single sampled byte to the oracle used by the executable
 machine.  The program consumes exactly that one-byte prefix. -/

--- a/interpreter/Interpreter/Wasm/Host/Random.lean
+++ b/interpreter/Interpreter/Wasm/Host/Random.lean
@@ -1,0 +1,118 @@
+import Interpreter.Wasm.SmallStep
+
+/-!
+# An explicit entropy-oracle host
+
+`Random` exposes one import:
+
+* `get : (i32, i32) -> ()` writes `length` bytes at `pointer`.
+
+The host remains deterministic for a fixed `Oracle`.  Its state records an
+infinite byte oracle and the index of the next unread byte.  Probability is
+introduced separately, by placing a distribution on finite oracle prefixes;
+it is not hidden inside the executable small-step semantics.
+
+An out-of-bounds range or malformed argument list traps without changing the
+store.  A zero-length request is valid at the byte immediately after memory.
+-/
+
+namespace Wasm.Random
+
+/-- A byte in the mathematical entropy model.  `Fin 256` has the finite
+structure needed by the probability library; it is converted to `UInt8` only
+at the Wasm memory boundary. -/
+abbrev Byte := Fin 256
+
+/-- A deterministic realization of an infinite entropy source. -/
+abbrev Oracle := Nat → Byte
+
+/-- Mutable state owned by the random host. -/
+structure State where
+  oracle : Oracle
+  cursor : Nat := 0
+
+/-- Start reading an oracle at its first byte. -/
+def State.ofOracle (oracle : Oracle) : State := { oracle }
+
+/-- The all-zero oracle is useful as an inert default, not as a probabilistic
+model. -/
+def Oracle.zero : Oracle := fun _ => 0
+
+instance : Inhabited State := ⟨State.ofOracle Oracle.zero⟩
+
+/-- Avoid attempting to print the function-valued oracle. -/
+instance : Repr State where
+  reprPrec state _ := s!"Random.State(cursor={state.cursor})"
+
+/-- The next `count` oracle bytes, converted to the representation stored in
+linear memory. -/
+def State.draw (state : State) (count : Nat) : List UInt8 :=
+  List.ofFn fun index : Fin count =>
+    UInt8.ofFin (state.oracle (state.cursor + index.val))
+
+@[simp]
+theorem State.draw_length (state : State) (count : Nat) :
+    (state.draw count).length = count := by
+  simp [State.draw]
+
+/-- Advance past `count` bytes without changing the oracle realization. -/
+def State.advance (state : State) (count : Nat) : State :=
+  { state with cursor := state.cursor + count }
+
+/-- The number of addressable bytes in the primary linear memory. -/
+def byteCapacity (store : Store State) : Nat := store.mem.pages * 65536
+
+/-- Whether the half-open range `[pointer, pointer + length)` is in memory. -/
+def rangeInBounds (store : Store State) (pointer length : Nat) : Bool :=
+  pointer + length ≤ byteCapacity store
+
+/-- Pure implementation of `random.get(pointer, length)`. -/
+def getResult (store : Store State) (args : List Value) : HostResult State :=
+  match args with
+  | [.i32 pointer, .i32 length] =>
+      if rangeInBounds store pointer.toNat length.toNat then
+        let bytes := store.host.draw length.toNat
+        .Return []
+          { store with
+            mem := store.mem.writeBytes pointer.toNat bytes
+            host := store.host.advance length.toNat }
+      else
+        .Trap store "random.get: out of bounds memory access"
+  | _ => .Trap store "random.get: expected (pointer, length)"
+
+/-- Concrete implementation of the `random.get(pointer, length)` import. -/
+def getHost : HostFn State :=
+  { params := [.i32, .i32]
+    results := []
+    invoke := getResult }
+
+/-- The single import expected by a module using this random host. -/
+def imports : List ImportDecl :=
+  [{ «module» := "random", name := "get",
+     params := [.i32, .i32], results := [] }]
+
+/-- Executable environment for a fixed oracle stored in `Store.host`. -/
+def env : HostEnv State := { funcs := [getHost] }
+
+/-- Pathwise contract for `random.get`.  It fixes how the selected oracle
+bytes affect memory while remaining parametric in the oracle itself. -/
+def getContract : HostContract State :=
+  fun store args result => result = getResult store args
+
+/-- Relational specification corresponding to `Random.imports`. -/
+def spec : HostSpec State := { contracts := [getContract] }
+
+/-- The concrete environment satisfies the pathwise specification for every
+module whose import list is exactly `Random.imports`. -/
+theorem env_satisfies (module : Module) (himports : module.imports = imports) :
+    env.Satisfies module spec := by
+  intro index hindex
+  rw [himports] at hindex
+  have hzero : index = 0 := by
+    simpa [imports] using hindex
+  subst index
+  refine ⟨getHost, getContract, rfl, rfl, ?_⟩
+  intro store args
+  rfl
+
+end Wasm.Random

--- a/interpreter/Interpreter/Wasm/Host/Random/Probability.lean
+++ b/interpreter/Interpreter/Wasm/Host/Random/Probability.lean
@@ -1,0 +1,96 @@
+import Interpreter.Wasm.Host.Random
+import Mathlib.Probability.Distributions.Uniform
+import Mathlib.Tactic
+
+/-!
+# Finite probability models for the entropy oracle
+
+A probabilistic theorem chooses a finite oracle prefix uniformly and evaluates
+the otherwise deterministic Wasm machine with that prefix.  A program proof
+must also establish that execution consumes no more than the sampled prefix;
+`Oracle.ofPrefix` deliberately uses zero beyond it so accidental overuse is
+visible in the functional proof rather than receiving unstated randomness.
+
+This finite model supports exact probabilities for bounded executions.  An
+IID product measure on infinite oracles can be added later without changing
+the executable host or its pathwise contract.
+-/
+
+namespace Wasm.Random
+
+open MeasureTheory
+open scoped ENNReal
+
+/-- A finite prefix containing exactly `count` oracle bytes. -/
+abbrev Prefix (count : Nat) := Fin count → Byte
+
+/-- Complete a finite prefix to an executable oracle with an explicit zero
+fallback.  Probability claims using this completion must prove that the
+program's final cursor is at most `count`. -/
+def Oracle.ofPrefix {count : Nat} (bytes : Prefix count) : Oracle :=
+  fun index => if h : index < count then bytes ⟨index, h⟩ else 0
+
+@[simp]
+theorem Oracle.ofPrefix_apply {count index : Nat} (bytes : Prefix count)
+    (hindex : index < count) :
+    Oracle.ofPrefix bytes index = bytes ⟨index, hindex⟩ := by
+  simp [Oracle.ofPrefix, hindex]
+
+/-- The uniform distribution over all byte strings of length `count`. -/
+noncomputable def uniformPrefix (count : Nat) : PMF (Prefix count) :=
+  PMF.uniformOfFintype (Prefix count)
+
+/-- Lift any deterministic oracle-parametric evaluator—such as a projection
+of the fuel-bounded Wasm runner—to a discrete distribution of results. -/
+noncomputable def evalWithUniformPrefix (count : Nat)
+    (eval : Oracle → β) : PMF β :=
+  (uniformPrefix count).map fun bytes => eval (Oracle.ofPrefix bytes)
+
+/-- Probability of an event under a discrete distribution. -/
+noncomputable def probability (distribution : PMF α) (event : Set α) :
+    ℝ≥0∞ :=
+  distribution.toOuterMeasure event
+
+/-- Uniform-prefix events reduce to finite counting.  This is the main bridge
+for exact probability theorems about bounded randomized programs. -/
+theorem uniformPrefix_probability (count : Nat)
+    (event : Set (Prefix count)) [Fintype event] :
+    probability (uniformPrefix count) event =
+      Fintype.card event / Fintype.card (Prefix count) := by
+  exact PMF.toOuterMeasure_uniformOfFintype_apply event
+
+/-- A uniformly sampled oracle byte. -/
+noncomputable def uniformByte : PMF Byte := PMF.uniformOfFintype Byte
+
+/-- Bytes below 128 are canonically the elements of `Fin 128`. -/
+def lowHalfEquiv : { byte : Byte // byte.val < 128 } ≃ Fin 128 where
+  toFun byte := ⟨byte.val, byte.property⟩
+  invFun byte := ⟨⟨byte.val, by omega⟩, byte.isLt⟩
+  left_inv byte := by rfl
+  right_inv byte := by rfl
+
+/-- Exactly half of all bytes have a numeric value below 128. -/
+theorem lowHalf_card :
+    Fintype.card { byte : Byte // byte.val < 128 } = 128 := by
+  rw [Fintype.card_congr lowHalfEquiv]
+  simp
+
+/-- A one-byte threshold test is a fair coin. -/
+theorem uniformByte_lowHalf_probability :
+    probability uniformByte { byte | byte.val < 128 } =
+      (1 / 2 : ℝ≥0∞) := by
+  rw [probability]
+  change (PMF.uniformOfFintype Byte).toOuterMeasure
+      { byte | byte.val < 128 } = 1 / 2
+  rw [PMF.toOuterMeasure_uniformOfFintype_apply]
+  change (Fintype.card { byte : Byte // byte.val < 128 } : ℝ≥0∞) /
+      (Fintype.card Byte : ℝ≥0∞) = 1 / 2
+  rw [lowHalf_card]
+  have half : (128 : ℝ≥0∞) / 256 = 1 / 2 := by
+    apply (ENNReal.div_eq_div_iff (by norm_num) (by norm_num)
+      (by norm_num) (by norm_num)).2
+    norm_num
+  rw [Fintype.card_fin]
+  exact half
+
+end Wasm.Random

--- a/interpreter/Interpreter/Wasm/Host/Random/Probability.lean
+++ b/interpreter/Interpreter/Wasm/Host/Random/Probability.lean
@@ -1,6 +1,7 @@
 import Interpreter.Wasm.Host.Random
 import Mathlib.Probability.Distributions.Uniform
-import Mathlib.Tactic
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Order
 
 /-!
 # Finite probability models for the entropy oracle


### PR DESCRIPTION
## Summary

- add a deterministic `random.get(pointer, length)` host backed by an explicit entropy oracle and cursor
- add a finite-prefix probability layer using uniform `PMF` distributions while preserving the executable `step?`/relational `Step` correspondence
- add an end-to-end Wasm example proving a one-byte threshold branch succeeds with probability exactly `1/2`

## Design

The executable host remains deterministic for each fixed oracle. Probability is introduced separately by sampling finite oracle prefixes uniformly. Program proofs must establish that execution consumes no more entropy than the sampled prefix, preventing the deterministic fallback from silently contributing randomness.

## Validation

- `cd interpreter && lake build`
- `cd codelib && lake build`
- `cd programs/lean && lake build`
- Lean axiom checks on the new theorems; no `sorry` or `native_decide` dependencies
