### PR TITLE
Add verified StdIO selection-sort tutorial

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -41,6 +41,7 @@ import CodeLib.SepLogic.SmallStepTotalLifting
 import CodeLib.SepLogic.SmallStepAdequacy
 import CodeLib.Examples.MergeSort.TotalProof
 import CodeLib.Examples.Quicksort.TotalProof
+import CodeLib.Examples.SelectionSort.StdIOProof
 
 /-!
 # CodeLib — umbrella import for downstream code

--- a/codelib/CodeLib/Examples/SelectionSort.lean
+++ b/codelib/CodeLib/Examples/SelectionSort.lean
@@ -1,0 +1,128 @@
+import Interpreter.Wasm.SmallStep
+
+/-!
+# Selection sort: two handwritten Wasm programs
+
+This tutorial uses two implementations of the same in-place selection sort.
+The recursive implementation expresses both the minimum scan and the suffix
+traversal with function calls; its proof will follow those calls by induction.
+The loop implementation expresses the traversals with structured loops; its
+proof will instead use an outer and an inner loop invariant.
+
+The values being sorted are Wasm `i64`s interpreted as unsigned `UInt64`s.
+The `StdIO` wrapper and the shared public correctness statement live in
+`CodeLib.Examples.SelectionSort.StdIO`.
+-/
+
+namespace Wasm.Examples.SelectionSort
+
+open Wasm
+
+/-! ## Small Wasm-building helpers -/
+
+def incrementLocal (index : Nat) : Program :=
+  [.localGet index, .const 1, .add, .localSet index]
+
+def addressAt (base index : Nat) : Program :=
+  [.localGet base, .localGet index, .const 8, .mul, .add]
+
+def loadAt (base index : Nat) : Program :=
+  addressAt base index ++ [.load64 0]
+
+def storeAt (base index : Nat) (value : Program) : Program :=
+  addressAt base index ++ value ++ [.store64 0]
+
+def swapAt (base left right temporary : Nat) : Program :=
+  loadAt base left ++ [.localSet temporary] ++
+  storeAt base left (loadAt base right) ++
+  storeAt base right [.localGet temporary]
+
+def swapFirstWith (base right temporary : Nat) : Program :=
+  [.localGet base, .load64 0, .localSet temporary,
+   .localGet base] ++ loadAt base right ++ [.store64 0] ++
+  storeAt base right [.localGet temporary]
+
+def whileLoopCode (condition body : Program) : Program :=
+  condition ++ [.eqz, .br_if 1] ++ body ++ [.br 0]
+
+def whileDo (condition body : Program) : Program :=
+  [.block 0 0 [.loop 0 0 (whileLoopCode condition body)]]
+
+/-! ## Recursive implementation
+
+`findMinRecursive` has parameters `(array, length, best, scan)` and returns the
+index of the least unsigned `i64` value seen from `scan` onward. The sort entry
+swaps that value into the first cell and recursively sorts the suffix.
+-/
+
+def findMinRecursiveBody (selfIndex : Nat) : Program :=
+  [.localGet 3, .localGet 1, .ltU, .eqz,
+   .iff 0 0 [.localGet 2, .ret] []] ++
+  loadAt 0 3 ++ loadAt 0 2 ++
+  [.ltUI64,
+   .iff 0 0 [.localGet 3, .localSet 2] [],
+   .localGet 0, .localGet 1, .localGet 2,
+   .localGet 3, .const 1, .add,
+   .call selfIndex,
+   .ret]
+
+def findMinRecursiveFunction (selfIndex : Nat) : Function :=
+  { params := [.i32, .i32, .i32, .i32]
+    results := [.i32]
+    body := findMinRecursiveBody selfIndex }
+
+def recursiveSelectionSortBody
+    (findMinIndex selfIndex : Nat) : Program :=
+  [.localGet 1, .const 2, .ltU,
+   .iff 0 0 [.ret] [],
+   .localGet 0, .localGet 1, .const 0, .const 1,
+   .call findMinIndex,
+   .localSet 2] ++
+  swapAt 0 3 2 4 ++
+  [.localGet 0, .const 8, .add,
+   .localGet 1, .const 1, .sub,
+   .call selfIndex,
+   .ret]
+
+def recursiveSelectionSortFunction
+    (findMinIndex selfIndex : Nat) : Function :=
+  { params := [.i32, .i32]
+    locals := [.i32, .i32, .i64]
+    body := recursiveSelectionSortBody findMinIndex selfIndex }
+
+/-! ## Loop implementation
+
+Parameters are `(array, length)`. Locals `2` through `5` are respectively the
+outer index, current minimum index, scan index, and `i64` swap temporary.
+-/
+
+def loopSelectionSortInnerCondition : Program :=
+  [.localGet 4, .localGet 1, .ltU]
+
+def loopSelectionSortInnerStep : Program :=
+  loadAt 0 4 ++ loadAt 0 3 ++
+  [.ltUI64,
+   .iff 0 0 [.localGet 4, .localSet 3] []] ++
+  incrementLocal 4
+
+def loopSelectionSortOuterCondition : Program :=
+  [.localGet 2, .const 1, .add, .localGet 1, .ltU]
+
+def loopSelectionSortOuterStep : Program :=
+  [.localGet 2, .localSet 3,
+   .localGet 2, .const 1, .add, .localSet 4] ++
+  whileDo loopSelectionSortInnerCondition loopSelectionSortInnerStep ++
+  swapAt 0 2 3 5 ++
+  incrementLocal 2
+
+def loopSelectionSortBody : Program :=
+  [.const 0, .localSet 2] ++
+  whileDo loopSelectionSortOuterCondition loopSelectionSortOuterStep ++
+  [.ret]
+
+def loopSelectionSortFunction : Function :=
+  { params := [.i32, .i32]
+    locals := [.i32, .i32, .i32, .i64]
+    body := loopSelectionSortBody }
+
+end Wasm.Examples.SelectionSort

--- a/codelib/CodeLib/Examples/SelectionSort/Pure.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/Pure.lean
@@ -1,0 +1,298 @@
+import CodeLib.Examples.SelectionSort
+import Mathlib.Data.List.Sort
+
+/-! Pure list facts shared by the recursive and loop proofs. -/
+
+namespace Wasm.Examples.SelectionSort
+
+def Sorted (values : List UInt64) : Prop :=
+  values.Pairwise (· ≤ ·)
+
+private theorem uint64_le_refl (value : UInt64) : value ≤ value := by
+  change value.toNat ≤ value.toNat
+  omega
+
+private theorem uint64_le_of_lt {left right : UInt64}
+    (h : left < right) : left ≤ right := by
+  change left.toNat < right.toNat at h
+  change left.toNat ≤ right.toNat
+  omega
+
+private theorem uint64_le_trans {a b c : UInt64}
+    (hab : a ≤ b) (hbc : b ≤ c) : a ≤ c := by
+  change a.toNat ≤ b.toNat at hab
+  change b.toNat ≤ c.toNat at hbc
+  change a.toNat ≤ c.toNat
+  omega
+
+private theorem uint64_le_of_not_lt {left right : UInt64}
+    (h : ¬ left < right) : right ≤ left := by
+  change ¬ left.toNat < right.toNat at h
+  change right.toNat ≤ left.toNat
+  omega
+
+def swapElems (values : List UInt64) (i j : Nat) : List UInt64 :=
+  (values.set i values[j]!).set j values[i]!
+
+theorem swapElems_length (values : List UInt64) (i j : Nat) :
+    (swapElems values i j).length = values.length := by
+  simp [swapElems, List.length_set]
+
+theorem swapElems_get_i (values : List UInt64) {i j : Nat}
+    (hi : i < values.length) (hj : j < values.length) :
+    (swapElems values i j)[i]! = values[j]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs <;> simp_all
+
+theorem swapElems_get_j (values : List UInt64) {i j : Nat}
+    (hi : i < values.length) (hj : j < values.length) :
+    (swapElems values i j)[j]! = values[i]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs <;> simp_all
+
+theorem swapElems_get_other (values : List UInt64) {i j k : Nat}
+    (hki : k ≠ i) (hkj : k ≠ j) :
+    (swapElems values i j)[k]! = values[k]! := by
+  unfold swapElems
+  simp only [List.getElem!_eq_getElem?_getD, List.getElem?_set]
+  split_ifs <;> simp_all
+
+theorem swapElems_take_of_le (values : List UInt64) {i j n : Nat}
+    (hin : n ≤ i) (hjn : n ≤ j) :
+    (swapElems values i j).take n = values.take n := by
+  unfold swapElems
+  rw [List.take_set, List.take_set]
+  have hlen : (List.take n values).length ≤ n := List.length_take_le n values
+  rw [List.set_eq_of_length_le (by rw [List.length_set]; exact hlen.trans hjn),
+    List.set_eq_of_length_le (hlen.trans hin)]
+
+theorem swapElems_perm (values : List UInt64) {i j : Nat}
+    (hi : i < values.length) (hj : j < values.length) :
+    List.Perm values (swapElems values i j) := by
+  rw [List.perm_iff_count]
+  intro value
+  simp only [swapElems]
+  have hi_eq : values[i]! = values[i] := getElem!_pos values i hi
+  have hj_eq : values[j]! = values[j] := getElem!_pos values j hj
+  rw [hi_eq, hj_eq]
+  have hlen : (values.set i values[j]).length = values.length := List.length_set
+  rw [List.count_set (hlen ▸ hj), List.count_set hi]
+  have hset_j : ((values.set i values[j])[j] == value) =
+      (values[j] == value) := by
+    congr 1
+    simp [List.getElem_set]
+  rw [hset_j]
+  have hle : (if values[i] == value then 1 else 0) ≤
+      values.count value := by
+    split_ifs with h
+    · exact List.count_pos_iff.mpr
+        ((beq_iff_eq.mp h) ▸ List.getElem_mem hi)
+    · exact Nat.zero_le _
+  omega
+
+/-- `best` is a minimum of the half-open range `[start, scan)`. -/
+def MinScan (values : List UInt64) (start best scan : Nat) : Prop :=
+  start ≤ best ∧ best < scan ∧ scan ≤ values.length ∧
+    ∀ k, start ≤ k → k < scan → values[best]! ≤ values[k]!
+
+theorem minScan_start (values : List UInt64) {start : Nat}
+    (hstart : start < values.length) :
+    MinScan values start start (start + 1) := by
+  refine ⟨Nat.le_refl _, by omega, by omega, ?_⟩
+  intro k hk hks
+  have : k = start := by omega
+  subst k
+  exact uint64_le_refl _
+
+theorem MinScan.step (values : List UInt64) {start best scan : Nat}
+    (h : MinScan values start best scan) (hscan : scan < values.length) :
+    MinScan values start
+      (if values[scan]! < values[best]! then scan else best) (scan + 1) := by
+  rcases h with ⟨hstartBest, hbestScan, hscanLength, hmin⟩
+  by_cases hlt : values[scan]! < values[best]!
+  · simp only [if_pos hlt]
+    refine ⟨by omega, by omega, by omega, ?_⟩
+    intro k hk hks
+    by_cases hkscan : k = scan
+    · subst k
+      exact uint64_le_refl _
+    · exact uint64_le_trans (uint64_le_of_lt hlt)
+        (hmin k hk (by omega))
+  · simp only [if_neg hlt]
+    refine ⟨hstartBest, by omega, by omega, ?_⟩
+    intro k hk hks
+    by_cases hkscan : k = scan
+    · subst k
+      exact uint64_le_of_not_lt hlt
+    · exact hmin k hk (by omega)
+
+/-- Prefix `[0, fixed)` is sorted, contains the globally least `fixed`
+elements, and the whole current array is a permutation of the input. -/
+def OuterInvariant
+    (input current : List UInt64) (fixed : Nat) : Prop :=
+  current.length = input.length ∧
+  List.Perm input current ∧
+  fixed ≤ current.length ∧
+  Sorted (current.take fixed) ∧
+  ∀ x ∈ current.take fixed, ∀ y ∈ current.drop fixed, x ≤ y
+
+theorem outerInvariant_start (input : List UInt64) :
+    OuterInvariant input input 0 := by
+  refine ⟨rfl, List.Perm.refl _, Nat.zero_le _, ?_, ?_⟩
+  · exact List.Pairwise.nil
+  · intro x hx
+    simp at hx
+
+theorem OuterInvariant.step
+    {input current : List UInt64} {fixed best : Nat}
+    (hout : OuterInvariant input current fixed)
+    (hfixed : fixed < current.length)
+    (hbest : fixed ≤ best ∧ best < current.length)
+    (hmin : ∀ k, fixed ≤ k → k < current.length →
+      current[best]! ≤ current[k]!) :
+    OuterInvariant input (swapElems current fixed best) (fixed + 1) := by
+  rcases hout with ⟨hlength, hperm, hfixedLe, hsorted, hcross⟩
+  let updated := swapElems current fixed best
+  have hupdatedLength : updated.length = current.length :=
+    swapElems_length current fixed best
+  have htake : updated.take (fixed + 1) =
+      current.take fixed ++ [current[best]!] := by
+    rw [List.take_succ_eq_append_getElem (hupdatedLength ▸ hfixed)]
+    rw [swapElems_take_of_le current (Nat.le_refl fixed) hbest.1]
+    rw [show updated[fixed] = updated[fixed]! from
+      (getElem!_pos updated fixed (hupdatedLength ▸ hfixed)).symm]
+    exact congrArg (current.take fixed ++ [·])
+      (swapElems_get_i current hfixed hbest.2)
+  have suffixMem (k : Nat) (hkLower : fixed ≤ k)
+      (hkUpper : k < current.length) : current[k]! ∈ current.drop fixed := by
+    rw [List.mem_iff_getElem]
+    refine ⟨k - fixed, ?_, ?_⟩
+    · simp only [List.length_drop]
+      omega
+    · rw [List.getElem_drop]
+      rw [getElem!_pos current k hkUpper]
+      congr 1
+      omega
+  have updatedSuffix (y : UInt64) (hy : y ∈ updated.drop (fixed + 1)) :
+      ∃ k, fixed < k ∧ k < current.length ∧ updated[k]! = y := by
+    rw [List.mem_iff_getElem] at hy
+    rcases hy with ⟨offset, hoffset, hy⟩
+    have hkUpdated : fixed + 1 + offset < updated.length := by
+      simp only [List.length_drop] at hoffset
+      rw [hupdatedLength] at hoffset ⊢
+      omega
+    refine ⟨fixed + 1 + offset, by omega, ?_, ?_⟩
+    · rw [hupdatedLength] at hkUpdated
+      exact hkUpdated
+    · rw [getElem!_pos updated (fixed + 1 + offset) hkUpdated]
+      rw [← hy, List.getElem_drop]
+  refine ⟨hupdatedLength.trans hlength,
+    hperm.trans (swapElems_perm current hfixed hbest.2), ?_, ?_, ?_⟩
+  · rw [hupdatedLength]
+    omega
+  · rw [htake]
+    unfold Sorted at hsorted ⊢
+    rw [List.pairwise_append]
+    refine ⟨hsorted, List.pairwise_singleton _ _, ?_⟩
+    intro x hx y hy
+    simp only [List.mem_singleton] at hy
+    subst y
+    exact hcross x hx current[best]! (suffixMem best hbest.1 hbest.2)
+  · intro x hx y hy
+    rw [htake] at hx
+    simp only [List.mem_append, List.mem_singleton] at hx
+    rcases updatedSuffix y hy with ⟨k, hfk, hkLength, hky⟩
+    have hsource :
+        (updated[k]! = current[fixed]!) ∨
+        (updated[k]! = current[k]!) := by
+      by_cases hkb : k = best
+      · left
+        subst k
+        exact swapElems_get_j current hfixed hbest.2
+      · right
+        exact swapElems_get_other current (by omega) hkb
+    rcases hx with hx | rfl
+    · rcases hsource with hsource | hsource
+      · rw [← hky, hsource]
+        exact hcross x hx current[fixed]!
+          (suffixMem fixed (Nat.le_refl fixed) hfixed)
+      · rw [← hky, hsource]
+        exact hcross x hx current[k]!
+          (suffixMem k (by omega) hkLength)
+    · rcases hsource with hsource | hsource
+      · rw [← hky, hsource]
+        exact hmin fixed (Nat.le_refl fixed) hfixed
+      · rw [← hky, hsource]
+        exact hmin k (by omega) hkLength
+
+theorem OuterInvariant.sorted
+    {input current : List UInt64} {fixed : Nat}
+    (h : OuterInvariant input current fixed)
+    (hfinished : current.length ≤ fixed + 1) :
+    Sorted current := by
+  rcases h with ⟨_hlength, _hperm, hfixed, hsorted, hcross⟩
+  unfold Sorted at hsorted ⊢
+  rw [← List.take_append_drop fixed current]
+  rw [List.pairwise_append]
+  refine ⟨hsorted, ?_, hcross⟩
+  have hsuffixLength : (current.drop fixed).length ≤ 1 := by
+    simp only [List.length_drop]
+    omega
+  match hsuffix : current.drop fixed with
+  | [] => exact List.Pairwise.nil
+  | [_] => exact List.pairwise_singleton _ _
+  | _ :: _ :: _ => simp [hsuffix] at hsuffixLength
+
+theorem OuterInvariant.perm
+    {input current : List UInt64} {fixed : Nat}
+    (h : OuterInvariant input current fixed) :
+    List.Perm input current := h.2.1
+
+/-- The pure composition step used by the recursive implementation: place a
+minimum at the head, recursively sort the tail, then reattach the head. -/
+theorem recursive_compose
+    {input : List UInt64} {best : Nat} {tailOutput : List UInt64}
+    (hlength : 0 < input.length)
+    (hbest : best < input.length)
+    (hmin : ∀ k, k < input.length → input[best]! ≤ input[k]!)
+    (htailPerm : List.Perm (List.drop 1 (swapElems input 0 best)) tailOutput)
+    (htailSorted : Sorted tailOutput) :
+    let output := (swapElems input 0 best)[0]! :: tailOutput
+    List.Perm input output ∧ Sorted output := by
+  let updated := swapElems input 0 best
+  have houter : OuterInvariant input updated 1 :=
+    (outerInvariant_start input).step hlength ⟨Nat.zero_le _, hbest⟩
+      (fun k _hk hklen => hmin k hklen)
+  have hupdatedLength : updated.length = input.length :=
+    swapElems_length input 0 best
+  have hupdatedNonempty : 0 < updated.length := by omega
+  have hdecomp : updated = updated[0]! :: updated.drop 1 := by
+    cases hUpdated : updated with
+    | nil =>
+        have hlength := congrArg List.length hUpdated
+        simp only [List.length_nil] at hlength
+        omega
+    | cons head tail => simp
+  dsimp only
+  constructor
+  · exact houter.perm.trans (hdecomp ▸ htailPerm.cons updated[0]!)
+  · unfold Sorted at htailSorted ⊢
+    rw [List.pairwise_cons]
+    refine ⟨?_, htailSorted⟩
+    intro y hy
+    have hyUpdated : y ∈ updated.drop 1 := htailPerm.mem_iff.mpr hy
+    apply houter.2.2.2.2 updated[0]!
+    · have htake : updated.take 1 = [updated[0]!] := by
+        cases hUpdated : updated with
+        | nil =>
+            have hlength := congrArg List.length hUpdated
+            simp only [List.length_nil] at hlength
+            omega
+        | cons head tail => simp
+      rw [htake]
+      simp
+    · exact hyUpdated
+
+end Wasm.Examples.SelectionSort

