### PR TITLE
Add `@[rust_ref]` and `@[equiv_of]` to CodeLib.Attrs

### DIFF
--- a/codelib/CodeLib/Attrs.lean
+++ b/codelib/CodeLib/Attrs.lean
@@ -1,14 +1,15 @@
 import Lean
 
 /-!
-# `@[spec_of]` and `@[proves]` — load-bearing project attributes
+# The load-bearing project attributes
 
-These two attributes are the link between Lean specifications and the code
-they describe, and between proofs and the specifications they discharge.
-They carry the metadata that `verifier extract` reads off the source. The
-runtime behavior here is intentionally minimal — the attribute machinery
-only needs to *exist* so the source typechecks; semantics live in the
-extractor.
+These four attributes are the link between Lean specifications and the code
+they describe, between proofs and the specifications they discharge, and
+between a hand-written Lean model and the compiled function it stands in
+for. They carry the metadata that `verifier extract` reads off the source.
+The runtime behavior here is intentionally minimal — the attribute
+machinery only needs to *exist* so the source typechecks; semantics live in
+the extractor.
 
 ## `@[spec_of <kind> "qualified::name"]`
 
@@ -31,8 +32,35 @@ is the fully qualified name of a `@[spec_of …] def`. The theorem's stated
 type is not required to be syntactically `SpecName` (a reformulation is
 fine); the attribute is the source of truth for the link.
 
+## `@[rust_ref "qualified::name"]`
+
+Marks a `def` as a hand-written Lean model of a Rust function — the
+readable transliteration a proof reasons about when the compiled wasm is
+too raw to state anything against. The argument is the `crate::fn_name`
+join key `@[spec_of "rust-exported" …]` already uses, quoted for the same
+reason: a Rust path is not a Lean identifier.
+
+A model tagged this way *owes* an equivalence. Without a theorem tying it
+to the compiled function, everything proved about the model says nothing
+about the code that runs; `@[equiv_of]` is how that debt is discharged.
+Neither attribute enforces the obligation — together they make owed and
+discharged both visible, to a reader and to tooling.
+
+## `@[equiv_of modelName]`
+
+Marks a `theorem` as the equivalence a `@[rust_ref]` model owes: the
+compiled function computes what the model says. `modelName` names a Lean
+declaration, so it is written **bare** and registers the way `@[proves]`
+does, not the way `@[spec_of]` and `@[rust_ref]` do. As with `@[proves]`,
+the theorem's stated type is not constrained to any particular shape; the
+attribute is the link.
+
+`CodeLib/Attrs/Check.lean` applies both model attributes, so a build fails
+if either registration here stops accepting the form documented above.
+
 See `verifier/EXTRACT.md` (§P4, §P5, §P7) for the full discovery
-contract.
+contract. `extract` reads `@[spec_of]` and `@[proves]` today; `@[rust_ref]`
+and `@[equiv_of]` are not part of the artifact yet.
 -/
 
 open Lean
@@ -51,6 +79,17 @@ syntax (name := spec_of) "spec_of" str str : attr
 formal spec. See module docstring. -/
 syntax (name := proves) "proves" ident : attr
 
