### PR TITLE
Add host-agnostic Wasm.RunsWith

### DIFF
--- a/interpreter/Interpreter/Wasm/Host/Run.lean
+++ b/interpreter/Interpreter/Wasm/Host/Run.lean
@@ -1,0 +1,44 @@
+import Interpreter.Wasm.SmallStep
+
+/-!
+# Entering a module through its host
+
+`HostEnv` says what a host *does*; this file says how a module is *started*
+under one, and what it means for that run to finish.  Both definitions are
+parametric in the host state `α`, exactly as `HostFn`, `HostEnv`, `HostSpec`
+and `HostContract` already are, so a host introduced later reuses them
+unchanged.
+
+`RunsWith` is the shape a user-facing specification wants: an export name, the
+host state the run begins in, and a predicate on the host state it must end
+in.  Fuel, linear memory and the machine's administrative bookkeeping stay
+inside the relation.
+
+These definitions cannot live in `Interpreter/Wasm/Host.lean` beside `HostEnv`
+itself: that file is imported by `Semantics`, which `SmallStep` is built on, so
+naming `SmallStep.Config` there would close an import cycle.
+-/
+
+namespace Wasm
+
+/-- Initialize `m` at its export named `op`, running under `env` from host
+state `initial` over the module's own initial memory, globals and tables.
+`none` when `m` exports no such name, or when the entry point that name
+resolves to cannot be entered. -/
+def startConfig? [Inhabited α] (env : HostEnv α) (m : Module) (op : String)
+    (initial : α) : Option (SmallStep.Config α) := do
+  let entry ← m.findExport op
+  (SmallStep.initConfig
+    { module := m, host := env }
+    entry { (m.initialStore : Store α) with host := initial } []).toOption
+
+/-- Export `op` of `m`, started under `env` in host state `initial`, terminates
+having returned no values and left a host state satisfying `post`. -/
+def RunsWith [Inhabited α] (env : HostEnv α) (m : Module) (op : String)
+    (initial : α) (post : α → Prop) : Prop :=
+  ∃ config,
+    startConfig? env m op initial = some config ∧
+    SmallStep.TerminatesWith config (fun values final =>
+      values = [] ∧ post final.wasm.host)
+
+end Wasm

--- a/interpreter/Interpreter/Wasm/Host/StdIO.lean
+++ b/interpreter/Interpreter/Wasm/Host/StdIO.lean
@@ -1,4 +1,4 @@
-import Interpreter.Wasm.SmallStep
+import Interpreter.Wasm.Host.Run
 
 /-!
 # A byte-buffer standard-I/O host
@@ -16,6 +16,11 @@ provides two imports, both using `(length, pointer)` argument order:
 An out-of-bounds memory range or malformed argument list traps without making
 any state change.  Zero-length accesses are valid even at the byte immediately
 after the end of memory, matching the usual half-open-range convention.
+
+`Runs` at the end of this file names the byte-stream contract once: a spec
+author states "this export, on these input bytes, terminates having written
+these output bytes" without rebuilding the machine by hand.  It is the
+`StdIO` reading of the host-agnostic `Wasm.RunsWith`.
 -/
 
 namespace Wasm.StdIO
@@ -160,5 +165,17 @@ theorem env_satisfies (m : Module) (himports : m.imports = imports) :
     rfl
   · simp [imports] at hi
     omega
+
+/-! ## The byte-stream contract
+
+Nothing below depends on a particular module, so a workspace states its
+contract by supplying its own `«module»` rather than by repeating the setup.
+-/
+
+/-- Export `op` of `m`, run on `input`, terminates having returned no values
+and written exactly `output`.  Fuel, linear memory and host-state plumbing stay
+inside the relation; the statement mentions only the two byte streams. -/
+def Runs (m : Module) (op : String) (input output : List UInt8) : Prop :=
+  RunsWith env m op (State.ofInput input) (fun final => final.output = output)
 
 end Wasm.StdIO

--- a/programs/lean/Project/Mergesort/Spec.lean
+++ b/programs/lean/Project/Mergesort/Spec.lean
@@ -31,24 +31,10 @@ base-ten numbers separated by one ASCII space, with no trailing newline. -/
 def encodeValues (values : List UInt64) : List UInt8 :=
   (String.intercalate " " (values.map toString)).toUTF8.toList
 