--- a/codelib/CodeLib/Examples/SelectionSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/StdIO.lean
@@ -1,0 +1,262 @@
+import CodeLib.Examples.SelectionSort.TotalProof
+import CodeLib.RustStd.MemArray
+import Interpreter.Wasm.Host.StdIO
+import Mathlib.Data.List.Sort
+
+/-!
+# Selection sort as a `StdIO` program
+
+This is the stream-facing layer of the selection-sort tutorial. Input is a
+packed sequence of little-endian unsigned 64-bit integers. The program calls
+`stdio.read`, sorts the words in its one-page memory, and passes the same byte
+region to `stdio.write`.
+
+Both the recursive and loop implementations satisfy the same public contract:
+for every input representable by the fixed page, there exists an output
+returned by the program, and that output is a sorted permutation of the input.
+The recursive proof will use induction; the loop proof will use invariants.
+-/
+
+namespace Wasm.Examples.SelectionSort.StdIO
+
+open Wasm SepLogic SmallStep
+open Iris Iris.Std
+
+def bufferBytes : Nat := 65536
+def array : UInt32 := 0
+
+/-! ## Little-endian `UInt64` streams -/
+
+/-- The eight little-endian bytes of an unsigned 64-bit word. -/
+def encodeWord (value : UInt64) : List UInt8 :=
+  [ (value &&& 0xff).toUInt8
+  , ((value >>> 8) &&& 0xff).toUInt8
+  , ((value >>> 16) &&& 0xff).toUInt8
+  , ((value >>> 24) &&& 0xff).toUInt8
+  , ((value >>> 32) &&& 0xff).toUInt8
+  , ((value >>> 40) &&& 0xff).toUInt8
+  , ((value >>> 48) &&& 0xff).toUInt8
+  , ((value >>> 56) &&& 0xff).toUInt8 ]
+
+/-- Reassemble an unsigned 64-bit word from its little-endian bytes. -/
+def decodeWord (b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ : UInt8) : UInt64 :=
+  b₀.toUInt64 ||| (b₁.toUInt64 <<< 8) |||
+    (b₂.toUInt64 <<< 16) ||| (b₃.toUInt64 <<< 24) |||
+    (b₄.toUInt64 <<< 32) ||| (b₅.toUInt64 <<< 40) |||
+    (b₆.toUInt64 <<< 48) ||| (b₇.toUInt64 <<< 56)
+
+def serialize (values : List UInt64) : List UInt8 :=
+  values.flatMap encodeWord
+
+/-- Reject a trailing partial word instead of silently ignoring it. -/
+def deserialize : List UInt8 → Option (List UInt64)
+  | [] => some []
+  | b₀ :: b₁ :: b₂ :: b₃ :: b₄ :: b₅ :: b₆ :: b₇ :: rest =>
+      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ :: ·)
+  | _ => none
+
+@[simp] theorem decode_encode (value : UInt64) :
+    decodeWord
+      (value &&& 0xff).toUInt8
+      (((value >>> 8) &&& 0xff).toUInt8)
+      (((value >>> 16) &&& 0xff).toUInt8)
+      (((value >>> 24) &&& 0xff).toUInt8)
+      (((value >>> 32) &&& 0xff).toUInt8)
+      (((value >>> 40) &&& 0xff).toUInt8)
+      (((value >>> 48) &&& 0xff).toUInt8)
+      (((value >>> 56) &&& 0xff).toUInt8) = value := by
+  simp only [decodeWord]
+  bv_decide
+
+@[simp] theorem deserialize_serialize (values : List UInt64) :
+    deserialize (serialize values) = some values := by
+  induction values with
+  | nil => rfl
+  | cons value values ih =>
+      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
+        List.nil_append, deserialize, decode_encode]
+      change (deserialize (serialize values)).map (value :: ·) =
+        some (value :: values)
+      rw [ih]
+      rfl
+
+@[simp] theorem serialize_length (values : List UInt64) :
+    (serialize values).length = 8 * values.length := by
+  induction values with
+  | nil => rfl
+  | cons value values ih =>
+      change (List.flatMap encodeWord values).length = 8 * values.length at ih
+      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
+        List.nil_append, List.length_cons, Nat.mul_add]
+      omega
+
+/-! ## Link each sort against the `StdIO` ABI -/
+
+/-- Read one page, require EOF, sort `byteLength / 8` words, and write them.
+The unified indices are `0 = read`, `1 = write`, followed by the supplied sort
+functions and finally `main`. -/
+def mainBody (sortIndex : Nat) : Program :=
+  [ .const (UInt32.ofNat bufferBytes), .const array, .call 0, .localSet 0
+  , .const 1, .const (UInt32.ofNat bufferBytes), .call 0, .localSet 1
+  , .const array, .localGet 0, .const 8, .divU, .call sortIndex
+  , .localGet 0, .const array, .call 1
+  , .ret ]
+
+def mainFunction (sortIndex : Nat) : Function :=
+  { locals := [.i32, .i32]
+    body := mainBody sortIndex }
+
+structure Executable where
+  module : Module
+  entry : Nat
+  sortEntry : Nat
+  imports_eq : module.imports = Wasm.StdIO.imports
+  memory_pages :
+    (module.initialStore (α := Wasm.StdIO.State)).mem.pages = 1
+
+def recursive : Executable :=
+  { module :=
+      { imports := Wasm.StdIO.imports
+        funcs :=
+          [ findMinRecursiveFunction 2
+          , recursiveSelectionSortFunction 2 3
+          , mainFunction 3 ]
+        memory := some { pagesMin := 1, pagesMax := some 1 } }
+    entry := 4
+    sortEntry := 3
+    imports_eq := rfl
+    memory_pages := rfl }
+
+def loop : Executable :=
+  { module :=
+      { imports := Wasm.StdIO.imports
+        funcs := [loopSelectionSortFunction, mainFunction 2]
+        memory := some { pagesMin := 1, pagesMax := some 1 } }
+    entry := 3
+    sortEntry := 2
+    imports_eq := rfl
+    memory_pages := rfl }
+
+def initialStore (program : Executable) (input : List UInt8) :
+    Store Wasm.StdIO.State :=
+  { (program.module.initialStore (α := Wasm.StdIO.State)) with
+      host := Wasm.StdIO.State.ofInput input }
+
+def execute (program : Executable) (fuel entry : Nat)
+    (store : Store Wasm.StdIO.State) (args : List Value) :
+    Option (List Value × Store Wasm.StdIO.State) :=
+  match SmallStep.initConfig
+      { module := program.module, host := Wasm.StdIO.env } entry store args with
+  | .error _ => none
+  | .ok phase =>
+      match (SmallStep.runSteps fuel phase).result with
+      | .success values finalStore => some (values, finalStore.wasm)
+      | _ => none
+
+def replaceHost (store : Store α) (host : β) : Store β :=
+  { store with host := host }
+
+/-- The host-independent call configuration shared by the executable runner
+and the Iris proof. Keeping the explicit `.call` exposes exactly the public
+function contract proved in `TotalProof`. -/
+def sortConfig (program : Executable) (store : Store Wasm.StdIO.State)
+    (args : List Value) : Config Unit :=
+  { expr := .running
+      ⟨⟨[], [], args⟩, [.call program.sortEntry], 0, [], [], []⟩
+    store :=
+      { runtime := { module := program.module, host := ({} : HostEnv Unit) }
+        wasm := replaceHost store () } }
+
+/-- The sort functions cannot call an import. Running them with an inert host
+makes that independence explicit, after which the unchanged StdIO buffers are
+reattached. -/
+def executeSort (program : Executable) (fuel : Nat)
+    (store : Store Wasm.StdIO.State) (args : List Value) :
+    Option (List Value × Store Wasm.StdIO.State) :=
+  match (SmallStep.runSteps fuel (sortConfig program store args)).result with
+  | .success values finalStore =>
+      some (values, replaceHost finalStore.wasm store.host)
+  | _ => none
+
+def writtenStore (store : Store Wasm.StdIO.State) (length : UInt32) :
+    Store Wasm.StdIO.State :=
+  { store with
+    host :=
+      { input := store.host.input
+        output := store.host.output ++
+          store.mem.readBytes array.toNat length.toNat } }
+
+def runAfterRead (program : Executable) (fuel : Nat)
+    (byteLength : UInt32) (afterRead : Store Wasm.StdIO.State) :
+    Option (List UInt8) := do
+  let (probeValues, afterProbe) ← execute program 2 0 afterRead
+    [.i32 (UInt32.ofNat 65536), .i32 1]
+  guard (probeValues = [.i32 0])
+  let (_, afterSort) ← executeSort program fuel afterProbe
+    [.i32 (UInt32.ofNat (byteLength.toNat / 8)), .i32 array]
+  let (_, afterWrite) ← execute program 2 1 afterSort
+    [.i32 array, .i32 byteLength]
+  pure afterWrite.host.output
+
+/-- Execute `read`, an EOF probe, the selected sort, and `write` as explicit
+small-step phases. This is the same style as the merge-sort StdIO tutorial and
+keeps the host-independent sort proof reusable. -/
+def run (program : Executable) (fuel : Nat)
+    (input : List UInt8) : Option (List UInt8) := do
+  let (readValues, afterRead) ← execute program 2 0
+    (initialStore program input)
+    [.i32 array, .i32 (UInt32.ofNat bufferBytes)]
+  let byteLength ← match readValues with
+    | [.i32 length] => some length
+    | _ => none
+  runAfterRead program fuel byteLength afterRead
+
+def runValues (program : Executable) (fuel : Nat)
+    (input : List UInt64) : Option (List UInt64) :=
+  (run program fuel (serialize input)).bind deserialize
+
+/-! ## Shared public correctness statement -/
+
+def Sorted (values : List UInt64) : Prop :=
+  values.Pairwise (· ≤ ·)
+
+def Fits (input : List UInt64) : Prop :=
+  (serialize input).length ≤ bufferBytes
+
+def RunsValues (program : Executable)
+    (input output : List UInt64) : Prop :=
+  ∃ fuel, runValues program fuel input = some output
+
+/-- For every representable input there exists an output returned by the
+program, and the output is exactly a sorted permutation of the input. -/
+def Correct (program : Executable) : Prop :=
+  ∀ input, Fits input →
+    ∃ output,
+      RunsValues program input output ∧
+      List.Perm input output ∧
+      Sorted output
+
+/-- Correctness theorem proved by induction in `StdIOProof`. -/
+def RecursiveCorrect : Prop := Correct recursive
+
+/-- Correctness theorem proved with loop invariants in `StdIOProof`. -/
+def LoopCorrect : Prop := Correct loop
+
+/-! ## Executable smoke checks
+
+These checks exercise the complete `read → sort → write` path. They are not
+the tutorial's correctness proofs. The value above `UInt32.size` ensures the
+program is genuinely sorting unsigned 64-bit words rather than 32-bit ones.
+-/
+
+theorem recursive_exec_u64 :
+    runValues recursive 5000 [5, 1, 0x100000000, 2, 3] =
+      some [1, 2, 3, 5, 0x100000000] := by
+  native_decide
+
+theorem loop_exec_u64 :
+    runValues loop 5000 [5, 1, 0x100000000, 2, 3] =
+      some [1, 2, 3, 5, 0x100000000] := by
+  native_decide
+
+end Wasm.Examples.SelectionSort.StdIO

--- a/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
@@ -801,19 +801,6 @@ theorem twp_loopSortCall [WasmSmallStepGS hlc]
     · simpa [hlength] using hwords
     · simpa [array, hlength] using hcapacity
 
-theorem recursive_sort_partiallyMeets (input : List UInt64) (hfit : Fits input) :
-    SmallStep.PartiallyMeets (concreteSortConfig recursive input) (SortPost input) := by
-  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
-    (concreteSortConfig recursive input) (inputHeap input) ∅ (SortPost input)
-  · exact inputHeap_agrees recursive input hfit
-  · exact inputHeap_inBounds recursive input hfit
-  · exact globalHeapAgrees_empty _
-  · intro _
-    iintro Hresources
-    iapply twp.to_wp
-    iapply twp_recursiveSortCall input hfit
-    iexact Hresources
-
 theorem recursive_sort_stronglyNormalizing
     (input : List UInt64) (hfit : Fits input) :
     Iris.ProgramLogic.StronglyNormalizing
@@ -850,19 +837,6 @@ theorem recursive_sort_terminatesWith
     iintro Hresources
     iapply twp.to_wp
     iapply twp_recursiveSortCall input hfit
-    iexact Hresources
-
-theorem loop_sort_partiallyMeets (input : List UInt64) (hfit : Fits input) :
-    SmallStep.PartiallyMeets (concreteSortConfig loop input) (SortPost input) := by
-  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
-    (concreteSortConfig loop input) (inputHeap input) ∅ (SortPost input)
-  · exact inputHeap_agrees loop input hfit
-  · exact inputHeap_inBounds loop input hfit
-  · exact globalHeapAgrees_empty _
-  · intro _
-    iintro Hresources
-    iapply twp.to_wp
-    iapply twp_loopSortCall input hfit
     iexact Hresources
 
 theorem loop_sort_stronglyNormalizing