+/-- `@[rust_ref "<crate>::<fn>"]` — tag a `def` as a hand-written Lean
+model of the named Rust function. The target is quoted for the same reason
+`spec_of`'s is: a Rust path is not a Lean identifier. A model tagged this
+way owes an `@[equiv_of]`. See module docstring. -/
+syntax (name := rust_ref) "rust_ref" str : attr
+
+/-- `@[equiv_of modelName]` — tag a theorem as the equivalence a
+`@[rust_ref]` model owes to the compiled function. The model is named
+bare, as an identifier, not as a string. See module docstring. -/
+syntax (name := equiv_of) "equiv_of" ident : attr
+
 initialize
   Lean.registerBuiltinAttribute {
     name            := `spec_of
@@ -64,6 +103,24 @@ initialize
   Lean.registerBuiltinAttribute {
     name            := `proves
     descr           := "Mark a theorem as a verification of a named formal spec."
+    applicationTime := .afterCompilation
+    add             := fun _ _ _ => pure ()
+    erase           := fun _ => pure ()
+  }
+
+initialize
+  Lean.registerBuiltinAttribute {
+    name            := `rust_ref
+    descr           := "Mark a `def` as a hand-written Lean model of a Rust function."
+    applicationTime := .afterCompilation
+    add             := fun _ _ _ => pure ()
+    erase           := fun _ => pure ()
+  }
+
+initialize
+  Lean.registerBuiltinAttribute {
+    name            := `equiv_of
+    descr           := "Mark a theorem as the equivalence a hand-written Lean model owes."
     applicationTime := .afterCompilation
     add             := fun _ _ _ => pure ()
     erase           := fun _ => pure ()

--- a/codelib/CodeLib/Attrs/Check.lean
+++ b/codelib/CodeLib/Attrs/Check.lean
@@ -1,0 +1,31 @@
+import CodeLib.Attrs
+
+/-!
+# Application sites for `@[rust_ref]` and `@[equiv_of]`
+
+Registering an attribute and accepting the form its documentation shows are
+two different things, and only an application site can fail — the
+registration in `CodeLib/Attrs.lean` compiles whatever grammar it declares.
+These two declarations are that site: the build stops here if `@[rust_ref]`
+stops taking a quoted `crate::fn` target, or `@[equiv_of]` stops taking a
+bare identifier.
+
+`@[spec_of]` and `@[proves]` need no counterpart: the crates under
+`programs/` apply them on every build.
+
+Nothing below is claimed about wasm. `identity` names no Rust function and
+`identityModel` models nothing — these declarations exist to be tagged.
+-/
+
+namespace CodeLib.Attrs.Check
+
+/-- Stands in for a hand-written Lean model of a Rust function. -/
+@[rust_ref "codelib_attrs_check::identity"]
+def identityModel (n : Nat) : Nat := n
+
+/-- Stands in for the equivalence `identityModel` owes to the compiled
+function it models. -/
+@[equiv_of identityModel]
+theorem identityModel_eq (n : Nat) : identityModel n = n := rfl
+
+end CodeLib.Attrs.Check

--- a/codelib/lakefile.toml
+++ b/codelib/lakefile.toml
@@ -16,4 +16,4 @@ rev = "27f05563f6f65993056c44da95be8a474dc9e57f"
 
 [[lean_lib]]
 name = "CodeLib"
-roots = ["CodeLib", "CodeLib.Examples.Quicksort.Proof"]
+roots = ["CodeLib", "CodeLib.Attrs.Check", "CodeLib.Examples.Quicksort.Proof"]

--- a/verifier/EXTRACT.md
+++ b/verifier/EXTRACT.md
@@ -159,6 +159,15 @@ The `@[spec_of]` and `@[proves]` attributes are defined in
 truth for their semantics is this document and the extractor that
 reads them.
 
+That file also defines `@[rust_ref "crate::fn"]` and
+`@[equiv_of model]`, which tag a hand-written Lean model of a Rust
+function and the equivalence that model owes to the compiled code. The
+extractor does not read them: they reach no artifact field and raise no
+diagnostic, and a `def` carrying only `@[rust_ref]` is not a
+`FormalSpec`. Recording them is a schema change — new artifact entries
+and a `schema_version` bump — and is deliberately not part of the change
+that defined the attributes.
+
 ---
 
 ## Top-level artifact


### PR DESCRIPTION
`codelib/CodeLib/Attrs.lean` gains two attributes beside `spec_of` and `proves`:

```lean
syntax (name := rust_ref) "rust_ref" str   : attr  -- @[rust_ref "crate::fn"]
syntax (name := equiv_of) "equiv_of" ident : attr  -- @[equiv_of modelName]
```

`@[rust_ref]` marks a `def` as a hand-written Lean model of the named Rust function; the target is quoted for the same reason `spec_of`'s is, a Rust path being no Lean identifier. `@[equiv_of]` marks a theorem as the equivalence that model owes to the compiled function — it names a Lean declaration, so it takes a bare identifier and registers the way `proves` does. Both are `.afterCompilation` no-ops like the existing pair. Neither enforces the obligation; together they make owed and discharged visible in the source rather than inferred from naming.

An attribute is only available to files that import its definition, so `Attrs.lean` cannot apply its own registrations and nothing there breaks if a grammar drifts. `codelib/CodeLib/Attrs/Check.lean` is that application site: one tagged `def`, one tagged `theorem`, nothing claimed about wasm. It is a `lean_lib` root of its own rather than part of the `CodeLib` umbrella, so `import CodeLib` does not pull the two placeholders in. Happy to fold it into the umbrella, move it under `Examples/`, or drop it.

The extractor is untouched. It reads `spec_of` and `proves` and ignores other attribute heads, so the new tags reach no artifact field and raise no diagnostic, and a `def` carrying only `@[rust_ref]` is not a `FormalSpec`. Recording them would be a schema change; `EXTRACT.md` now states that gap rather than leaving it to be discovered.