-/-- Initial Wasm store with `input` attached to the deterministic StdIO host. -/
-def initialStore (input : List UInt8) : Store StdIO.State :=
-  { («module».initialStore (α := StdIO.State)) with
-      host := StdIO.State.ofInput input }
-
-/-- Initialize the generated module at its exported `mergesort` entry point. -/
-def initialConfig? (input : List UInt8) : Option (SmallStep.Config StdIO.State) := do
-  let entry ← «module».findExport "mergesort"
-  (SmallStep.initConfig
-    { module := «module», host := StdIO.env }
-    entry (initialStore input) []).toOption
-
-/-- Fuel-free relational execution over byte streams. -/
+/-- Fuel-free relational execution over byte streams, through the shared StdIO
+seam at the generated module's exported `mergesort` entry point. -/
 def RunsBytes (input output : List UInt8) : Prop :=
-  ∃ initial,
-    initialConfig? input = some initial ∧
-    SmallStep.TerminatesWith initial (fun values final =>
-      values = [] ∧ final.wasm.host.output = output)
+  StdIO.Runs «module» "mergesort" input output
 
 /-- The host-level execution relation exposed to clients of the specification. -/
 def RunsValues (input output : List UInt64) : Prop :=


### PR DESCRIPTION
## What changes

Stating "export `op` of this module, run on these input bytes, terminates having
written those output bytes" currently costs about 25 lines of setup per
workspace: `Module.findExport`, an initial store rebuilt with
`host := StdIO.State.ofInput input`, `SmallStep.initConfig`, then
`SmallStep.TerminatesWith` inspecting `final.wasm.host.output`. Only the last
step is about standard I/O at all. This PR makes that setup one definition, and
makes the StdIO reading of it a one-liner. No new lemmas, no proof changes.

## The two layers

Layer 1 is host-agnostic, in the new `interpreter/Interpreter/Wasm/Host/Run.lean`:

```lean
def startConfig? [Inhabited α] (env : HostEnv α) (m : Module) (op : String)
    (initial : α) : Option (SmallStep.Config α)

def RunsWith [Inhabited α] (env : HostEnv α) (m : Module) (op : String)
    (initial : α) (post : α → Prop) : Prop
```

`RunsWith env m op initial post` holds when `startConfig?` succeeds and the
resulting machine terminates returning no values in a host state satisfying
`post`. It is parametric in `α`, as `HostFn`, `HostEnv`, `HostSpec` and
`HostContract` already are, so a host added later reuses it unchanged. The
`[Inhabited α]` constraint is not incidental: `Module.initialStore` builds its
store with `host := default`, and `startConfig?` overwrites that field with
`initial`.

Layer 2 is the StdIO reading, in `interpreter/Interpreter/Wasm/Host/StdIO.lean`:

```lean
def Runs (m : Module) (op : String) (input output : List UInt8) : Prop :=
  RunsWith env m op (State.ofInput input) (fun final => final.output = output)
```

## Call sites

`programs/lean/Project/Mergesort/Spec.lean` — `RunsBytes` is now
`StdIO.Runs «module» "mergesort" input output`, and unfolds to the same
proposition as before. Its local `initialStore` and `initialConfig?` had no
callers outside `RunsBytes` and are deleted.

## Why, and what comes next

More hosts are coming, and each one would otherwise repeat the same 25 lines.
#177 (`Add probabilistic random host`) is the first non-StdIO consumer: it adds
`Wasm.Random.State` and `Wasm.Random.env : HostEnv State`, which `RunsWith`
accepts as-is, so `Random.Runs` is the same one-liner as `StdIO.Runs`.

Host composition is not in this PR. Because `RunsWith` takes the env as a parameter, a
product host (`HostEnv α → HostEnv β → HostEnv (α × β)`, concatenating
`funcs`/`imports`/`contracts` and re-projecting each `invoke`) composes on top
of it later without a breaking change. The real constraint there is positional
import ordering, not `RunsWith`: `HostEnv.funcs` is documented as "indexed
identically to the declaring module's `imports` field", and `HostEnv.Satisfies`
reads `env.funcs[i]?` against `spec.contracts[i]?`, so concatenation only
composes when the importing module declares the two hosts' imports contiguously
and in the same order.

This PR proves nothing new about any program. It removes duplication and
unblocks the multi-host work.