--- a/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
@@ -1,0 +1,1085 @@
+import CodeLib.Examples.SelectionSort.StdIO
+
+/-!
+# Correctness of the selection-sort StdIO wrappers
+
+The host-facing read and write phases are proved once for either executable.
+The middle phase then uses the induction proof for `recursive` or the invariant
+proof for `loop`, but both discharge the same stream-level contract.
+-/
+
+namespace Wasm.Examples.SelectionSort.StdIO
+
+open Wasm SepLogic SmallStep
+open Iris Iris.Std
+
+theorem execute_read (program : Executable)
+    (store wasm : Store Wasm.StdIO.State)
+    (length pointer count : UInt32)
+    (hinvoke : Wasm.StdIO.readHost.invoke store
+      [.i32 length, .i32 pointer] = .Return [.i32 count] wasm) :
+    execute program 2 0 store [.i32 pointer, .i32 length] =
+      some ([.i32 count], wasm) := by
+  let machine : MachineStore Wasm.StdIO.State :=
+    { runtime := { module := program.module, host := Wasm.StdIO.env }, wasm := store }
+  let initial : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 pointer, .i32 length]⟩, [.call 0], 1, [], [], []⟩
+      store := machine }
+  let middle : Config Wasm.StdIO.State :=
+    { expr := .running ⟨⟨[], [], [.i32 count]⟩, [], 1, [], [], []⟩
+      store := { machine with wasm } }
+  have hcallRaw := Step.callHostReturn
+    (store := machine) (functionIndex := 0)
+    (imp := Wasm.StdIO.imports[0])
+    (hostFunction := Wasm.StdIO.readHost)
+    (params := []) (localValues := [])
+    (values := [.i32 pointer, .i32 length])
+    (results := [.i32 count]) (wasm := wasm)
+    (code := []) (arity := 1) (remainder := [])
+    (controls := []) (calls := [])
+    (by simp [machine, program.imports_eq, Wasm.StdIO.imports])
+    (by simp [machine, program.imports_eq]) rfl hinvoke
+  have hcall : Step initial (.host 0) middle := by
+    simpa [initial, middle, machine, Wasm.StdIO.imports, Wasm.StdIO.env] using hcallRaw
+  have hfinish : Step middle (.administrative .finish)
+      ⟨.done [.i32 count], { machine with wasm }⟩ := Step.finish
+  have hrun := runSteps_eq_success_of_steps
+    (Steps.cons hcall (Steps.single hfinish))
+  have hinit : SmallStep.initConfig
+      { module := program.module, host := Wasm.StdIO.env } 0 store
+        [.i32 pointer, .i32 length] = .ok initial := by
+    simp [SmallStep.initConfig, initial, machine, program.imports_eq,
+      Wasm.StdIO.imports, Wasm.StdIO.env]
+  simp only [execute, hinit]
+  rw [show (runSteps 2 initial).result =
+      .success [.i32 count] { machine with wasm } by simpa using hrun]
+
+theorem execute_write (program : Executable)
+    (store wasm : Store Wasm.StdIO.State) (length pointer : UInt32)
+    (hinvoke : Wasm.StdIO.writeHost.invoke store
+      [.i32 length, .i32 pointer] = .Return [] wasm) :
+    execute program 2 1 store [.i32 pointer, .i32 length] =
+      some ([], wasm) := by
+  let machine : MachineStore Wasm.StdIO.State :=
+    { runtime := { module := program.module, host := Wasm.StdIO.env }, wasm := store }
+  let initial : Config Wasm.StdIO.State :=
+    { expr := .running
+        ⟨⟨[], [], [.i32 pointer, .i32 length]⟩, [.call 1], 0, [], [], []⟩
+      store := machine }
+  let middle : Config Wasm.StdIO.State :=
+    { expr := .running ⟨⟨[], [], []⟩, [], 0, [], [], []⟩
+      store := { machine with wasm } }
+  have hcallRaw := Step.callHostReturn
+    (store := machine) (functionIndex := 1)
+    (imp := Wasm.StdIO.imports[1])
+    (hostFunction := Wasm.StdIO.writeHost)
+    (params := []) (localValues := [])
+    (values := [.i32 pointer, .i32 length]) (results := [])
+    (wasm := wasm) (code := []) (arity := 0) (remainder := [])
+    (controls := []) (calls := [])
+    (by simp [machine, program.imports_eq, Wasm.StdIO.imports])
+    (by simp [machine, program.imports_eq]) rfl hinvoke
+  have hcall : Step initial (.host 1) middle := by
+    simpa [initial, middle, machine, Wasm.StdIO.imports, Wasm.StdIO.env] using hcallRaw
+  have hfinish : Step middle (.administrative .finish)
+      ⟨.done [], { machine with wasm }⟩ := Step.finish
+  have hrun := runSteps_eq_success_of_steps
+    (Steps.cons hcall (Steps.single hfinish))
+  have hinit : SmallStep.initConfig
+      { module := program.module, host := Wasm.StdIO.env } 1 store
+        [.i32 pointer, .i32 length] = .ok initial := by
+    simp [SmallStep.initConfig, initial, machine, program.imports_eq,
+      Wasm.StdIO.imports, Wasm.StdIO.env]
+  simp only [execute, hinit]
+  rw [show (runSteps 2 initial).result =
+      .success [] { machine with wasm } by simpa using hrun]
+
+theorem execute_write_bytes (program : Executable)
+    (store : Store Wasm.StdIO.State) (length : UInt32)
+    (hbound : array.toNat + length.toNat ≤ Wasm.StdIO.byteCapacity store) :
+    execute program 2 1 store [.i32 array, .i32 length] =
+      some ([], writtenStore store length) := by
+  apply execute_write
+  simp only [Wasm.StdIO.writeHost, Wasm.StdIO.writeResult]
+  rw [if_pos]
+  · rfl
+  · simp only [Wasm.StdIO.rangeInBounds]
+    exact decide_eq_true hbound
+
+private theorem take_eq_self_of_length_le {β : Type} (xs : List β) (n : Nat)
+    (h : xs.length ≤ n) : xs.take n = xs := by
+  induction xs generalizing n with
+  | nil => simp
+  | cons x xs ih =>
+      cases n with
+      | zero => simp at h
+      | succ n =>
+          simp only [List.take_succ_cons, List.length_cons] at h ⊢
+          rw [ih n (Nat.le_of_succ_le_succ h)]
+
+@[simp] private theorem initialStore_host (program : Executable)
+    (input : List UInt8) :
+    (initialStore program input).host = Wasm.StdIO.State.ofInput input := rfl
+
+set_option maxRecDepth 100000 in
+private theorem initial_byteCapacity (program : Executable)
+    (input : List UInt8) :
+    Wasm.StdIO.byteCapacity (initialStore program input) = 65536 := by
+  change (program.module.initialStore (α := Wasm.StdIO.State)).mem.pages * 65536 = 65536
+  have hpages :
+      (program.module.initialStore (α := Wasm.StdIO.State)).mem.pages = 1 := by
+    simpa only using program.memory_pages
+  rw [hpages]
+
+def afterRead (program : Executable) (input : List UInt64) :
+    Store Wasm.StdIO.State :=
+  { initialStore program (serialize input) with
+    mem := (initialStore program (serialize input)).mem.writeBytes
+      array.toNat (serialize input)
+    host := { input := [], output := [] } }
+
+set_option maxRecDepth 10000 in
+theorem read_fits (program : Executable) (input : List UInt64)
+    (hfit : Fits input) :
+    execute program 2 0 (initialStore program (serialize input))
+      [.i32 array, .i32 (UInt32.ofNat bufferBytes)] =
+      some ([.i32 (UInt32.ofNat (serialize input).length)],
+        afterRead program input) := by
+  apply execute_read
+  simp only [Wasm.StdIO.readHost, Wasm.StdIO.readResult,
+    initialStore_host, Wasm.StdIO.State.ofInput]
+  have hbuffer : (UInt32.ofNat bufferBytes).toNat = bufferBytes :=
+    UInt32.toNat_ofNat_of_lt' (by decide)
+  rw [hbuffer, take_eq_self_of_length_le _ _ hfit]
+  rw [if_pos (by
+    simp only [Wasm.StdIO.rangeInBounds, array,
+      initial_byteCapacity]
+    apply decide_eq_true
+    simpa only [Fits, bufferBytes, show (0 : UInt32).toNat = 0 by decide,
+      Nat.zero_add] using hfit)]
+  simp [afterRead, array]
+
+private theorem afterRead_byteCapacity (program : Executable)
+    (input : List UInt64) :
+    Wasm.StdIO.byteCapacity (afterRead program input) = 65536 := by
+  simpa only [afterRead, Wasm.StdIO.byteCapacity, Mem.writeBytes] using
+    initial_byteCapacity program (serialize input)
+
+theorem probe_afterRead (program : Executable) (input : List UInt64) :
+    execute program 2 0 (afterRead program input)
+      [.i32 (UInt32.ofNat 65536), .i32 1] =
+      some ([.i32 0], afterRead program input) := by
+  apply execute_read
+  apply Wasm.StdIO.read_empty
+  · rfl
+  · rw [afterRead_byteCapacity]
+    decide
+
+theorem encodedLength_toNat (input : List UInt64) (hfit : Fits input) :
+    (UInt32.ofNat (serialize input).length).toNat =
+      (serialize input).length := by
+  apply UInt32.toNat_ofNat_of_lt'
+  simp only [Fits, serialize_length, bufferBytes] at hfit ⊢
+  simp only [UInt32.size]
+  omega
+
+theorem encodedLength_words (input : List UInt64) (hfit : Fits input) :
+    (UInt32.ofNat (serialize input).length).toNat / 8 = input.length := by
+  rw [encodedLength_toNat input hfit, serialize_length]
+  omega
+
+/-! ## The packed stream and the u64 separation-logic array agree -/
+
+def writeWordArray64 (mem : Mem) (base : UInt32) : List UInt64 → Mem
+  | [] => mem
+  | value :: values => writeWordArray64 (mem.write64 base value) (base + 8) values
+
+def heap64Aux (heap : WasmHeapMap (Option UInt8)) (base : UInt32) :
+    List UInt64 → WasmHeapMap (Option UInt8)
+  | [] => heap
+  | value :: values => heap64Aux (store64Heap heap base value) (base + 8) values
+
+def inputHeap (input : List UInt64) : WasmHeapMap (Option UInt8) :=
+  heap64Aux ∅ array input
+
+theorem writeBytes_encodeWord (mem : Mem) (base : UInt32) (value : UInt64) :
+    mem.writeBytes base.toNat (encodeWord value) = mem.write64 base value := by
+  cases mem with
+  | mk pages bytes =>
+    simp only [Mem.writeBytes, encodeWord, List.length_cons, List.length_nil,
+      Mem.write64]
+    congr
+    funext i
+    by_cases h0 : i = base.toNat
+    · subst i; simp
+    by_cases h1 : i = base.toNat + 1
+    · subst i; simp
+    by_cases h2 : i = base.toNat + 2
+    · subst i; simp
+    by_cases h3 : i = base.toNat + 3
+    · subst i; simp
+    by_cases h4 : i = base.toNat + 4
+    · subst i; simp
+    by_cases h5 : i = base.toNat + 5
+    · subst i; simp
+    by_cases h6 : i = base.toNat + 6
+    · subst i; simp
+    by_cases h7 : i = base.toNat + 7
+    · subst i; simp
+    rw [dif_neg (by omega)]
+    simp [h0, h1, h2, h3, h4, h5, h6, h7]
+
+theorem writeBytes_serialize (mem : Mem) (base : UInt32)
+    (values : List UInt64)
+    (hfit : base.toNat + 8 * values.length < UInt32.size) :
+    mem.writeBytes base.toNat (serialize values) =
+      writeWordArray64 mem base values := by
+  induction values generalizing mem base with
+  | nil =>
+      simp only [serialize, List.flatMap_nil, writeWordArray64]
+      cases mem
+      simp only [Mem.writeBytes, List.length_nil, Nat.add_zero]
+      congr
+      funext i
+      rw [dif_neg (by omega)]
+  | cons value values ih =>
+      simp only [serialize, List.flatMap_cons, writeWordArray64]
+      rw [Mem.writeBytes_append, writeBytes_encodeWord]
+      simp only [List.length_cons, Nat.mul_add] at hfit
+      have hbase : (base + 8).toNat = base.toNat + 8 :=
+        UInt32.add_ofNat_toNat_noWrap base 8 (by decide) (by
+          simp only [UInt32.size] at hfit ⊢
+          omega)
+      rw [show base.toNat + (encodeWord value).length = (base + 8).toNat by
+        simp [encodeWord, hbase]]
+      apply ih
+      rw [hbase]
+      omega
+
+theorem heap64Aux_agrees
+    (heap : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32)
+    (values : List UInt64) (hagree : heapAgreesWithMem heap mem)
+    (hfit : base.toNat + 8 * values.length < UInt32.size) :
+    heapAgreesWithMem (heap64Aux heap base values)
+      (writeWordArray64 mem base values) := by
+  induction values generalizing heap mem base with
+  | nil => simpa [heap64Aux, writeWordArray64]
+  | cons value values ih =>
+      simp only [heap64Aux, writeWordArray64, List.length_cons] at *
+      simp only [UInt32.size] at hfit
+      apply ih
+      · apply store64_sound
+        · exact UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 4 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 5 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 6 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 7 (by decide) (by omega)
+        · exact hagree
+      · have h8 : (base + 8 : UInt32).toNat = base.toNat + 8 :=
+          UInt32.add_ofNat_toNat_noWrap base 8 (by decide) (by omega)
+        rw [h8]
+        simp only [UInt32.size]
+        omega
+
+theorem heap64Aux_inBounds
+    (heap : WasmHeapMap (Option UInt8)) (mem : Mem) (base : UInt32)
+    (values : List UInt64) (hinBounds : heapAddressesInBounds heap mem)
+    (hfit : base.toNat + 8 * values.length < UInt32.size)
+    (hmem : base.toNat + 8 * values.length ≤ mem.pages * 65536) :
+    heapAddressesInBounds (heap64Aux heap base values)
+      (writeWordArray64 mem base values) := by
+  induction values generalizing heap mem base with
+  | nil => simpa [heap64Aux, writeWordArray64]
+  | cons value values ih =>
+      simp only [heap64Aux, writeWordArray64, List.length_cons] at *
+      simp only [UInt32.size] at hfit
+      have h8 : (base + 8 : UInt32).toNat = base.toNat + 8 :=
+        UInt32.add_ofNat_toNat_noWrap base 8 (by decide) (by omega)
+      apply ih
+      · apply store64_inBounds
+        · exact UInt32.add_ofNat_toNat_noWrap base 1 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 2 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 3 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 4 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 5 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 6 (by decide) (by omega)
+        · exact UInt32.add_ofNat_toNat_noWrap base 7 (by decide) (by omega)
+        · exact hinBounds
+        · omega
+      · rw [h8]
+        simp only [UInt32.size]
+        omega
+      · simp only [Mem.write64]
+        rw [h8]
+        omega
+
+private theorem empty_agrees (mem : Mem) :
+    heapAgreesWithMem (∅ : WasmHeapMap (Option UInt8)) mem := by
+  intro address byte hget
+  rw [get?_empty] at hget
+  contradiction
+
+private theorem empty_inBounds (mem : Mem) :
+    heapAddressesInBounds (∅ : WasmHeapMap (Option UInt8)) mem := by
+  intro address byte hget
+  rw [get?_empty] at hget
+  contradiction
+
+theorem afterRead_mem_eq (program : Executable) (input : List UInt64)
+    (hfit : Fits input) :
+    (afterRead program input).mem =
+      writeWordArray64 (initialStore program (serialize input)).mem array input := by
+  unfold afterRead
+  simp only
+  apply writeBytes_serialize
+  simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+    Fits, serialize_length, bufferBytes] at hfit ⊢
+  omega
+
+theorem inputHeap_agrees (program : Executable) (input : List UInt64)
+    (hfit : Fits input) :
+    heapAgreesWithMem (inputHeap input) (afterRead program input).mem := by
+  rw [afterRead_mem_eq program input hfit]
+  unfold inputHeap
+  apply heap64Aux_agrees
+  · apply empty_agrees
+  · simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+      Fits, serialize_length, bufferBytes] at hfit ⊢
+    omega
+
+theorem inputHeap_inBounds (program : Executable) (input : List UInt64)
+    (hfit : Fits input) :
+    heapAddressesInBounds (inputHeap input) (afterRead program input).mem := by
+  rw [afterRead_mem_eq program input hfit]
+  unfold inputHeap
+  apply heap64Aux_inBounds
+  · apply empty_inBounds
+  · simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+      Fits, serialize_length, bufferBytes] at hfit ⊢
+    omega
+  · have hpages :
+        (initialStore program (serialize input)).mem.pages = 1 := by
+      exact program.memory_pages
+    rw [hpages]
+    simp only [array, UInt32.reduceToNat, Nat.zero_add, Nat.one_mul,
+      Fits, serialize_length, bufferBytes] at hfit ⊢
+    exact hfit
+
+set_option maxHeartbeats 6000000 in
+theorem heap64Aux_pointsTo [WasmHeapGS]
+    (heap : WasmHeapMap (Option UInt8)) (base : UInt32)
+    (values : List UInt64)
+    (hdisjoint : ∀ address byte, get? heap address = some byte →
+      address.toNat < base.toNat)
+    (hfit : base.toNat + 8 * values.length < UInt32.size) :
+    ([∗map] address ↦ value ∈ heap64Aux heap base values,
+      pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+        address (DFrac.own 1) value) ⊢
+      array64At base values ∗
+      ([∗map] address ↦ value ∈ heap,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          address (DFrac.own 1) value) := by
+  induction values generalizing heap base with
+  | nil =>
+      simp only [heap64Aux, array64At, BI.emp_sep.to_eq]
+      iintro Hheap
+      iexact Hheap
+  | cons value values ih =>
+      simp only [heap64Aux, List.length_cons] at *
+      simp only [UInt32.size] at hfit
+      have hn (n : Nat) (hn : n ≤ 8) :
+          (base + UInt32.ofNat n).toNat = base.toNat + n := by
+        apply UInt32.add_ofNat_toNat_noWrap base n
+        · omega
+        · omega
+      have hn1 := hn 1 (by omega)
+      have hn2 := hn 2 (by omega)
+      have hn3 := hn 3 (by omega)
+      have hn4 := hn 4 (by omega)
+      have hn5 := hn 5 (by omega)
+      have hn6 := hn 6 (by omega)
+      have hn7 := hn 7 (by omega)
+      have hn8 := hn 8 (by omega)
+      have hl1 : (base + 1 : UInt32).toNat = base.toNat + 1 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 1 (by decide)
+        omega
+      have hl2 : (base + 2 : UInt32).toNat = base.toNat + 2 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 2 (by decide)
+        omega
+      have hl3 : (base + 3 : UInt32).toNat = base.toNat + 3 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 3 (by decide)
+        omega
+      have hl4 : (base + 4 : UInt32).toNat = base.toNat + 4 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 4 (by decide)
+        omega
+      have hl5 : (base + 5 : UInt32).toNat = base.toNat + 5 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 5 (by decide)
+        omega
+      have hl6 : (base + 6 : UInt32).toNat = base.toNat + 6 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 6 (by decide)
+        omega
+      have hl7 : (base + 7 : UInt32).toNat = base.toNat + 7 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 7 (by decide)
+        omega
+      have hl8 : (base + 8 : UInt32).toNat = base.toNat + 8 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 8 (by decide)
+        omega
+      have hget (n : Nat) (hnle : n < 8) :
+          get? heap (base + UInt32.ofNat n) = none := by
+        by_contra h
+        obtain ⟨byte, hbyte⟩ := Option.ne_none_iff_exists.mp h
+        have hlt := hdisjoint _ _ hbyte.symm
+        rw [hn n (by omega)] at hlt
+        omega
+      have hget0 : get? heap base = none := by
+        simpa using hget 0 (by omega)
+      have hget1 := hget 1 (by omega)
+      have hget2 := hget 2 (by omega)
+      have hget3 := hget 3 (by omega)
+      have hget4 := hget 4 (by omega)
+      have hget5 := hget 5 (by omega)
+      have hget6 := hget 6 (by omega)
+      have hget7 := hget 7 (by omega)
+      have hgetL1 : get? heap (base + 1) = none := by simpa using hget1
+      have hgetL2 : get? heap (base + 2) = none := by simpa using hget2
+      have hgetL3 : get? heap (base + 3) = none := by simpa using hget3
+      have hgetL4 : get? heap (base + 4) = none := by simpa using hget4
+      have hgetL5 : get? heap (base + 5) = none := by simpa using hget5
+      have hgetL6 : get? heap (base + 6) = none := by simpa using hget6
+      have hgetL7 : get? heap (base + 7) = none := by simpa using hget7
+      have hne (i j : Nat) (hi : i ≤ 7) (hj : j ≤ 7) (hij : i ≠ j) :
+          base + UInt32.ofNat i ≠ base + UInt32.ofNat j := by
+        intro heq
+        have heq' := congrArg UInt32.toNat heq
+        rw [hn i (by omega), hn j (by omega)] at heq'
+        omega
+      have hneU (i j : UInt32) (hi : i.toNat ≤ 7) (hj : j.toNat ≤ 7)
+          (hij : i ≠ j) : base + i ≠ base + j := by
+        simpa only [UInt32.ofNat_toNat] using
+          hne i.toNat j.toNat hi hj (fun h => hij (UInt32.toNat_inj.mp h))
+      have hbaseNe (n : UInt32) (hn : n.toNat ≤ 7) (hpos : 0 < n.toNat) :
+          base ≠ base + n := by
+        have h := hneU 0 n (by decide) hn (by
+          intro heq
+          have := congrArg UInt32.toNat heq
+          exact hpos.ne' this.symm)
+        simpa using h
+      have hdisjoint' : ∀ address byte,
+          get? (store64Heap heap base value) address = some byte →
+          address.toNat < (base + 8).toNat := by
+        intro address byte haddress
+        change address.toNat < (base + UInt32.ofNat 8).toNat
+        rw [hn8]
+        by_cases h7 : address = base + 7
+        · subst address; rw [hl7]; omega
+        by_cases h6 : address = base + 6
+        · subst address; rw [hl6]; omega
+        by_cases h5 : address = base + 5
+        · subst address; rw [hl5]; omega
+        by_cases h4 : address = base + 4
+        · subst address; rw [hl4]; omega
+        by_cases h3 : address = base + 3
+        · subst address; rw [hl3]; omega
+        by_cases h2 : address = base + 2
+        · subst address; rw [hl2]; omega
+        by_cases h1 : address = base + 1
+        · subst address; rw [hl1]; omega
+        by_cases h0 : address = base
+        · subst address; omega
+        simp only [store64Heap, get?_insert_ne (Ne.symm h7),
+          get?_insert_ne (Ne.symm h6), get?_insert_ne (Ne.symm h5),
+          get?_insert_ne (Ne.symm h4), get?_insert_ne (Ne.symm h3),
+          get?_insert_ne (Ne.symm h2), get?_insert_ne (Ne.symm h1),
+          get?_insert_ne (Ne.symm h0)] at haddress
+        have hlt := hdisjoint address byte haddress
+        omega
+      have hfit' : (base + 8).toNat + 8 * values.length < UInt32.size := by
+        change (base + UInt32.ofNat 8).toNat + 8 * values.length < UInt32.size
+        rw [hn8]
+        simp only [UInt32.size]
+        omega
+      iintro Hheap
+      ihave Hsplit := ih (store64Heap heap base value) (base + 8)
+        hdisjoint' hfit' $$ Hheap
+      icases Hsplit with ⟨Hvalues, Hstored⟩
+      ihave Hword := store64Heap_pointsTo heap base value
+        hget0
+        (by simpa only [get?_insert_ne (hbaseNe 1 (by decide) (by decide))]
+          using hgetL1)
+        (by
+          simp only [get?_insert_ne (hneU 1 2 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 2 (by decide) (by decide))]
+          exact hgetL2)
+        (by
+          simp only [get?_insert_ne (hneU 2 3 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 1 3 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 3 (by decide) (by decide))]
+          exact hgetL3)
+        (by
+          simp only [get?_insert_ne (hneU 3 4 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 2 4 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 1 4 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 4 (by decide) (by decide))]
+          exact hgetL4)
+        (by
+          simp only [get?_insert_ne (hneU 4 5 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 3 5 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 2 5 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 1 5 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 5 (by decide) (by decide))]
+          exact hgetL5)
+        (by
+          simp only [get?_insert_ne (hneU 5 6 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 4 6 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 3 6 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 2 6 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 1 6 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 6 (by decide) (by decide))]
+          exact hgetL6)
+        (by
+          simp only [get?_insert_ne (hneU 6 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 5 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 4 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 3 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 2 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hneU 1 7 (by decide) (by decide) (by decide)),
+            get?_insert_ne (hbaseNe 7 (by decide) (by decide))]
+          exact hgetL7) $$ Hstored
+      icases Hword with ⟨Hword, Hheap⟩
+      simp only [array64At]
+      isplitl [Hword Hvalues]
+      · isplitl [Hword]
+        · iexact Hword
+        · iexact Hvalues
+      · iexact Hheap
+
+theorem inputHeap_pointsTo [WasmHeapGS] (input : List UInt64)
+    (hfit : Fits input) :
+    ([∗map] address ↦ value ∈ inputHeap input,
+      pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+        address (DFrac.own 1) value) ⊢ array64At array input := by
+  unfold inputHeap
+  iintro Hheap
+  ihave Hsplit := heap64Aux_pointsTo ∅ array input
+    (fun address byte hget => by simp [get?_empty] at hget)
+    (by
+      simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+        Fits, serialize_length, bufferBytes] at hfit ⊢
+      omega) $$ Hheap
+  icases Hsplit with ⟨Harray, _Hempty⟩
+  iexact Harray
+
+def readWordArray64 (mem : Mem) (base : UInt32) : Nat → List UInt64
+  | 0 => []
+  | n + 1 => mem.read64 base :: readWordArray64 mem (base + 8) n
+
+theorem array64At_words [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat) (obs : List StepKind)
+    (threads : Nat) (base : UInt32) (output : List UInt64)
+    (hfit : base.toNat + 8 * output.length < UInt32.size) :
+    stateInterp (GF := WasmHeapGF) store steps obs threads ∗
+      array64At base output ==∗
+    stateInterp (GF := WasmHeapGF) store steps obs threads ∗
+      array64At base output ∗
+      ⌜readWordArray64 store.wasm.mem base output.length = output⌝ := by
+  induction output generalizing base with
+  | nil =>
+      simp only [array64At, List.length_nil, readWordArray64]
+      iintro ⟨Hstate, Hempty⟩
+      imodintro
+      isplitl [Hstate]
+      · iexact Hstate
+      isplitl [Hempty]
+      · iexact Hempty
+      · ipureintro; trivial
+  | cons value output ih =>
+      simp only [array64At, List.length_cons] at *
+      have hn (n : Nat) (hn : n ≤ 8) :
+          (base + UInt32.ofNat n).toNat = base.toNat + n := by
+        apply UInt32.add_ofNat_toNat_noWrap base n
+        · omega
+        · simp only [UInt32.size] at hfit ⊢; omega
+      iintro ⟨Hstate, Hword, Houtput⟩
+      imod stateInterp_pointsTo_u64_facts_frame store steps obs threads
+        base value (hn 1 (by omega)) (hn 2 (by omega))
+        (hn 3 (by omega)) (hn 4 (by omega)) (hn 5 (by omega))
+        (hn 6 (by omega)) (hn 7 (by omega)) $$
+        [$Hstate $Hword] with ⟨Hstate, Hword, %hword⟩
+      have hfit' : (base + 8).toNat + 8 * output.length < UInt32.size := by
+        change (base + UInt32.ofNat 8).toNat + 8 * output.length < UInt32.size
+        rw [hn 8 (by omega)]
+        simp only [UInt32.size] at hfit ⊢
+        omega
+      imod ih (base + 8) hfit' $$ [$Hstate $Houtput] with
+        ⟨Hstate, Houtput, %hrest⟩
+      imodintro
+      isplitl [Hstate]
+      · iexact Hstate
+      isplitl [Hword Houtput]
+      · isplitl [Hword]
+        · iexact Hword
+        · iexact Houtput
+      · ipureintro
+        simp only [readWordArray64]
+        rw [hword.1]
+        exact congrArg (value :: ·) hrest
+
+theorem array64At_capacity [WasmSmallStepGS hlc]
+    (store : MachineStore α) (steps : Nat)
+    (observations : List StepKind) (threads : Nat)
+    (base : UInt32) (values : List UInt64)
+    (hfit : base.toNat + 8 * values.length < UInt32.size)
+    (hbaseBound : base.toNat ≤ store.wasm.mem.pages * 65536) :
+    stateInterp (GF := WasmHeapGF) store steps observations threads ∗
+      array64At base values ==∗
+    stateInterp (GF := WasmHeapGF) store steps observations threads ∗
+      array64At base values ∗
+      ⌜base.toNat + 8 * values.length ≤
+        store.wasm.mem.pages * 65536⌝ := by
+  by_cases hempty : values = []
+  · subst values
+    iintro ⟨Hstate, Harray⟩
+    imodintro
+    isplitl [Hstate]
+    · iexact Hstate
+    isplitl [Harray]
+    · iexact Harray
+    · ipureintro
+      simpa using hbaseBound
+  · have hlength : 0 < values.length := by
+      cases values with
+      | nil => contradiction
+      | cons value values => simp
+    let k := values.length - 1
+    have hk : k < values.length := by simp [k, hlength]
+    let address := base + 8 * UInt32.ofNat k
+    have haddress : address.toNat = base.toNat + 8 * k := by
+      exact Mem.words64_slotAddr_toNat base k (by
+        simp only [UInt32.size] at hfit
+        omega)
+    have hn (n : Nat) (hn : n ≤ 7) :
+        (address + UInt32.ofNat n).toNat = address.toNat + n := by
+      apply UInt32.add_ofNat_toNat_noWrap address n
+      · omega
+      · simp only [UInt32.size] at hfit ⊢
+        rw [haddress]
+        omega
+    iintro ⟨Hstate, Harray⟩
+    ihave Hfocus := array64At_get base values k hk $$ Harray
+    icases Hfocus with ⟨Hword, Hrestore⟩
+    imod stateInterp_pointsTo_u64_facts_frame
+      store steps observations threads address values[k]
+      (hn 1 (by omega)) (hn 2 (by omega)) (hn 3 (by omega))
+      (hn 4 (by omega)) (hn 5 (by omega)) (hn 6 (by omega))
+      (hn 7 (by omega)) $$ [$Hstate $Hword] with
+      ⟨Hstate, Hword, %hfacts⟩
+    imodintro
+    isplitl [Hstate]
+    · iexact Hstate
+    isplitl [Hrestore Hword]
+    · iapply Hrestore
+      iexact Hword
+    · ipureintro
+      rw [haddress] at hfacts
+      dsimp only [k] at hfacts
+      omega
+
+/-! ## Adequacy of the two host-independent sort calls -/
+
+def sortArguments (input : List UInt64) : List Value :=
+  [.i32 (UInt32.ofNat input.length), .i32 array]
+
+def concreteSortConfig (program : Executable) (input : List UInt64) : Config Unit :=
+  sortConfig program (afterRead program input) (sortArguments input)
+
+def SortPost (input : List UInt64)
+    (_values : List Value) (store : MachineStore α) : Prop :=
+  ∃ output,
+    List.Perm input output ∧ Sorted output ∧
+    readWordArray64 store.wasm.mem array input.length = output ∧
+    8 * input.length ≤ store.wasm.mem.pages * 65536
+
+set_option maxHeartbeats 6000000 in
+theorem twp_recursiveSortCall [WasmSmallStepGS hlc]
+    (input : List UInt64) (hfit : Fits input) :
+    (([∗map] address ↦ value ∈ inputHeap input,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          address (DFrac.own 1) value) ∗
+      ([∗map] index ↦ value ∈ (∅ : WasmGlobalMap Value),
+        globalPointsTo index value) ∗
+      runtimeModuleOwn (concreteSortConfig recursive input).store.runtime.module) ⊢
+      WP (concreteSortConfig recursive input).expr @ Stuckness.NotStuck; ⊤
+        [{ values,
+          ∀ (store : MachineStore Unit) (_observations : List StepKind),
+            stateInterp (GF := WasmHeapGF) store 0 [] 0 -∗
+            ⌜SortPost input values store⌝ }] := by
+  iintro ⟨Hheap, _Hglobals, Hruntime⟩
+  ihave Harray := inputHeap_pointsTo input hfit $$ Hheap
+  have hentry : recursive.sortEntry = 3 := rfl
+  simp only [concreteSortConfig, sortConfig, sortArguments, hentry]
+  iapply twp_recursiveSort recursive.module 2 3
+    (by decide) (by rfl) (by decide) (by rfl) array input
+    (by
+      simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+        Fits, serialize_length, bufferBytes] at hfit ⊢
+      omega)
+    (callerLocals := ⟨[], [], []⟩) (stack := []) (code := [])
+    (arity := 0) (remainder := []) (controls := []) (calls := [])
+  isplitl [Hruntime]
+  · iexact Hruntime
+  isplitl [Harray]
+  · iexact Harray
+  · iintro %output %hpure Hruntime Harray
+    iapply Wasm.SmallStep.twp_finish
+    iapply twp.value rfl
+    iintro %store %observations Hstate
+    have hlength := hpure.1.length_eq
+    have houtFit : array.toNat + 8 * output.length < UInt32.size := by
+      simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+        Fits, serialize_length, bufferBytes] at hfit ⊢
+      omega
+    imod array64At_words store 0 [] 0 array output houtFit $$
+      [$Hstate $Harray] with ⟨Hstate, Harray, %hwords⟩
+    imod array64At_capacity store 0 [] 0 array output houtFit
+      (by simp [array]) $$ [$Hstate $Harray] with
+      ⟨_Hstate, _Harray, %hcapacity⟩
+    ipureintro
+    refine ⟨output, hpure.1, ?_, ?_, ?_⟩
+    · simpa [Sorted, SelectionSort.Sorted] using hpure.2
+    · simpa [hlength] using hwords
+    · simpa [array, hlength] using hcapacity
+
+set_option maxHeartbeats 6000000 in
+theorem twp_loopSortCall [WasmSmallStepGS hlc]
+    (input : List UInt64) (hfit : Fits input) :
+    (([∗map] address ↦ value ∈ inputHeap input,
+        pointsTo (GF := WasmHeapGF) (H := WasmHeapMap)
+          address (DFrac.own 1) value) ∗
+      ([∗map] index ↦ value ∈ (∅ : WasmGlobalMap Value),
+        globalPointsTo index value) ∗
+      runtimeModuleOwn (concreteSortConfig loop input).store.runtime.module) ⊢
+      WP (concreteSortConfig loop input).expr @ Stuckness.NotStuck; ⊤
+        [{ values,
+          ∀ (store : MachineStore Unit) (_observations : List StepKind),
+            stateInterp (GF := WasmHeapGF) store 0 [] 0 -∗
+            ⌜SortPost input values store⌝ }] := by
+  iintro ⟨Hheap, _Hglobals, Hruntime⟩
+  ihave Harray := inputHeap_pointsTo input hfit $$ Hheap
+  have hentry : loop.sortEntry = 2 := rfl
+  simp only [concreteSortConfig, sortConfig, sortArguments, hentry]
+  iapply twp_loopSort loop.module 2 (by decide) (by rfl) array input
+    (by
+      simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+        Fits, serialize_length, bufferBytes] at hfit ⊢
+      omega)
+    (callerLocals := ⟨[], [], []⟩) (stack := []) (code := [])
+    (arity := 0) (remainder := []) (controls := []) (calls := [])
+  isplitl [Hruntime]
+  · iexact Hruntime
+  isplitl [Harray]
+  · iexact Harray
+  · iintro %output %hpure Hruntime Harray
+    iapply Wasm.SmallStep.twp_finish
+    iapply twp.value rfl
+    iintro %store %observations Hstate
+    have hlength := hpure.1.length_eq
+    have houtFit : array.toNat + 8 * output.length < UInt32.size := by
+      simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+        Fits, serialize_length, bufferBytes] at hfit ⊢
+      omega
+    imod array64At_words store 0 [] 0 array output houtFit $$
+      [$Hstate $Harray] with ⟨Hstate, Harray, %hwords⟩
+    imod array64At_capacity store 0 [] 0 array output houtFit
+      (by simp [array]) $$ [$Hstate $Harray] with
+      ⟨_Hstate, _Harray, %hcapacity⟩
+    ipureintro
+    refine ⟨output, hpure.1, ?_, ?_, ?_⟩
+    · simpa [Sorted, SelectionSort.Sorted] using hpure.2
+    · simpa [hlength] using hwords
+    · simpa [array, hlength] using hcapacity
+
+theorem recursive_sort_partiallyMeets (input : List UInt64) (hfit : Fits input) :
+    SmallStep.PartiallyMeets (concreteSortConfig recursive input) (SortPost input) := by
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+    (concreteSortConfig recursive input) (inputHeap input) ∅ (SortPost input)
+  · exact inputHeap_agrees recursive input hfit
+  · exact inputHeap_inBounds recursive input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    iapply twp.to_wp
+    iapply twp_recursiveSortCall input hfit
+    iexact Hresources
+
+theorem recursive_sort_stronglyNormalizing
+    (input : List UInt64) (hfit : Fits input) :
+    Iris.ProgramLogic.StronglyNormalizing
+      (Iris.ProgramLogic.ExprErasedStep (Expr := Expr Unit)
+        (State := MachineStore Unit) (Obs := StepKind))
+      ((concreteSortConfig recursive input).expr,
+        (concreteSortConfig recursive input).store) := by
+  apply Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_stronglyNormalizing.{0}
+    (concreteSortConfig recursive input) (inputHeap input) ∅
+    (fun _values => iprop(True))
+  · exact inputHeap_agrees recursive input hfit
+  · exact inputHeap_inBounds recursive input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    ihave Hsort := twp_recursiveSortCall input hfit $$ Hresources
+    iapply twp.mono (fun _values => ?_) $$ Hsort
+    iintro _Hpost
+    itrivial
+
+theorem recursive_sort_terminatesWith
+    (input : List UInt64) (hfit : Fits input) :
+    SmallStep.TerminatesWith
+      (concreteSortConfig recursive input) (SortPost input) := by
+  apply Wasm.SmallStep.stronglyNormalizing_adequate_terminates
+    (concreteSortConfig recursive input) (SortPost input)
+    (recursive_sort_stronglyNormalizing input hfit)
+  apply wasm_smallStep_heap_globals_runtime_store_adequacy.{0}
+    (concreteSortConfig recursive input) (inputHeap input) ∅ (SortPost input)
+  · exact inputHeap_agrees recursive input hfit
+  · exact inputHeap_inBounds recursive input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    iapply twp.to_wp
+    iapply twp_recursiveSortCall input hfit
+    iexact Hresources
+
+theorem loop_sort_partiallyMeets (input : List UInt64) (hfit : Fits input) :
+    SmallStep.PartiallyMeets (concreteSortConfig loop input) (SortPost input) := by
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+    (concreteSortConfig loop input) (inputHeap input) ∅ (SortPost input)
+  · exact inputHeap_agrees loop input hfit
+  · exact inputHeap_inBounds loop input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    iapply twp.to_wp
+    iapply twp_loopSortCall input hfit
+    iexact Hresources
+
+theorem loop_sort_stronglyNormalizing
+    (input : List UInt64) (hfit : Fits input) :
+    Iris.ProgramLogic.StronglyNormalizing
+      (Iris.ProgramLogic.ExprErasedStep (Expr := Expr Unit)
+        (State := MachineStore Unit) (Obs := StepKind))
+      ((concreteSortConfig loop input).expr,
+        (concreteSortConfig loop input).store) := by
+  apply Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_stronglyNormalizing.{0}
+    (concreteSortConfig loop input) (inputHeap input) ∅
+    (fun _values => iprop(True))
+  · exact inputHeap_agrees loop input hfit
+  · exact inputHeap_inBounds loop input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    ihave Hsort := twp_loopSortCall input hfit $$ Hresources
+    iapply twp.mono (fun _values => ?_) $$ Hsort
+    iintro _Hpost
+    itrivial
+
+theorem loop_sort_terminatesWith
+    (input : List UInt64) (hfit : Fits input) :
+    SmallStep.TerminatesWith
+      (concreteSortConfig loop input) (SortPost input) := by
+  apply Wasm.SmallStep.stronglyNormalizing_adequate_terminates
+    (concreteSortConfig loop input) (SortPost input)
+    (loop_sort_stronglyNormalizing input hfit)
+  apply wasm_smallStep_heap_globals_runtime_store_adequacy.{0}
+    (concreteSortConfig loop input) (inputHeap input) ∅ (SortPost input)
+  · exact inputHeap_agrees loop input hfit
+  · exact inputHeap_inBounds loop input hfit
+  · exact globalHeapAgrees_empty _
+  · intro _
+    iintro Hresources
+    iapply twp.to_wp
+    iapply twp_loopSortCall input hfit
+    iexact Hresources
+
+theorem executeSort_host (program : Executable) (fuel : Nat)
+    (initial final : Store Wasm.StdIO.State) (args values : List Value)
+    (hexecute : executeSort program fuel initial args = some (values, final)) :
+    final.host = initial.host := by
+  unfold executeSort at hexecute
+  generalize hresult : (runSteps fuel _).result = result at hexecute
+  cases result <;> simp_all [replaceHost]
+  case success =>
+    have hhost := congrArg
+      (fun concrete : Store Wasm.StdIO.State => concrete.host) hexecute.2
+    simpa [replaceHost] using hhost.symm
+
+private theorem execute_sort_complete_of_terminates
+    (program : Executable) (input : List UInt64)
+    (hterminates : SmallStep.TerminatesWith
+      (concreteSortConfig program input) (SortPost input)) :
+    ∃ fuel values store,
+      executeSort program fuel (afterRead program input) (sortArguments input) =
+        some (values, store) ∧
+      SortPost input values
+        { runtime := { module := program.module, host := Wasm.StdIO.env }
+          wasm := store } := by
+  rcases hterminates with ⟨trace, values, finalStore, hsteps, hpost⟩
+  let store : Store Wasm.StdIO.State :=
+    replaceHost finalStore.wasm (afterRead program input).host
+  refine ⟨trace.length, values, store, ?_, ?_⟩
+  · unfold executeSort
+    change (match
+      (runSteps trace.length (concreteSortConfig program input)).result with
+      | .success values finalStore =>
+          some (values, replaceHost finalStore.wasm
+            (afterRead program input).host)
+      | _ => none) = some (values, store)
+    rw [runSteps_eq_success_of_steps hsteps]
+  · simpa [SortPost, store, replaceHost] using hpost
+
+theorem recursive_execute_sort_complete
+    (input : List UInt64) (hfit : Fits input) :
+    ∃ fuel values store,
+      executeSort recursive fuel (afterRead recursive input) (sortArguments input) =
+        some (values, store) ∧
+      SortPost input values
+        { runtime := { module := recursive.module, host := Wasm.StdIO.env }
+          wasm := store } :=
+  execute_sort_complete_of_terminates recursive input
+    (recursive_sort_terminatesWith input hfit)
+
+theorem loop_execute_sort_complete
+    (input : List UInt64) (hfit : Fits input) :
+    ∃ fuel values store,
+      executeSort loop fuel (afterRead loop input) (sortArguments input) =
+        some (values, store) ∧
+      SortPost input values
+        { runtime := { module := loop.module, host := Wasm.StdIO.env }
+          wasm := store } :=
+  execute_sort_complete_of_terminates loop input
+    (loop_sort_terminatesWith input hfit)
+
+/-! ## Returning the sorted memory as a little-endian stream -/
+
+private theorem readBytes_eight_add (mem : Mem) (offset n : Nat) :
+    mem.readBytes offset (8 + n) =
+      [mem.bytes offset, mem.bytes (offset + 1), mem.bytes (offset + 2),
+       mem.bytes (offset + 3), mem.bytes (offset + 4),
+       mem.bytes (offset + 5), mem.bytes (offset + 6),
+       mem.bytes (offset + 7)] ++ mem.readBytes (offset + 8) n := by
+  unfold Mem.readBytes
+  rw [List.range_add]
+  simp only [List.map_append, List.range_succ, List.range_zero,
+    List.map_cons, List.map_nil, List.nil_append]
+  congr 1
+  simp [Nat.add_assoc]
+
+/-- Deserializing complete little-endian words observes exactly `Mem.words64`. -/
+theorem deserialize_readBytes64 (mem : Mem) (base : UInt32) (count : Nat)
+    (hfit : base.toNat + 8 * count < UInt32.size) :
+    deserialize (mem.readBytes base.toNat (8 * count)) =
+      some (readWordArray64 mem base count) := by
+  induction count generalizing base with
+  | zero => rfl
+  | succ count ih =>
+      rw [show 8 * (count + 1) = 8 + 8 * count by omega]
+      rw [readBytes_eight_add]
+      simp only [List.cons_append, List.nil_append, deserialize]
+      have hbase : (base + 8).toNat = base.toNat + 8 := by
+        apply UInt32.add_ofNat_toNat_noWrap base 8 (by decide)
+        simp only [UInt32.size] at hfit ⊢
+        omega
+      have hdecode : decodeWord
+          (mem.bytes base.toNat) (mem.bytes (base.toNat + 1))
+          (mem.bytes (base.toNat + 2)) (mem.bytes (base.toNat + 3))
+          (mem.bytes (base.toNat + 4)) (mem.bytes (base.toNat + 5))
+          (mem.bytes (base.toNat + 6)) (mem.bytes (base.toNat + 7)) =
+          mem.read64 base := by
+        rfl
+      rw [hdecode]
+      simp only [readWordArray64]
+      change (deserialize (mem.readBytes (base.toNat + 8) (8 * count))).map
+          (mem.read64 base :: ·) =
+        some (mem.read64 base :: readWordArray64 mem (base + 8) count)
+      rw [← hbase, ih]
+      · rfl
+      · rw [hbase]
+        omega
+
+set_option maxRecDepth 10000 in
+theorem run_fits (program : Executable) (fuel : Nat)
+    (input : List UInt64) (hfit : Fits input) :
+    run program fuel (serialize input) =
+      runAfterRead program fuel (UInt32.ofNat (serialize input).length)
+        (afterRead program input) := by
+  unfold run
+  rw [read_fits program input hfit]
+  simp only [Bind.bind, Option.bind]
+
+private theorem correct_of_sort_complete
+    (program : Executable)
+    (hsortComplete : ∀ input, Fits input →
+      ∃ fuel values store,
+        executeSort program fuel (afterRead program input) (sortArguments input) =
+          some (values, store) ∧
+        SortPost input values
+          { runtime := { module := program.module, host := Wasm.StdIO.env }
+            wasm := store }) :
+    Correct program := by
+  intro input hfit
+  rcases hsortComplete input hfit with
+    ⟨fuel, values, afterSort, hsort, output, hperm, hsorted, hread,
+      hcapacity⟩
+  have hhost := executeSort_host program fuel
+    (afterRead program input) afterSort (sortArguments input) values hsort
+  have hbyteLength :
+      (UInt32.ofNat (serialize input).length).toNat = 8 * input.length := by
+    rw [encodedLength_toNat input hfit, serialize_length]
+  have hwriteBound : array.toNat +
+      (UInt32.ofNat (serialize input).length).toNat ≤
+      Wasm.StdIO.byteCapacity afterSort := by
+    simp only [array, UInt32.reduceToNat, Nat.zero_add,
+      Wasm.StdIO.byteCapacity, hbyteLength]
+    exact hcapacity
+  have hwrite := execute_write_bytes program afterSort
+    (UInt32.ofNat (serialize input).length) hwriteBound
+  have houtput : afterSort.host.output = [] := by
+    rw [hhost]
+    rfl
+  have hrun : run program fuel (serialize input) =
+      some (afterSort.mem.readBytes array.toNat (8 * input.length)) := by
+    rw [run_fits program fuel input hfit]
+    unfold runAfterRead
+    rw [probe_afterRead program input]
+    simp only [guard]
+    rw [encodedLength_words input hfit]
+    simp only [Bind.bind, Option.bind, if_true, Pure.pure]
+    unfold sortArguments at hsort
+    rw [hsort]
+    simp only []
+    rw [hwrite]
+    simp only [writtenStore, houtput, List.nil_append, hbyteLength]
+  refine ⟨output, ⟨fuel, ?_⟩, hperm, hsorted⟩
+  unfold runValues
+  rw [hrun]
+  simp only [Option.bind_some]
+  rw [deserialize_readBytes64]
+  · exact congrArg some hread
+  · simp only [array, UInt32.reduceToNat, Nat.zero_add, UInt32.size,
+      Fits, serialize_length, bufferBytes] at hfit ⊢
+    omega
+
+/-- The recursive StdIO selection sort terminates and returns a sorted
+permutation. Its algorithmic proof is the induction proof in `TotalProof`. -/
+theorem recursive_correct : RecursiveCorrect := by
+  exact correct_of_sort_complete recursive recursive_execute_sort_complete
+
+/-- The loop-based StdIO selection sort terminates and returns a sorted
+permutation. Its algorithmic proof uses the inner and outer loop invariants in
+`TotalProof`. -/
+theorem loop_correct : LoopCorrect := by
+  exact correct_of_sort_complete loop loop_execute_sort_complete
+
+end Wasm.Examples.SelectionSort.StdIO

--- a/codelib/CodeLib/Examples/SelectionSort/TotalProof.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/TotalProof.lean
@@ -1,0 +1,1474 @@
+import CodeLib.Examples.SelectionSort.Pure
+import CodeLib.SepLogic.SmallStepAdequacy
+import CodeLib.SepLogic.SmallStepTotalLoop
+
+/-!
+# Total Iris proofs for the two selection-sort implementations
+
+The recursive proof follows recursive calls by induction.  The loop proof
+uses `MinScan` for the inner loop and `OuterInvariant` for the outer loop.
+-/
+
+namespace Wasm.SmallStep
+
+open Iris Iris.ProgramLogic Language.Notation Std
+open Wasm.SepLogic
+
+variable [WasmSmallStepGS hlc]
+local instance instSelectionSortWasmTotalIrisGS :
+    IrisGS_gen hlc (Expr α) WasmHeapGF :=
+  instIrisGS
+variable {s : Stuckness} {E : CoPset}
+variable {Φ : List Value → IProp WasmHeapGF}
+
+/- These i64 rules are the direct total-WP counterparts of `wp_ltUI64`,
+`wp_load64`, and `wp_store64`.  They are kept here because the generic total
+lifting library currently only exposes the i32 memory rules. -/
+
+theorem twp_ltUI64
+    {params localValues values : List Value}
+    {lhs rhs : UInt64} {result : UInt32} {code : Program} {arity : Nat}
+    {remainder : List Value} {controls : List ControlFrame}
+    {calls : List CallFrame}
+    (hresult : result = if lhs < rhs then 1 else 0) :
+    WP (.running
+      ⟨⟨params, localValues, .i32 result :: values⟩,
+        code, arity, remainder, controls, calls⟩ : Expr α) @ s; E [{ Φ }] ⊢
+    WP (.running
+      ⟨⟨params, localValues, .i64 rhs :: .i64 lhs :: values⟩,
+        .ltUI64 :: code, arity, remainder, controls, calls⟩ : Expr α) @ s; E
+      [{ Φ }] :=
+  twp_pureStep _ _ _ (fun _ => Step.ltUI64 hresult)
+
+theorem twp_load64
+    {params localValues values : List Value}
+    {address offset : UInt32} {code : Program} {arity : Nat}
+    {remainder : List Value} {controls : List ControlFrame}
+    {calls : List CallFrame} (word : UInt64)
+    (hnowrap : (address + offset).toNat = address.toNat + offset.toNat)
+    (h1 : ((address + offset) + 1).toNat = (address + offset).toNat + 1)
+    (h2 : ((address + offset) + 2).toNat = (address + offset).toNat + 2)
+    (h3 : ((address + offset) + 3).toNat = (address + offset).toNat + 3)
+    (h4 : ((address + offset) + 4).toNat = (address + offset).toNat + 4)
+    (h5 : ((address + offset) + 5).toNat = (address + offset).toNat + 5)
+    (h6 : ((address + offset) + 6).toNat = (address + offset).toNat + 6)
+    (h7 : ((address + offset) + 7).toNat = (address + offset).toNat + 7) :
+    let current : ThreadState α :=
+      ⟨⟨params, localValues, .i32 address :: values⟩,
+        .load64 offset :: code, arity, remainder, controls, calls⟩
+    let next : ThreadState α :=
+      ⟨⟨params, localValues, .i64 word :: values⟩,
+        code, arity, remainder, controls, calls⟩
+    pointsTo_u64 (address + offset) word -∗
+    (pointsTo_u64 (address + offset) word -∗
+      WP (Expr.running next : Expr α) @ s; E [{ Φ }]) -∗
+      WP (Expr.running current : Expr α) @ s; E [{ Φ }] := by
+  dsimp only
+  iintro Hword Htwp
+  iapply twp_lift_step_no_fork rfl
+  iintro %store %ns %obs %nt Hσ
+  ihave %Hfacts :
+      ⌜store.wasm.mem.read64 (address + offset) = word ∧
+        (address + offset).toNat + 8 ≤ store.wasm.mem.pages * 65536⌝ $$
+      [Hσ Hword]
+  · imod stateInterp_pointsTo_u64_facts store ns obs nt
+      (address + offset) word h1 h2 h3 h4 h5 h6 h7 $$
+      [$Hσ $Hword] with %Hfacts
+    ipureintro
+    exact Hfacts
+  obtain ⟨Hread, HinBounds⟩ := Hfacts
+  have hbound : address.toNat + offset.toNat + 8 ≤
+      store.wasm.mem.pages * 65536 := by
+    simpa only [hnowrap] using HinBounds
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplitr
+  · ipureintro
+    cases s <;> simp only [Stuckness.MaybeReducibleNoObs]
+    exact ⟨.running
+        ⟨⟨params, localValues, .i64 word :: values⟩,
+          code, arity, remainder, controls, calls⟩,
+      store, [], ⟨rfl, .instruction (.load64 offset), rfl,
+        by simpa [Hread] using
+          Step.load64 (α := α) (address := Value.i32 address) rfl hbound⟩⟩
+  iintro %κ %e₂ %store₂ %forks %Hstep
+  rcases Hstep with ⟨hforks, _kind, _hobs, wasmStep⟩
+  change forks = [] at hforks
+  subst forks
+  subst κ
+  have expectedStep : Step
+      ⟨.running
+        ⟨⟨params, localValues, .i32 address :: values⟩,
+          .load64 offset :: code, arity, remainder, controls, calls⟩, store⟩
+      (.instruction (.load64 offset))
+      ⟨.running
+        ⟨⟨params, localValues, .i64 word :: values⟩,
+          code, arity, remainder, controls, calls⟩, store⟩ := by
+    simpa [Hread] using
+      (Step.load64 (α := α) (address := Value.i32 address) rfl hbound)
+  obtain ⟨rfl, hconfig⟩ := step_deterministic expectedStep wasmStep
+  have parts := Config.mk.inj hconfig
+  have hexpr := parts.1
+  have hstore := parts.2
+  simp only at hexpr hstore
+  subst e₂
+  subst store₂
+  imod Hclose
+  imodintro
+  isplit
+  · ipureintro; rfl
+  isplit
+  · ipureintro; rfl
+  isplitl [Hσ]
+  · iexact Hσ
+  · iapply Htwp
+    iexact Hword
+
+theorem twp_store64
+    {params localValues values : List Value}
+    {address offset : UInt32} {value : UInt64}
+    {code : Program} {arity : Nat}
+    {remainder : List Value} {controls : List ControlFrame}
+    {calls : List CallFrame} (oldWord : UInt64)
+    (hnowrap : (address + offset).toNat = address.toNat + offset.toNat)
+    (h1 : ((address + offset) + 1).toNat = (address + offset).toNat + 1)
+    (h2 : ((address + offset) + 2).toNat = (address + offset).toNat + 2)
+    (h3 : ((address + offset) + 3).toNat = (address + offset).toNat + 3)
+    (h4 : ((address + offset) + 4).toNat = (address + offset).toNat + 4)
+    (h5 : ((address + offset) + 5).toNat = (address + offset).toNat + 5)
+    (h6 : ((address + offset) + 6).toNat = (address + offset).toNat + 6)
+    (h7 : ((address + offset) + 7).toNat = (address + offset).toNat + 7) :
+    let current : ThreadState α :=
+      ⟨⟨params, localValues, .i64 value :: .i32 address :: values⟩,
+        .store64 offset :: code, arity, remainder, controls, calls⟩
+    let next : ThreadState α :=
+      ⟨⟨params, localValues, values⟩,
+        code, arity, remainder, controls, calls⟩
+    pointsTo_u64 (address + offset) oldWord -∗
+    (pointsTo_u64 (address + offset) value -∗
+      WP (Expr.running next : Expr α) @ s; E [{ Φ }]) -∗
+      WP (Expr.running current : Expr α) @ s; E [{ Φ }] := by
+  dsimp only
+  iintro Hword Htwp
+  iapply twp_lift_step_no_fork rfl
+  iintro %store %ns %obs %nt Hσ
+  ihave %Hfacts :
+      ⌜store.wasm.mem.read64 (address + offset) = oldWord ∧
+        (address + offset).toNat + 8 ≤ store.wasm.mem.pages * 65536⌝ $$
+      [Hσ Hword]
+  · imod stateInterp_pointsTo_u64_facts store ns obs nt
+      (address + offset) oldWord h1 h2 h3 h4 h5 h6 h7 $$
+      [$Hσ $Hword] with %Hfacts
+    ipureintro
+    exact Hfacts
+  have hbound : address.toNat + offset.toNat + 8 ≤
+      store.wasm.mem.pages * 65536 := by
+    simpa only [hnowrap] using Hfacts.2
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplitr
+  · ipureintro
+    cases s <;> simp only [Stuckness.MaybeReducibleNoObs]
+    exact ⟨.running
+        ⟨⟨params, localValues, values⟩,
+          code, arity, remainder, controls, calls⟩,
+      { store with wasm :=
+          { store.wasm with
+            mem := store.wasm.mem.write64 (address + offset) value } },
+      [], ⟨rfl, .instruction (.store64 offset), rfl,
+        Step.store64 (α := α) (address := Value.i32 address) rfl hbound⟩⟩
+  iintro %κ %e₂ %store₂ %forks %Hstep
+  rcases Hstep with ⟨hforks, _kind, _hobs, wasmStep⟩
+  change forks = [] at hforks
+  subst forks
+  subst κ
+  have expectedStep : Step
+      ⟨.running
+        ⟨⟨params, localValues, .i64 value :: .i32 address :: values⟩,
+          .store64 offset :: code, arity, remainder, controls, calls⟩, store⟩
+      (.instruction (.store64 offset))
+      ⟨.running
+        ⟨⟨params, localValues, values⟩,
+          code, arity, remainder, controls, calls⟩,
+        { store with wasm :=
+            { store.wasm with
+              mem := store.wasm.mem.write64 (address + offset) value } }⟩ :=
+    Step.store64 (α := α) (address := Value.i32 address) rfl hbound
+  obtain ⟨rfl, hconfig⟩ := step_deterministic expectedStep wasmStep
+  have parts := Config.mk.inj hconfig
+  have hexpr := parts.1
+  have hstore := parts.2
+  simp only at hexpr hstore
+  subst e₂
+  subst store₂
+  imod stateInterp_store64 store ns obs nt
+      (address + offset) oldWord value h1 h2 h3 h4 h5 h6 h7 Hfacts.2 $$
+      [$Hσ $Hword] with ⟨Hσ, Hword⟩
+  imod Hclose
+  imodintro
+  isplit
+  · ipureintro; rfl
+  isplit
+  · ipureintro; rfl
+  isplitl [Hσ]
+  · iexact Hσ
+  · iapply Htwp
+    iexact Hword
+
+end Wasm.SmallStep
+
+namespace Wasm.Examples.SelectionSort
+
+open Wasm
+open Iris Iris.ProgramLogic Language.Notation Std
+open Wasm.SepLogic
+open Wasm.SmallStep
+
+private theorem arrayAddress64_toNat (base : UInt32) {index length : Nat}
+    (hfit : base.toNat + 8 * length ≤ UInt32.size)
+    (hindex : index < length) :
+    (base + UInt32.ofNat index * 8).toNat = base.toNat + 8 * index := by
+  have hi : index < UInt32.size := by omega
+  have hp : index * 8 < UInt32.size := by omega
+  rw [UInt32.toNat_add, UInt32.toNat_mul, UInt32.toNat_ofNat_of_lt' hi]
+  have height : (8 : UInt32).toNat = 8 := by decide
+  rw [height, Nat.mod_eq_of_lt hp, Nat.mul_comm index 8]
+  apply Nat.mod_eq_of_lt
+  simp only [UInt32.size] at hfit ⊢
+  omega
+
+theorem twp_address64
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex elementIndex : Nat} {base element : UInt32}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (helement : (⟨params, localValues, stack⟩ : Locals).get elementIndex =
+      some (.i32 element)) :
+    WP (.running
+      ⟨⟨params, localValues, .i32 (8 * element + base) :: stack⟩,
+        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E [{ Φ }] ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        addressAt baseIndex elementIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  iintro Hwp
+  simp only [addressAt, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.twp_localGet hbase
+  iapply Wasm.SmallStep.twp_localGet (by simpa using helement)
+  iapply Wasm.SmallStep.twp_const
+  iapply Wasm.SmallStep.twp_mul
+  iapply Wasm.SmallStep.twp_add
+  iexact Hwp
+
+private theorem address64_steps (address : UInt32)
+    (hroom : address.toNat + 8 ≤ UInt32.size) :
+    ((address + 1).toNat = address.toNat + 1) ∧
+    ((address + 2).toNat = address.toNat + 2) ∧
+    ((address + 3).toNat = address.toNat + 3) ∧
+    ((address + 4).toNat = address.toNat + 4) ∧
+    ((address + 5).toNat = address.toNat + 5) ∧
+    ((address + 6).toNat = address.toNat + 6) ∧
+    ((address + 7).toNat = address.toNat + 7) := by
+  have hroom' : address.toNat + 8 ≤ 4294967296 := by
+    simpa only [UInt32.size] using hroom
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 1 (by decide) (by omega)
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 2 (by decide) (by omega)
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 3 (by decide) (by omega)
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 4 (by decide) (by omega)
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 5 (by decide) (by omega)
+  constructor
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 6 (by decide) (by omega)
+  · simpa using UInt32.add_ofNat_toNat_noWrap address 7 (by decide) (by omega)
+
+set_option maxHeartbeats 2000000 in
+theorem twp_loadAt64
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex elementIndex : Nat} {base : UInt32}
+    {input : List UInt64} {k : Nat} (hk : k < input.length)
+    (hfit : base.toNat + 8 * input.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex =
+      some (.i32 base))
+    (helement : (⟨params, localValues, stack⟩ : Locals).get elementIndex =
+      some (.i32 (UInt32.ofNat k))) :
+    array64At base input ∗
+      (array64At base input -∗
+        WP (.running
+          ⟨⟨params, localValues, .i64 input[k] :: stack⟩,
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running
+      ⟨⟨params, localValues, stack⟩,
+        loadAt baseIndex elementIndex ++ code,
+        arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  let address : UInt32 := base + 8 * UInt32.ofNat k
+  have hslot : address.toNat = base.toNat + 8 * k := by
+    dsimp [address]
+    simpa [UInt32.mul_comm] using arrayAddress64_toNat base hfit hk
+  have hroom : address.toNat + 8 ≤ UInt32.size := by rw [hslot]; omega
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7⟩ := address64_steps address hroom
+  iintro ⟨Harray, Hcont⟩
+  ihave Hfocus := array64At_get base input k hk $$ Harray
+  icases Hfocus with ⟨Hword, Hclose⟩
+  simp only [loadAt, List.append_assoc, List.cons_append, List.nil_append]
+  iapply twp_address64 hbase helement
+  have haddress : 8 * UInt32.ofNat k + base = address := by
+    dsimp [address]; exact UInt32.add_comm _ _
+  rw [haddress]
+  ihave Hword' : pointsTo_u64 (address + 0) input[k] $$ [Hword]
+  · rw [UInt32.add_zero]
+    iexact Hword
+  iapply Wasm.SmallStep.twp_load64 (address := address) (offset := 0)
+    input[k] (by simp)
+    (by simpa using h1) (by simpa using h2) (by simpa using h3)
+    (by simpa using h4) (by simpa using h5) (by simpa using h6)
+    (by simpa using h7) $$ Hword'
+  iintro Hword
+  iapply Hcont
+  iapply Hclose
+  rw [UInt32.add_zero]
+  iexact Hword
+
+private theorem twp_store64_cell
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {address : UInt32} {oldWord newWord : UInt64}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hroom : address.toNat + 8 ≤ UInt32.size) :
+    pointsTo_u64 address oldWord ∗
+      (pointsTo_u64 address newWord -∗
+        WP (.running
+          ⟨⟨params, localValues, stack⟩,
+            code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running
+      ⟨⟨params, localValues, .i64 newWord :: .i32 address :: stack⟩,
+        .store64 0 :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7⟩ := address64_steps address hroom
+  iintro ⟨Hword, Hcont⟩
+  ihave Hword' : pointsTo_u64 (address + 0) oldWord $$ [Hword]
+  · rw [UInt32.add_zero]
+    iexact Hword
+  iapply Wasm.SmallStep.twp_store64 (address := address) (offset := 0)
+    (value := newWord) oldWord (by simp)
+    (by simpa using h1) (by simpa using h2) (by simpa using h3)
+    (by simpa using h4) (by simpa using h5) (by simpa using h6)
+    (by simpa using h7) $$ Hword'
+  iintro Hword
+  iapply Hcont
+  rw [UInt32.add_zero]
+  iexact Hword
+
+set_option maxHeartbeats 4000000 in
+theorem twp_swapAt64
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    {params localValues stack : List Value}
+    {baseIndex aIndex bIndex tmpIndex : Nat}
+    {base : UInt32} {input : List UInt64} {a b : Nat}
+    {updated : Locals}
+    (ha : a < input.length) (hb : b < input.length)
+    (hfit : base.toNat + 8 * input.length ≤ UInt32.size)
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame}
+    (hbase : (⟨params, localValues, stack⟩ : Locals).get baseIndex = some (.i32 base))
+    (ha_local : (⟨params, localValues, stack⟩ : Locals).get aIndex =
+      some (.i32 (UInt32.ofNat a)))
+    (htmp_set : (⟨params, localValues, .i64 input[a] :: stack⟩ : Locals).set?
+      tmpIndex (.i64 input[a]) = some updated)
+    (hbase_after : updated.get baseIndex = some (.i32 base))
+    (ha_after : updated.get aIndex = some (.i32 (UInt32.ofNat a)))
+    (hb_after : updated.get bIndex = some (.i32 (UInt32.ofNat b)))
+    (htmp_after : updated.get tmpIndex = some (.i64 input[a])) :
+    array64At base input ∗
+      (array64At base (swapElems input a b) -∗
+        WP (.running ⟨{ updated with values := stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨⟨params, localValues, stack⟩,
+      swapAt baseIndex aIndex bIndex tmpIndex ++ code,
+      arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  let addrA : UInt32 := 8 * UInt32.ofNat a + base
+  let addrB : UInt32 := 8 * UInt32.ofNat b + base
+  have hslotA : addrA.toNat = base.toNat + 8 * a := by
+    dsimp [addrA]; rw [UInt32.add_comm]
+    simpa [UInt32.mul_comm] using arrayAddress64_toNat base hfit ha
+  have hslotB : addrB.toNat = base.toNat + 8 * b := by
+    dsimp [addrB]; rw [UInt32.add_comm]
+    simpa [UInt32.mul_comm] using arrayAddress64_toNat base hfit hb
+  have hroomA : addrA.toNat + 8 ≤ UInt32.size := by rw [hslotA]; omega
+  have hroomB : addrB.toNat + 8 ≤ UInt32.size := by rw [hslotB]; omega
+  have hswap : swapElems input a b =
+      (input.set a input[b]).set b input[a] := by
+    unfold swapElems
+    rw [getElem!_pos input b hb, getElem!_pos input a ha]
+  iintro ⟨Harray, Hcont⟩
+  simp only [swapAt, storeAt, List.append_assoc, List.cons_append, List.nil_append]
+  iapply twp_loadAt64 ha hfit hbase ha_local
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  iapply Wasm.SmallStep.twp_localSet htmp_set
+  iapply twp_address64 (by simpa using hbase_after) (by simpa using ha_after)
+  iapply twp_loadAt64 hb hfit (by simpa using hbase_after) (by simpa using hb_after)
+  isplitl [Harray]
+  · iexact Harray
+  iintro Harray
+  ihave HfocusA := array64At_set base input a input[b] ha $$ Harray
+  icases HfocusA with ⟨HcellA, HcloseA⟩
+  iapply twp_store64_cell hroomA
+  isplitl [HcellA]
+  · dsimp [addrA]
+    rw [UInt32.add_comm]
+    iexact HcellA
+  iintro HcellA
+  ihave Harray2 : array64At base (input.set a input[b]) $$ [HcellA HcloseA]
+  · iapply HcloseA
+    dsimp [addrA]
+    rw [UInt32.add_comm]
+    iexact HcellA
+  iapply twp_address64 (by simpa using hbase_after) (by simpa using hb_after)
+  iapply Wasm.SmallStep.twp_localGet (by simpa using htmp_after)
+  have hb2 : b < (input.set a input[b]).length := by simpa
+  ihave HfocusB := array64At_set base (input.set a input[b]) b input[a] hb2 $$ Harray2
+  icases HfocusB with ⟨HcellB, HcloseB⟩
+  iapply twp_store64_cell hroomB
+  isplitl [HcellB]
+  · dsimp [addrB]
+    rw [UInt32.add_comm]
+    iexact HcellB
+  iintro HcellB
+  iapply Hcont
+  rw [hswap]
+  iapply HcloseB
+  dsimp [addrB]
+  rw [UInt32.add_comm]
+  iexact HcellB
+
+def findMinLocals (arr : UInt32) (length best scan : Nat)
+    (stack : List Value) : Locals :=
+  ⟨[.i32 arr, .i32 (UInt32.ofNat length), .i32 (UInt32.ofNat best),
+      .i32 (UInt32.ofNat scan)], [], stack⟩
+
+private theorem nat_lt_u32_iff {left right : Nat}
+    (hl : left < UInt32.size) (hr : right < UInt32.size) :
+    (UInt32.ofNat left < UInt32.ofNat right) ↔ left < right := by
+  change (UInt32.ofNat left).toNat < (UInt32.ofNat right).toNat ↔ _
+  rw [UInt32.toNat_ofNat_of_lt' hl, UInt32.toNat_ofNat_of_lt' hr]
+
+set_option maxHeartbeats 8000000 in
+private theorem twp_findMin_aux
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (findIndex : Nat)
+    (himports : ¬findIndex < runtimeModule.imports.length)
+    (hfunction : runtimeModule.funcs[findIndex - runtimeModule.imports.length]? =
+      some (findMinRecursiveFunction findIndex))
+    (arr : UInt32) (input : List UInt64) (start best scan : Nat)
+    (hinv : MinScan input start best scan)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    (n : Nat) (hn : input.length - scan ≤ n)
+    {callerLocals : Locals} {stack : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    runtimeModuleOwn runtimeModule ∗ array64At arr input ∗
+      (∀ finalBest : Nat,
+        ⌜start ≤ finalBest ∧ finalBest < input.length ∧
+          ∀ k, start ≤ k → k < input.length →
+            input[finalBest]! ≤ input[k]!⌝ -∗
+        runtimeModuleOwn runtimeModule -∗ array64At arr input -∗
+        WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat finalBest) :: stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨{ callerLocals with values :=
+        (.i32 (UInt32.ofNat scan) :: .i32 (UInt32.ofNat best) ::
+        .i32 (UInt32.ofNat input.length) :: .i32 arr :: stack) },
+      .call findIndex :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  induction n generalizing best scan callerLocals stack code arity remainder controls calls with
+  | zero =>
+      have hscan : input.length ≤ scan := by omega
+      iintro ⟨Hruntime, Harray, Hcont⟩
+      ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
+      · iexact Hruntime
+      iapply Wasm.SmallStep.twp_call runtimeModule findIndex
+        (findMinRecursiveFunction findIndex) himports hfunction $$ HruntimeLater
+      iintro Hruntime
+      simp [findMinRecursiveFunction, Function.toLocals, Function.numParams]
+      simp only [findMinRecursiveBody, List.cons_append, List.nil_append,
+        List.append_assoc]
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_localGet rfl
+      have hlengthSize : input.length < UInt32.size := by
+        simp only [UInt32.size] at hfit ⊢; omega
+      have hscanSize : scan < UInt32.size := by
+        have := hinv.2.2.1
+        omega
+      have hnotlt : ¬ UInt32.ofNat scan < UInt32.ofNat input.length :=
+        mt (nat_lt_u32_iff hscanSize hlengthSize).mp (by omega)
+      iapply Wasm.SmallStep.twp_ltU rfl
+      simp only [if_neg hnotlt]
+      iapply Wasm.SmallStep.twp_eqz rfl
+      simp only
+      iapply Wasm.SmallStep.twp_iff
+        (selectedBody := [.localGet 2, .ret]) (by simp)
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_returnFromCallExplicit
+      simp only [List.take_succ_cons, List.take_zero, List.singleton_append]
+      have hpure : start ≤ best ∧ best < input.length ∧
+          ∀ k, start ≤ k → k < input.length →
+            input[best]?.getD default ≤ input[k]?.getD default := by
+        refine ⟨hinv.1,
+          _root_.lt_of_lt_of_le hinv.2.1 hinv.2.2.1, ?_⟩
+        intro k hk hklen
+        simpa only [List.getElem!_eq_getElem?_getD] using
+          hinv.2.2.2 k hk (by omega)
+      iapply Hcont $$ %best %hpure Hruntime Harray
+  | succ n ih =>
+      iintro ⟨Hruntime, Harray, Hcont⟩
+      let callerFrame : CallFrame :=
+        { locals := { callerLocals with values := stack }
+          continuation := code
+          resultArity := arity
+          callerRemainder := remainder
+          control := controls }
+      ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
+      · iexact Hruntime
+      iapply Wasm.SmallStep.twp_call runtimeModule findIndex
+        (findMinRecursiveFunction findIndex) himports hfunction $$ HruntimeLater
+      iintro Hruntime
+      simp [findMinRecursiveFunction, Function.toLocals, Function.numParams]
+      simp only [findMinRecursiveBody, List.cons_append, List.nil_append,
+        List.append_assoc]
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_localGet rfl
+      have hlengthSize : input.length < UInt32.size := by
+        simp only [UInt32.size] at hfit ⊢; omega
+      have hscanSize : scan < UInt32.size := by
+        by_cases hs : scan < input.length
+        · omega
+        · have := hinv.2.2.1
+          omega
+      have hcmp := nat_lt_u32_iff hscanSize hlengthSize
+      iapply Wasm.SmallStep.twp_ltU rfl
+      by_cases hs : scan < input.length
+      · simp only [if_pos (hcmp.mpr hs)]
+        iapply Wasm.SmallStep.twp_eqz rfl
+        simp only [if_neg (by decide : ¬(1 : UInt32) = 0)]
+        iapply Wasm.SmallStep.twp_iff (selectedBody := []) (by simp)
+        iapply Wasm.SmallStep.twp_exitControl rfl
+        simp only [List.take_zero, List.nil_append, List.drop_zero]
+        have hbestLen : best < input.length :=
+          _root_.lt_of_lt_of_le hinv.2.1 hinv.2.2.1
+        iapply twp_loadAt64 hs hfit rfl rfl
+        isplitl [Harray]
+        · iexact Harray
+        iintro Harray
+        iapply twp_loadAt64 hbestLen hfit rfl rfl
+        isplitl [Harray]
+        · iexact Harray
+        iintro Harray
+        iapply Wasm.SmallStep.twp_ltUI64 rfl
+        by_cases hlt : input[scan] < input[best]
+        · simp only [if_pos hlt]
+          iapply Wasm.SmallStep.twp_iff rfl
+          simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localSet rfl
+          iapply Wasm.SmallStep.twp_exitControl rfl
+          simp only [List.take_zero, List.nil_append, List.drop_zero]
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_const
+          iapply Wasm.SmallStep.twp_add
+          rw [show 1 + UInt32.ofNat scan = UInt32.ofNat (scan + 1) by
+            rw [UInt32.add_comm]
+            change UInt32.ofNat scan + UInt32.ofNat 1 = _
+            rw [← UInt32.ofNat_add]]
+          simp only [List.set_cons_succ, List.set_cons_zero]
+          have hnext : MinScan input start scan (scan + 1) := by
+            have hstep := MinScan.step input hinv hs
+            have hlt' : input[scan]! < input[best]! := by
+              rw [getElem!_pos input scan hs, getElem!_pos input best hbestLen]
+              exact hlt
+            rw [if_pos hlt'] at hstep
+            exact hstep
+          iapply ih scan (scan + 1)
+            hnext
+            (by omega)
+            (callerLocals :=
+              ⟨[.i32 arr, .i32 (UInt32.ofNat input.length),
+                .i32 (UInt32.ofNat scan), .i32 (UInt32.ofNat scan)], [], []⟩)
+            (stack := []) (code := [.ret]) (arity := 1) (remainder := [])
+            (controls := [])
+            (calls := callerFrame :: calls)
+          isplitl [Hruntime]
+          · iexact Hruntime
+          isplitl [Harray]
+          · iexact Harray
+          iintro %finalBest %hpure Hruntime Harray
+          iapply Wasm.SmallStep.twp_returnFromCallExplicit
+          simp only [List.take_succ_cons, List.take_zero, List.nil_append,
+            List.cons_append]
+          have hpure' : start ≤ finalBest ∧ finalBest < input.length ∧
+              ∀ k, start ≤ k → k < input.length →
+                input[finalBest]?.getD default ≤ input[k]?.getD default := by
+            simpa only [List.getElem!_eq_getElem?_getD] using hpure
+          iapply Hcont $$ %finalBest %hpure' Hruntime Harray
+        · simp only [if_neg hlt]
+          iapply Wasm.SmallStep.twp_iff rfl
+          simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
+          iapply Wasm.SmallStep.twp_exitControl rfl
+          simp only [List.take_zero, List.nil_append, List.drop_zero]
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_localGet rfl
+          iapply Wasm.SmallStep.twp_const
+          iapply Wasm.SmallStep.twp_add
+          rw [show 1 + UInt32.ofNat scan = UInt32.ofNat (scan + 1) by
+            rw [UInt32.add_comm]
+            change UInt32.ofNat scan + UInt32.ofNat 1 = _
+            rw [← UInt32.ofNat_add]]
+          have hnext : MinScan input start best (scan + 1) := by
+            have hstep := MinScan.step input hinv hs
+            have hlt' : ¬ input[scan]! < input[best]! := by
+              rw [getElem!_pos input scan hs, getElem!_pos input best hbestLen]
+              exact hlt
+            rw [if_neg hlt'] at hstep
+            exact hstep
+          iapply ih best (scan + 1)
+            hnext
+            (by omega)
+            (callerLocals :=
+              ⟨[.i32 arr, .i32 (UInt32.ofNat input.length),
+                .i32 (UInt32.ofNat best), .i32 (UInt32.ofNat scan)], [], []⟩)
+            (stack := []) (code := [.ret]) (arity := 1) (remainder := [])
+            (controls := [])
+            (calls := callerFrame :: calls)
+          isplitl [Hruntime]
+          · iexact Hruntime
+          isplitl [Harray]
+          · iexact Harray
+          iintro %finalBest %hpure Hruntime Harray
+          iapply Wasm.SmallStep.twp_returnFromCallExplicit
+          simp only [List.take_succ_cons, List.take_zero, List.nil_append,
+            List.cons_append]
+          have hpure' : start ≤ finalBest ∧ finalBest < input.length ∧
+              ∀ k, start ≤ k → k < input.length →
+                input[finalBest]?.getD default ≤ input[k]?.getD default := by
+            simpa only [List.getElem!_eq_getElem?_getD] using hpure
+          iapply Hcont $$ %finalBest %hpure' Hruntime Harray
+      · have hnotlt := mt hcmp.mp hs
+        simp only [if_neg hnotlt]
+        iapply Wasm.SmallStep.twp_eqz rfl
+        simp only
+        iapply Wasm.SmallStep.twp_iff
+          (selectedBody := [.localGet 2, .ret]) (by simp)
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_returnFromCallExplicit
+        simp only [List.take_succ_cons, List.take_zero,
+          List.singleton_append]
+        have hpure : start ≤ best ∧ best < input.length ∧
+            ∀ k, start ≤ k → k < input.length →
+              input[best]?.getD default ≤ input[k]?.getD default := by
+          refine ⟨hinv.1,
+            _root_.lt_of_lt_of_le hinv.2.1 hinv.2.2.1, ?_⟩
+          intro k hk hklen
+          simpa only [List.getElem!_eq_getElem?_getD] using
+            hinv.2.2.2 k hk (by omega)
+        iapply Hcont $$ %best %hpure Hruntime Harray
+
+theorem twp_findMin
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (findIndex : Nat)
+    (himports : ¬findIndex < runtimeModule.imports.length)
+    (hfunction : runtimeModule.funcs[findIndex - runtimeModule.imports.length]? =
+      some (findMinRecursiveFunction findIndex))
+    (arr : UInt32) (input : List UInt64) (start best scan : Nat)
+    (hinv : MinScan input start best scan)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    {callerLocals : Locals} {stack : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    runtimeModuleOwn runtimeModule ∗ array64At arr input ∗
+      (∀ finalBest : Nat,
+        ⌜start ≤ finalBest ∧ finalBest < input.length ∧
+          ∀ k, start ≤ k → k < input.length →
+            input[finalBest]! ≤ input[k]!⌝ -∗
+        runtimeModuleOwn runtimeModule -∗ array64At arr input -∗
+        WP (.running ⟨{ callerLocals with
+          values := .i32 (UInt32.ofNat finalBest) :: stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨{ callerLocals with values :=
+        (.i32 (UInt32.ofNat scan) :: .i32 (UInt32.ofNat best) ::
+        .i32 (UInt32.ofNat input.length) :: .i32 arr :: stack) },
+      .call findIndex :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] :=
+  twp_findMin_aux runtimeModule findIndex himports hfunction arr input
+    start best scan hinv hfit input.length (Nat.sub_le _ _)
+
+private theorem sorted_of_length_lt_two (values : List UInt64)
+    (h : values.length < 2) : Sorted values := by
+  match values with
+  | [] => exact List.Pairwise.nil
+  | [value] => exact List.pairwise_singleton _ _
+  | _ :: _ :: _ =>
+      simp only [List.length_cons] at h
+      omega
+
+set_option maxHeartbeats 12000000 in
+set_option maxRecDepth 10000 in
+private theorem twp_recursiveSort_aux
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (findIndex sortIndex : Nat)
+    (himportsFind : ¬findIndex < runtimeModule.imports.length)
+    (hfunctionFind : runtimeModule.funcs[findIndex - runtimeModule.imports.length]? =
+      some (findMinRecursiveFunction findIndex))
+    (himportsSort : ¬sortIndex < runtimeModule.imports.length)
+    (hfunctionSort : runtimeModule.funcs[sortIndex - runtimeModule.imports.length]? =
+      some (recursiveSelectionSortFunction findIndex sortIndex))
+    (arr : UInt32) (input : List UInt64)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    (n : Nat) (hn : input.length ≤ n)
+    {callerLocals : Locals} {stack : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    runtimeModuleOwn runtimeModule ∗ array64At arr input ∗
+      (∀ output : List UInt64,
+        ⌜List.Perm input output ∧ Sorted output⌝ -∗
+        runtimeModuleOwn runtimeModule -∗ array64At arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨{ callerLocals with values :=
+        (.i32 (UInt32.ofNat input.length) :: .i32 arr :: stack) },
+      .call sortIndex :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  induction n generalizing arr input callerLocals stack code arity remainder controls calls with
+  | zero =>
+      have hinput : input = [] := by
+        apply List.eq_nil_of_length_eq_zero
+        omega
+      subst input
+      iintro ⟨Hruntime, Harray, Hcont⟩
+      ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
+      · iexact Hruntime
+      iapply Wasm.SmallStep.twp_call runtimeModule sortIndex
+        (recursiveSelectionSortFunction findIndex sortIndex)
+        himportsSort hfunctionSort $$ HruntimeLater
+      iintro Hruntime
+      simp [recursiveSelectionSortFunction, Function.toLocals,
+        Function.numParams, ValueType.zero]
+      simp only [recursiveSelectionSortBody, List.cons_append, List.nil_append]
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_const
+      iapply Wasm.SmallStep.twp_ltU (result := 1) (by simp)
+      iapply Wasm.SmallStep.twp_iff (selectedBody := [.ret]) (by simp)
+      iapply Wasm.SmallStep.twp_returnFromCallExplicit
+      simp only [List.take_zero, List.nil_append]
+      have hpure : ([] : List UInt64) = [] ∧ Sorted [] :=
+        ⟨rfl, List.Pairwise.nil⟩
+      iapply Hcont $$ %([] : List UInt64) %hpure Hruntime Harray
+  | succ n ih =>
+      iintro ⟨Hruntime, Harray, Hcont⟩
+      let callerFrame : CallFrame :=
+        { locals := { callerLocals with values := stack }
+          continuation := code
+          resultArity := arity
+          callerRemainder := remainder
+          control := controls }
+      ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
+      · iexact Hruntime
+      iapply Wasm.SmallStep.twp_call runtimeModule sortIndex
+        (recursiveSelectionSortFunction findIndex sortIndex)
+        himportsSort hfunctionSort $$ HruntimeLater
+      iintro Hruntime
+      simp [recursiveSelectionSortFunction, Function.toLocals,
+        Function.numParams, ValueType.zero]
+      simp only [recursiveSelectionSortBody, List.cons_append, List.nil_append]
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_const
+      have hlengthSize : input.length < UInt32.size := by
+        simp only [UInt32.size] at hfit ⊢; omega
+      have htwoSize : 2 < UInt32.size := by decide
+      have hcmp := nat_lt_u32_iff hlengthSize htwoSize
+      by_cases hbase : input.length < 2
+      · iapply Wasm.SmallStep.twp_ltU (result := 1) (by
+          have hlt : UInt32.ofNat input.length < (2 : UInt32) := by
+            simpa using hcmp.mpr hbase
+          simp [hlt])
+        iapply Wasm.SmallStep.twp_iff
+          (selectedBody := [.ret]) (by simp)
+        iapply Wasm.SmallStep.twp_returnFromCallExplicit
+        simp only [List.take_zero, List.nil_append]
+        have hpure : List.Perm input input ∧ Sorted input :=
+          ⟨List.Perm.refl _, sorted_of_length_lt_two input hbase⟩
+        iapply Hcont $$ %input %hpure Hruntime Harray
+      · have hnotlt := mt hcmp.mp hbase
+        iapply Wasm.SmallStep.twp_ltU (result := 0) (by
+          have hnlt : ¬UInt32.ofNat input.length < (2 : UInt32) := by
+            simpa using hnotlt
+          simp [hnlt])
+        iapply Wasm.SmallStep.twp_iff (selectedBody := []) (by simp)
+        iapply Wasm.SmallStep.twp_exitControl rfl
+        simp only [List.take_zero, List.nil_append, List.drop_zero]
+        have hlen : 0 < input.length := by omega
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_const
+        iapply Wasm.SmallStep.twp_const
+        iapply twp_findMin runtimeModule findIndex himportsFind hfunctionFind
+          arr input 0 0 1 (minScan_start input hlen) hfit
+          (callerLocals :=
+            { params := [.i32 arr, .i32 (UInt32.ofNat input.length)]
+              locals := [.i32 0, .i32 0, .i64 0]
+              values := [] })
+          (stack := [])
+          (code := Instruction.localSet 2 :: (swapAt 0 3 2 4 ++
+            [Instruction.localGet 0, Instruction.const 8, Instruction.add,
+              Instruction.localGet 1, Instruction.const 1, Instruction.sub,
+              Instruction.call sortIndex, Instruction.ret]))
+          (arity := 0) (remainder := []) (controls := [])
+          (calls := callerFrame :: calls) (s := s) (E := E) (Φ := Φ)
+        isplitl [Hruntime]
+        · iexact Hruntime
+        isplitl [Harray]
+        · iexact Harray
+        iintro %best %hminimum Hruntime Harray
+        have hbest : best < input.length := hminimum.2.1
+        iapply Wasm.SmallStep.twp_localSet rfl
+        simp only
+        iapply twp_swapAt64 (a := 0) (b := best)
+          hlen hbest hfit rfl rfl rfl rfl rfl rfl rfl
+        isplitl [Harray]
+        · iexact Harray
+        iintro Hupdated
+        let updated := swapElems input 0 best
+        have hupdatedLength : updated.length = input.length :=
+          swapElems_length input 0 best
+        have hupdatedNonempty : 0 < updated.length := by omega
+        have hdecomp : updated = updated[0]! :: updated.drop 1 := by
+          cases hUpdated : updated with
+          | nil =>
+              have hlength := congrArg List.length hUpdated
+              simp only [List.length_nil] at hlength
+              omega
+          | cons head tail => simp
+        ihave Hupdated' :
+            array64At arr (updated[0]! :: updated.drop 1) $$ [Hupdated]
+        · rw [← hdecomp]
+          iexact Hupdated
+        isimp only [array64At] at Hupdated'
+        icases Hupdated' with ⟨Hhead, Htail⟩
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_const
+        iapply Wasm.SmallStep.twp_add
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_const
+        iapply Wasm.SmallStep.twp_sub
+        have harrStep : (arr + 8).toNat = arr.toNat + 8 := by
+          simpa using UInt32.add_ofNat_toNat_noWrap arr 8 (by decide) (by
+            simp only [UInt32.size] at hfit ⊢
+            omega)
+        have htailLength : (updated.drop 1).length = input.length - 1 := by
+          simp only [List.length_drop, hupdatedLength]
+        have hfitTail : (arr + 8).toNat + 8 * (updated.drop 1).length ≤
+            UInt32.size := by
+          rw [harrStep, htailLength]
+          omega
+        have hpred : UInt32.ofNat input.length - 1 =
+            UInt32.ofNat (input.length - 1) := by
+          apply UInt32.toNat.inj
+          rw [UInt32.toNat_sub, show (1 : UInt32).toNat = 1 from rfl,
+            UInt32.toNat_ofNat_of_lt' hlengthSize,
+            UInt32.toNat_ofNat_of_lt' (by omega : input.length - 1 < UInt32.size)]
+          have hbound := (UInt32.ofNat input.length).toNat_lt
+          rw [UInt32.toNat_ofNat_of_lt' hlengthSize] at hbound
+          omega
+        rw [hpred]
+        simp only [List.length_cons, List.length_nil, Nat.reduceAdd,
+          Nat.reduceSub, List.set]
+        rw [UInt32.add_comm 8 arr, ← htailLength]
+        iapply ih (arr + 8) (updated.drop 1) hfitTail (by
+          rw [htailLength]
+          omega)
+          (callerLocals :=
+            { params := [.i32 arr, .i32 (UInt32.ofNat input.length)]
+              locals := [.i32 (UInt32.ofNat best), .i32 0, .i64 input[0]]
+              values := [] })
+          (stack := []) (code := [.ret]) (arity := 0) (remainder := [])
+          (controls := []) (calls := callerFrame :: calls)
+        isplitl [Hruntime]
+        · iexact Hruntime
+        isplitl [Htail]
+        · iexact Htail
+        iintro %tailOutput %htailPure Hruntime HtailOutput
+        iapply Wasm.SmallStep.twp_returnFromCallExplicit
+        simp only [List.take_zero, List.nil_append]
+        let output := updated[0]! :: tailOutput
+        have hpure : List.Perm input output ∧ Sorted output := by
+          dsimp only [output, updated]
+          apply recursive_compose hlen hbest
+          · intro k hk
+            exact hminimum.2.2 k (Nat.zero_le _) hk
+          · simpa only [updated] using htailPure.1
+          · exact htailPure.2
+        ihave Houtput : array64At arr output $$ [Hhead HtailOutput]
+        · dsimp only [output]
+          simp only [array64At]
+          isplitl [Hhead]
+          · iexact Hhead
+          · iexact HtailOutput
+        iapply Hcont $$ %output %hpure Hruntime Houtput
+
+theorem twp_recursiveSort
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (findIndex sortIndex : Nat)
+    (himportsFind : ¬findIndex < runtimeModule.imports.length)
+    (hfunctionFind : runtimeModule.funcs[findIndex - runtimeModule.imports.length]? =
+      some (findMinRecursiveFunction findIndex))
+    (himportsSort : ¬sortIndex < runtimeModule.imports.length)
+    (hfunctionSort : runtimeModule.funcs[sortIndex - runtimeModule.imports.length]? =
+      some (recursiveSelectionSortFunction findIndex sortIndex))
+    (arr : UInt32) (input : List UInt64)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    {callerLocals : Locals} {stack : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    runtimeModuleOwn runtimeModule ∗ array64At arr input ∗
+      (∀ output : List UInt64,
+        ⌜List.Perm input output ∧ Sorted output⌝ -∗
+        runtimeModuleOwn runtimeModule -∗ array64At arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨{ callerLocals with values :=
+        (.i32 (UInt32.ofNat input.length) :: .i32 arr :: stack) },
+      .call sortIndex :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] :=
+  twp_recursiveSort_aux runtimeModule findIndex sortIndex himportsFind
+    hfunctionFind himportsSort hfunctionSort arr input hfit input.length
+    (Nat.le_refl _)
+
+/-! ## Loop implementation -/
+
+def loopSortLocals (arr : UInt32) (length outer best scan : Nat)
+    (temporary : UInt64) (stack : List Value) : Locals :=
+  ⟨[.i32 arr, .i32 (UInt32.ofNat length)],
+    [.i32 (UInt32.ofNat outer), .i32 (UInt32.ofNat best),
+      .i32 (UInt32.ofNat scan), .i64 temporary], stack⟩
+
+private structure InnerState where
+  best : Nat
+  scan : Nat
+
+set_option maxHeartbeats 8000000 in
+private theorem twp_innerLoop
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (arr : UInt32) (current : List UInt64) (length : Nat)
+    (hlength : current.length = length)
+    (outer best scan : Nat) (temporary : UInt64)
+    (hinv : MinScan current outer best scan)
+    (hfit : arr.toNat + 8 * current.length ≤ UInt32.size)
+    {stack : List Value} {code : Program} {arity : Nat}
+    {remainder : List Value} {controls : List ControlFrame}
+    {calls : List CallFrame} :
+    array64At arr current ∗
+      (∀ finalBest : Nat,
+        ⌜outer ≤ finalBest ∧ finalBest < current.length ∧
+          ∀ k, outer ≤ k → k < current.length →
+            current[finalBest]! ≤ current[k]!⌝ -∗
+        array64At arr current -∗
+        WP (.running ⟨loopSortLocals arr length outer finalBest
+            length temporary stack,
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨loopSortLocals arr length outer best scan
+        temporary stack,
+      whileDo loopSelectionSortInnerCondition loopSelectionSortInnerStep ++ code,
+      arity, remainder, controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] := by
+  let Finish : IProp WasmHeapGF := iprop%
+    ∀ finalBest : Nat,
+      ⌜outer ≤ finalBest ∧ finalBest < current.length ∧
+        ∀ k, outer ≤ k → k < current.length →
+          current[finalBest]! ≤ current[k]!⌝ -∗
+      array64At arr current -∗
+      WP (.running ⟨loopSortLocals arr length outer finalBest
+          length temporary stack,
+        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E [{ Φ }]
+  let Inv : InnerState → IProp WasmHeapGF := fun state => iprop%
+    ⌜MinScan current outer state.best state.scan⌝ ∗
+      array64At arr current ∗ Finish
+  iintro ⟨Harray, Hfinish⟩
+  simp only [whileDo, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.twp_block
+  iapply Wasm.SmallStep.twp_loop_wf_family
+    (measure := fun state : InnerState => current.length - state.scan)
+    (locals := fun state => loopSortLocals arr length outer
+      state.best state.scan temporary stack)
+    (I := Inv) (initial := ⟨best, scan⟩)
+    (initialLocals := loopSortLocals arr length outer best scan
+      temporary stack)
+    (body := whileLoopCode loopSelectionSortInnerCondition
+      loopSelectionSortInnerStep)
+    (code := []) (belowStack := stack) rfl rfl
+  · intro state
+    simp only [Inv, Wasm.SmallStep.loopBodyExpr]
+    iintro Hrec Hinv
+    icases Hinv with ⟨%hstate, Harray, Hfinish⟩
+    unfold MinScan at hstate
+    have hlengthSize : current.length < UInt32.size := by
+      simp only [UInt32.size] at hfit ⊢
+      omega
+    have hdeclaredSize : length < UInt32.size := by
+      rwa [← hlength]
+    have hscanSize : state.scan < UInt32.size := by
+      omega
+    have hcmp := nat_lt_u32_iff hscanSize hdeclaredSize
+    simp only [whileLoopCode, loopSelectionSortInnerCondition,
+      loopSelectionSortInnerStep, List.append_assoc, List.cons_append,
+      List.nil_append]
+    iapply Wasm.SmallStep.twp_localGet rfl
+    iapply Wasm.SmallStep.twp_localGet rfl
+    iapply Wasm.SmallStep.twp_ltU rfl
+    iapply Wasm.SmallStep.twp_eqz rfl
+    by_cases hs : state.scan < current.length
+    · have hs' : state.scan < length := by rwa [← hlength]
+      simp only [if_pos (hcmp.mpr hs'),
+        if_neg (by decide : ¬(1 : UInt32) = 0)]
+      iapply Wasm.SmallStep.twp_brIfZero
+      have hbestLen : state.best < current.length := by
+        exact _root_.lt_of_lt_of_le hstate.2.1 hstate.2.2.1
+      iapply twp_loadAt64 hs hfit rfl rfl
+      isplitl [Harray]
+      · iexact Harray
+      iintro Harray
+      iapply twp_loadAt64 hbestLen hfit rfl rfl
+      isplitl [Harray]
+      · iexact Harray
+      iintro Harray
+      iapply Wasm.SmallStep.twp_ltUI64 rfl
+      by_cases hlt : current[state.scan] < current[state.best]
+      · simp only [if_pos hlt]
+        iapply Wasm.SmallStep.twp_iff rfl
+        simp only [if_pos (by decide : (1 : UInt32) ≠ 0)]
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_localSet rfl
+        iapply Wasm.SmallStep.twp_exitControl rfl
+        simp only [List.take_zero, List.nil_append, List.drop_zero,
+          incrementLocal, List.cons_append]
+        simp only [loopSortLocals, List.length_cons, List.length_nil,
+          Nat.reduceAdd, Nat.reduceSub, List.set]
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_const
+        iapply Wasm.SmallStep.twp_add
+        iapply Wasm.SmallStep.twp_localSet rfl
+        iapply Wasm.SmallStep.twp_br rfl
+        rw [show 1 + UInt32.ofNat state.scan =
+            UInt32.ofNat (state.scan + 1) by
+          rw [UInt32.add_comm]
+          change UInt32.ofNat state.scan + UInt32.ofNat 1 = _
+          rw [← UInt32.ofNat_add]]
+        simp only [List.length_cons, List.length_nil,
+          Nat.reduceAdd, Nat.reduceSub, List.set, List.take_zero,
+          List.nil_append]
+        have hnext : MinScan current outer state.scan (state.scan + 1) := by
+          have hstep := MinScan.step current hstate hs
+          have hlt' : current[state.scan]! < current[state.best]! := by
+            rw [getElem!_pos current state.scan hs,
+              getElem!_pos current state.best hbestLen]
+            exact hlt
+          simpa only [if_pos hlt'] using hstep
+        ispecialize Hrec $$ %(⟨state.scan, state.scan + 1⟩ : InnerState)
+        iapply Hrec
+        · ipureintro
+          change current.length - (state.scan + 1) <
+            current.length - state.scan
+          omega
+        isplitr
+        · ipureintro
+          exact hnext
+        iframe
+      · simp only [if_neg hlt]
+        iapply Wasm.SmallStep.twp_iff rfl
+        simp only [if_neg (by decide : ¬(0 : UInt32) ≠ 0)]
+        iapply Wasm.SmallStep.twp_exitControl rfl
+        simp only [List.take_zero, List.nil_append, List.drop_zero,
+          incrementLocal, List.cons_append]
+        iapply Wasm.SmallStep.twp_localGet rfl
+        iapply Wasm.SmallStep.twp_const
+        iapply Wasm.SmallStep.twp_add
+        iapply Wasm.SmallStep.twp_localSet rfl
+        iapply Wasm.SmallStep.twp_br rfl
+        rw [show 1 + UInt32.ofNat state.scan =
+            UInt32.ofNat (state.scan + 1) by
+          rw [UInt32.add_comm]
+          change UInt32.ofNat state.scan + UInt32.ofNat 1 = _
+          rw [← UInt32.ofNat_add]]
+        simp only [loopSortLocals, List.length_cons, List.length_nil,
+          Nat.reduceAdd, Nat.reduceSub, List.set, List.take_zero,
+          List.nil_append]
+        have hnext : MinScan current outer state.best (state.scan + 1) := by
+          have hstep := MinScan.step current hstate hs
+          have hlt' : ¬ current[state.scan]! < current[state.best]! := by
+            rw [getElem!_pos current state.scan hs,
+              getElem!_pos current state.best hbestLen]
+            exact hlt
+          simpa only [if_neg hlt'] using hstep
+        ispecialize Hrec $$ %(⟨state.best, state.scan + 1⟩ : InnerState)
+        iapply Hrec
+        · ipureintro
+          change current.length - (state.scan + 1) <
+            current.length - state.scan
+          omega
+        isplitr
+        · ipureintro
+          exact hnext
+        iframe
+    · have hnlt : ¬UInt32.ofNat state.scan < UInt32.ofNat length := by
+        apply mt hcmp.mp
+        rwa [← hlength]
+      simp only [if_neg hnlt]
+      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      simp only [List.take_zero, List.nil_append, List.drop_zero]
+      have hscanEq : state.scan = current.length := by omega
+      rw [hscanEq, hlength]
+      simp only [loopSortLocals]
+      have hpure : outer ≤ state.best ∧ state.best < current.length ∧
+          ∀ k, outer ≤ k → k < current.length →
+            current[state.best]! ≤ current[k]! := by
+        refine ⟨hstate.1,
+          _root_.lt_of_lt_of_le hstate.2.1 hstate.2.2.1, ?_⟩
+        intro k hk hklen
+        exact hstate.2.2.2 k hk (by simpa [hscanEq] using hklen)
+      ispecialize Hfinish $$ %state.best %hpure Harray
+      isimp only [loopSortLocals] at Hfinish
+      iexact Hfinish
+  · simp only [Inv]
+    isplitr
+    · ipureintro
+      exact hinv
+    iframe
+
+private structure OuterState where
+  current : List UInt64
+  outer : Nat
+  best : Nat
+  scan : Nat
+  temporary : UInt64
+
+set_option maxHeartbeats 12000000 in
+set_option maxRecDepth 10000 in
+private theorem twp_outerLoop
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (arr : UInt32) (input current : List UInt64)
+    (outer best scan : Nat) (temporary : UInt64)
+    (hinv : OuterInvariant input current outer)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    {stack : List Value} {code : Program} {arity : Nat}
+    {remainder : List Value} {controls : List ControlFrame}
+    {calls : List CallFrame} :
+    array64At arr current ∗
+      (∀ (output : List UInt64) (outer' best' scan' : Nat)
+          (temporary' : UInt64),
+        ⌜List.Perm input output ∧ Sorted output⌝ -∗
+        array64At arr output -∗
+        WP (.running ⟨loopSortLocals arr input.length outer' best' scan'
+            temporary' stack,
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨loopSortLocals arr input.length outer best scan
+        temporary stack,
+      whileDo loopSelectionSortOuterCondition loopSelectionSortOuterStep ++ code,
+      arity, remainder, controls, calls⟩ : Expr Unit) @ s; E [{ Φ }] := by
+  let Finish : IProp WasmHeapGF := iprop%
+    ∀ (output : List UInt64) (outer' best' scan' : Nat)
+        (temporary' : UInt64),
+      ⌜List.Perm input output ∧ Sorted output⌝ -∗
+      array64At arr output -∗
+      WP (.running ⟨loopSortLocals arr input.length outer' best' scan'
+          temporary' stack,
+        code, arity, remainder, controls, calls⟩ : Expr Unit)
+        @ s; E [{ Φ }]
+  let Inv : OuterState → IProp WasmHeapGF := fun state => iprop%
+    ⌜OuterInvariant input state.current state.outer⌝ ∗
+      array64At arr state.current ∗ Finish
+  iintro ⟨Harray, Hfinish⟩
+  simp only [whileDo, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.twp_block
+  iapply Wasm.SmallStep.twp_loop_wf_family
+    (measure := fun state : OuterState => input.length - state.outer)
+    (locals := fun state => loopSortLocals arr input.length state.outer
+      state.best state.scan state.temporary stack)
+    (I := Inv)
+    (initial := ⟨current, outer, best, scan, temporary⟩)
+    (initialLocals := loopSortLocals arr input.length outer best scan
+      temporary stack)
+    (body := whileLoopCode loopSelectionSortOuterCondition
+      loopSelectionSortOuterStep)
+    (code := []) (belowStack := stack) rfl rfl
+  · intro state
+    simp only [Inv, Wasm.SmallStep.loopBodyExpr]
+    iintro Hrec Hinv
+    icases Hinv with ⟨%houter, Harray, Hfinish⟩
+    have hlength : state.current.length = input.length := houter.1
+    have hfitCurrent : arr.toNat + 8 * state.current.length ≤
+        UInt32.size := by rwa [hlength]
+    have hlengthSize : state.current.length < UInt32.size := by
+      simp only [UInt32.size] at hfitCurrent ⊢
+      omega
+    have houterSize : state.outer + 1 < UInt32.size := by
+      unfold OuterInvariant at houter
+      simp only [UInt32.size] at hfitCurrent ⊢
+      omega
+    have hinputSize : input.length < UInt32.size := by
+      rwa [← hlength]
+    have hcmp := nat_lt_u32_iff houterSize hinputSize
+    simp only [whileLoopCode, loopSelectionSortOuterCondition,
+      loopSelectionSortOuterStep, List.append_assoc, List.cons_append,
+      List.nil_append]
+    iapply Wasm.SmallStep.twp_localGet rfl
+    iapply Wasm.SmallStep.twp_const
+    iapply Wasm.SmallStep.twp_add
+    rw [show 1 + UInt32.ofNat state.outer =
+        UInt32.ofNat (state.outer + 1) by
+      rw [UInt32.add_comm]
+      change UInt32.ofNat state.outer + UInt32.ofNat 1 = _
+      rw [← UInt32.ofNat_add]]
+    iapply Wasm.SmallStep.twp_localGet rfl
+    iapply Wasm.SmallStep.twp_ltU rfl
+    iapply Wasm.SmallStep.twp_eqz rfl
+    by_cases hmore : state.outer + 1 < state.current.length
+    · have hmore' : state.outer + 1 < input.length := by
+        rwa [← hlength]
+      simp only [if_pos (hcmp.mpr hmore'),
+        if_neg (by decide : ¬(1 : UInt32) = 0)]
+      iapply Wasm.SmallStep.twp_brIfZero
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_localSet rfl
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_const
+      iapply Wasm.SmallStep.twp_add
+      rw [show 1 + UInt32.ofNat state.outer =
+          UInt32.ofNat (state.outer + 1) by
+        rw [UInt32.add_comm]
+        change UInt32.ofNat state.outer + UInt32.ofNat 1 = _
+        rw [← UInt32.ofNat_add]]
+      iapply Wasm.SmallStep.twp_localSet rfl
+      simp only [loopSortLocals, List.length_cons, List.length_nil,
+        Nat.reduceAdd, Nat.reduceSub, List.set]
+      have hlocals :
+          ({ params := [.i32 arr, .i32 (UInt32.ofNat input.length)]
+             locals := [.i32 (UInt32.ofNat state.outer),
+               .i32 (UInt32.ofNat state.outer),
+               .i32 (UInt32.ofNat (state.outer + 1)),
+               .i64 state.temporary]
+             values := stack } : Locals) =
+            loopSortLocals arr input.length state.outer state.outer
+              (state.outer + 1) state.temporary stack := rfl
+      rw [hlocals]
+      have houterLen : state.outer < state.current.length := by omega
+      iapply twp_innerLoop arr state.current input.length hlength
+        state.outer state.outer
+        (state.outer + 1) state.temporary
+        (minScan_start state.current houterLen) hfitCurrent
+        (stack := stack)
+        (code := swapAt 0 2 3 5 ++
+          (incrementLocal 2 ++ [Instruction.br 0]))
+        (arity := arity) (remainder := remainder)
+        (controls :=
+          { kind := .loop, paramArity := 0, resultArity := 0
+            body :=
+              .localGet 2 :: .const 1 :: .add :: .localGet 1 :: .ltU ::
+                .eqz :: .br_if 1 :: .localGet 2 :: .localSet 3 ::
+                .localGet 2 :: .const 1 :: .add :: .localSet 4 ::
+                (whileDo loopSelectionSortInnerCondition
+                  loopSelectionSortInnerStep ++
+                  (swapAt 0 2 3 5 ++
+                    (incrementLocal 2 ++ [Instruction.br 0])))
+            continuation := [], belowStack := stack } ::
+          { kind := .block, paramArity := 0, resultArity := 0
+            body := [.loop 0 0
+              (.localGet 2 :: .const 1 :: .add :: .localGet 1 :: .ltU ::
+                .eqz :: .br_if 1 :: .localGet 2 :: .localSet 3 ::
+                .localGet 2 :: .const 1 :: .add :: .localSet 4 ::
+                (whileDo loopSelectionSortInnerCondition
+                  loopSelectionSortInnerStep ++
+                  (swapAt 0 2 3 5 ++
+                    (incrementLocal 2 ++ [Instruction.br 0]))))]
+            continuation := code, belowStack := List.drop 0 stack } :: controls)
+        (calls := calls) (s := s) (E := E) (Φ := Φ)
+      isplitl [Harray]
+      · iexact Harray
+      iintro %finalBest %hminimum Harray
+      have hbest : finalBest < state.current.length := hminimum.2.1
+      iapply twp_swapAt64 (a := state.outer) (b := finalBest)
+        houterLen hbest hfitCurrent rfl rfl rfl rfl rfl rfl rfl
+      isplitl [Harray]
+      · iexact Harray
+      iintro Hupdated
+      simp only [incrementLocal, List.cons_append,
+        List.nil_append]
+      simp only [loopSortLocals, List.length_cons, List.length_nil,
+        Nat.reduceAdd, Nat.reduceSub, List.set]
+      iapply Wasm.SmallStep.twp_localGet rfl
+      iapply Wasm.SmallStep.twp_const
+      iapply Wasm.SmallStep.twp_add
+      iapply Wasm.SmallStep.twp_localSet rfl
+      iapply Wasm.SmallStep.twp_br rfl
+      rw [show 1 + UInt32.ofNat state.outer =
+          UInt32.ofNat (state.outer + 1) by
+        rw [UInt32.add_comm]
+        change UInt32.ofNat state.outer + UInt32.ofNat 1 = _
+        rw [← UInt32.ofNat_add]]
+      simp only [List.length_cons, List.length_nil,
+        Nat.reduceAdd, Nat.reduceSub, List.set, List.take_zero,
+        List.nil_append]
+      let updated := swapElems state.current state.outer finalBest
+      have hnext : OuterInvariant input updated (state.outer + 1) := by
+        dsimp only [updated]
+        apply OuterInvariant.step houter houterLen
+        · exact ⟨hminimum.1, hminimum.2.1⟩
+        · exact hminimum.2.2
+      ispecialize Hrec $$
+        %(⟨updated, state.outer + 1, finalBest,
+          input.length, state.current[state.outer]⟩ : OuterState)
+      iapply Hrec
+      · ipureintro
+        change input.length - (state.outer + 1) <
+          input.length - state.outer
+        omega
+      isplitr
+      · ipureintro
+        exact hnext
+      isplitl [Hupdated]
+      · rw [show updated =
+          swapElems state.current state.outer finalBest from rfl]
+        iexact Hupdated
+      · iexact Hfinish
+    · have hnlt : ¬UInt32.ofNat (state.outer + 1) <
+          UInt32.ofNat input.length := by
+        apply mt hcmp.mp
+        rwa [← hlength]
+      simp only [if_neg hnlt]
+      iapply Wasm.SmallStep.twp_brIf (by decide) rfl
+      simp only [List.take_zero, List.nil_append, List.drop_zero]
+      have hfinished : state.current.length ≤ state.outer + 1 := by omega
+      have hpure : List.Perm input state.current ∧ Sorted state.current :=
+        ⟨OuterInvariant.perm houter,
+          OuterInvariant.sorted houter hfinished⟩
+      ispecialize Hfinish $$ %state.current %state.outer %state.best
+        %state.scan %state.temporary %hpure Harray
+      isimp only [loopSortLocals] at Hfinish
+      simp only [loopSortLocals]
+      iexact Hfinish
+  · simp only [Inv]
+    isplitr
+    · ipureintro
+      exact hinv
+    isplitl [Harray]
+    · iexact Harray
+    · iexact Hfinish
+
+theorem twp_loopSort
+    [WasmSmallStepGS hlc]
+    {s : Stuckness} {E : CoPset}
+    {Φ : List Value → IProp WasmHeapGF}
+    (runtimeModule : Module) (sortIndex : Nat)
+    (himports : ¬sortIndex < runtimeModule.imports.length)
+    (hfunction : runtimeModule.funcs[sortIndex - runtimeModule.imports.length]? =
+      some loopSelectionSortFunction)
+    (arr : UInt32) (input : List UInt64)
+    (hfit : arr.toNat + 8 * input.length ≤ UInt32.size)
+    {callerLocals : Locals} {stack : List Value}
+    {code : Program} {arity : Nat} {remainder : List Value}
+    {controls : List ControlFrame} {calls : List CallFrame} :
+    runtimeModuleOwn runtimeModule ∗ array64At arr input ∗
+      (∀ output : List UInt64,
+        ⌜List.Perm input output ∧ Sorted output⌝ -∗
+        runtimeModuleOwn runtimeModule -∗ array64At arr output -∗
+        WP (.running ⟨{ callerLocals with values := stack },
+          code, arity, remainder, controls, calls⟩ : Expr Unit)
+          @ s; E [{ Φ }]) ⊢
+    WP (.running ⟨{ callerLocals with values :=
+        (.i32 (UInt32.ofNat input.length) :: .i32 arr :: stack) },
+      .call sortIndex :: code, arity, remainder, controls, calls⟩ : Expr Unit)
+      @ s; E [{ Φ }] := by
+  iintro ⟨Hruntime, Harray, Hcont⟩
+  let callerFrame : CallFrame :=
+    { locals := { callerLocals with values := stack }
+      continuation := code
+      resultArity := arity
+      callerRemainder := remainder
+      control := controls }
+  ihave HruntimeLater : runtimeModuleOwn runtimeModule $$ [Hruntime]
+  · iexact Hruntime
+  iapply Wasm.SmallStep.twp_call runtimeModule sortIndex
+    loopSelectionSortFunction himports hfunction $$ HruntimeLater
+  iintro Hruntime
+  simp [loopSelectionSortFunction, Function.toLocals, Function.numParams,
+    ValueType.zero]
+  simp only [loopSelectionSortBody, List.cons_append, List.nil_append]
+  iapply Wasm.SmallStep.twp_const
+  iapply Wasm.SmallStep.twp_localSet rfl
+  simp only [List.length_cons, List.length_nil,
+    Nat.reduceAdd, Nat.reduceSub, List.set]
+  have hlocals :
+      ({ params := [.i32 arr, .i32 (UInt32.ofNat input.length)]
+         locals := [.i32 0, .i32 0, .i32 0, .i64 0]
+         values := [] } : Locals) =
+        loopSortLocals arr input.length 0 0 0 0 [] := rfl
+  rw [hlocals]
+  iapply twp_outerLoop arr input input 0 0 0 0
+    (outerInvariant_start input) hfit
+    (stack := []) (code := [.ret]) (arity := 0) (remainder := [])
+    (controls := []) (calls := callerFrame :: calls)
+    (s := s) (E := E) (Φ := Φ)
+  isplitl [Harray]
+  · iexact Harray
+  iintro %output %outer %best %scan %temporary %hpure Harray
+  iapply Wasm.SmallStep.twp_returnFromCallExplicit
+  simp only [List.take_zero, List.nil_append]
+  iapply Hcont $$ %output %hpure Hruntime Harray
+
+end Wasm.Examples.SelectionSort


### PR DESCRIPTION
## Summary

- add two small handwritten Wasm selection-sort implementations over unsigned `u64` values: one recursive and one explicitly loop-based
- prove both implementations against the same permutation-and-sortedness contract, using induction for recursion and invariants for loops
- add a StdIO-facing wrapper that reads and writes packed little-endian `u64` streams
- prove end-to-end existence of a sorted output for every input fitting the fixed one-page buffer

## Public contract

For either executable and every fitting input, there exists an output returned by the program such that:

```lean
List.Perm input output ∧ Sorted output
```

Permutation already entails equal length, so the contract has no redundant length conjunct.

## Why

This provides the first tutorial foundations for demonstrating Talos specifications and contrasting recursive induction with explicit loop invariants, while keeping Wasm syntax secondary.

## Validation

- `cd codelib && lake build`
- all selection-sort files report zero Lean LSP diagnostics
- build output contains no warnings or errors
- `git diff --check`
