### PR TITLE
Add a universal host: resolve any module's imports by name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,42 @@ Three layers, kept deliberately small:
 
 When writing or updating a spec theorem (tagged `@[spec_of …]` / `@[proves …]`; see `codelib/CodeLib/Attrs.lean`), reach for these — the fuel value belongs inside the proof, not the statement.
 
+## Hosts: default to the universal one
+
+Host imports are resolved **positionally** — `call i` looks up `env.funcs[i]`, matching `m.imports[i]`. A hand-built `HostEnv` therefore serves exactly one import list, in one order, which is why each per-host `env_satisfies` carries the hypothesis `m.imports = thatHost.imports`.
+
+Don't choose a host. Use `Wasm.Universal` (`Interpreter/Wasm/Host/Universal.lean`), which offers every host function the interpreter knows and resolves a module's imports **by name**, in that module's own order:
+
+- `Universal.envFor m` / `Universal.specFor m` — the environment and spec for any module, whatever it imports (a subset, a mixture of hosts, or nothing).
+- `Universal.envFor_satisfies m` — holds for **every** module, with no hypothesis on its imports. Prefer it over the per-host `env_satisfies`.
+- `Universal.Runs` / `Universal.RunsBytes` — user-facing run predicates; specs name `Universal.State` directly.
+- `Universal.covers m` — smoke test that every import is implemented. Resolution is total: an unimplemented import traps rather than failing to resolve, so carry this check in the spec.
+
+Unused host functions are harmless — they sit in the state, unreachable, because no `call` resolves to them. Import-free modules get `HostEnv.empty` definitionally, so they pay nothing.
+
+**Adding a host** (`Interpreter/Wasm/Host/<Name>.lean`): write it exactly the way `Host/StdIO.lean` and `Host/Random.lean` are written — a `State`, the `HostFn`s, an `imports` list, and an `env` whose `funcs` line up with it positionally. **A host file never mentions registries, lenses, composition, or any other host.** There is one way to write a host, and the universal host did not change it.
+
+Then in `Host/Universal.lean` — the only file that knows hosts get composed — one field on `State` (with a default) and one `component` term:
+
+```lean
+structure State where
+  stdio : StdIO.State := default
+  clock : Clock.State := default
+deriving Inhabited
+
+def registry : HostRegistry State :=
+  .component StdIO.imports StdIO.env.funcs
+      State.stdio (fun whole part => { whole with stdio := part })
+  ++ .component Clock.imports Clock.env.funcs
+      State.clock (fun whole part => { whole with clock := part })
+```
+
+`component` asks a host for nothing it does not already have. It takes the field's getter and setter; the lens laws are auto-params that close by `rfl` for any record field, so no `HostLens` is ever named. Contracts and their soundness proofs default to the exact ones, so nobody writes a `HostContract` or a `Satisfies` proof for the universal path.
+
+That is the whole cost. Nothing else, anywhere, needs to change: every existing spec keeps compiling, because adding a defaulted field leaves construction sites and theorem statements valid.
+
+Prefer new host state to be a record of defaulted fields, and never tag `HostFn.lift` or `HostEntry.lift` `@[simp]` — unfolding a lift expands a whole `Store` update at every host call. Use the `HostFn.lift_invoke_*` inversion lemmas instead.
+
 ## Examples
 
 Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built Wasm module and proves theorems about it using the WP tactic layer. The standard pattern: state the property, apply `wp_run` to reduce to a concrete computation, then close with `simp` / `omega` / domain lemmas. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.

--- a/interpreter/Interpreter/Wasm.lean
+++ b/interpreter/Interpreter/Wasm.lean
@@ -5,8 +5,10 @@ import Interpreter.Wasm.Continuation
 import Interpreter.Wasm.Semantics
 import Interpreter.Wasm.Semantics.Lemmas
 import Interpreter.Wasm.SmallStep
+import Interpreter.Wasm.Host.Registry
 import Interpreter.Wasm.Host.StdIO
 import Interpreter.Wasm.Host.Random.Probability
+import Interpreter.Wasm.Host.Universal
 import Interpreter.Wasm.MeasureTermination
 import Interpreter.Wasm.Wp.Defs
 import Interpreter.Wasm.Wp.Atomic
@@ -32,6 +34,13 @@ split into:
 * `Wasm.Wp.*`              — `wp` framework: definitions, atomic
                                  equations, block / loop / call rules, and
                                  the `wp_run` / `wp_done` tactics
+* `Wasm.Host.Registry`     — name-keyed host registries: resolve a
+                                 module's own imports, in its own order,
+                                 into the positional `HostEnv` the
+                                 interpreter expects
+* `Wasm.Host.Universal`    — one host offering every host function; the
+                                 default for specifications, so a proof
+                                 never has to choose a host
 * `Wasm.Spec.Termination`  — fuel-free `TerminatesWith` /
                                  `PartiallyMeets` predicates (user-facing
                                  spec API)

--- a/interpreter/Interpreter/Wasm/Examples/Basic.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Basic.lean
@@ -28,6 +28,7 @@ import Interpreter.Wasm.Examples.ClzPopcnt
 import Interpreter.Wasm.Examples.HostDispatch
 import Interpreter.Wasm.Examples.Counter
 import Interpreter.Wasm.Examples.Random
+import Interpreter.Wasm.Examples.UniversalHost
 import Interpreter.Wasm.Examples.DecoderImport
 import Interpreter.Wasm.Examples.DecoderImportedGlobal
 import Interpreter.Wasm.Examples.FloatOps

--- a/interpreter/Interpreter/Wasm/Examples/UniversalHost.lean
+++ b/interpreter/Interpreter/Wasm/Examples/UniversalHost.lean
@@ -1,0 +1,118 @@
+import Interpreter.Wasm.Host.Universal
+
+/-!
+# Worked examples: one host for every module
+
+Three properties a per-host environment cannot have, demonstrated on concrete
+modules run under `Universal.envFor`.
+
+1. **Mixed imports.** A module may import `random.get` and `stdio.write`
+   together. Neither `Random.env` nor `StdIO.env` can serve it: each is a fixed
+   positional list, and this module's index 1 is a function the other host owns.
+2. **Subsets, safely.** A module may import `stdio.write` alone. This one is
+   worth dwelling on: `StdIO.env.funcs` is `[readHost, writeHost]`, so under
+   `StdIO.env` a lone `stdio.write` import resolves at index 0 to *`read`* — it
+   runs, silently, doing the wrong thing. Name-keyed resolution cannot make that
+   mistake.
+3. **No imports.** A module importing nothing is served by the empty
+   environment, definitionally, so nothing about the universal host leaks into
+   the 13 emitted programs that declare `imports := []`.
+-/
+
+namespace Wasm.Examples.UniversalHost
+
+open Wasm.Universal
+
+/-! ## 1. A module importing two different hosts
+
+Draws one entropy byte into address zero, then writes that byte to standard
+output. Both argument lists follow their own host's convention: `random.get`
+takes `(pointer, length)`, `stdio.write` takes `(length, pointer)`. -/
+
+def mixed : Module :=
+  { imports :=
+      [ { «module» := "random", name := "get",
+          params := [.i32, .i32], results := [] }
+      , { «module» := "stdio", name := "write",
+          params := [.i32, .i32], results := [] } ]
+    funcs := [{ body := [.const 0, .const 1, .call 0,
+                         .const 1, .const 0, .call 1] }]
+    memory := some { pagesMin := 1 }
+    exports := [{ name := "roll", funcIdx := 2 }] }
+
+theorem mixed_covered : covers mixed = true := by native_decide
+
+def mixedStore (oracle : Random.Oracle) : Store State :=
+  { (mixed.initialStore (α := State)) with
+      host := State.ofInputAndOracle [] oracle }
+
+/-- Run `mixed` and report what reached standard output. -/
+def mixedOutput (oracle : Random.Oracle) (fuel : Nat) : Option (List UInt8) :=
+  match SmallStep.initConfig { module := mixed, host := envFor mixed }
+      2 (mixedStore oracle) [] with
+  | .error _ => none
+  | .ok config =>
+    match (SmallStep.runSteps fuel config).result with
+    | .success _ final => some final.wasm.host.stdio.output
+    | _ => none
+
+/-- The entropy byte crosses from one host's state, through linear memory, into
+the other host's state — in a single run, under a single environment. -/
+theorem mixed_writes_entropy_byte : mixedOutput (fun _ => 7) 50 = some [7] := by
+  native_decide
+
+/-- And it is genuinely the oracle's first byte that is written. -/
+theorem mixed_writes_first_oracle_byte :
+    mixedOutput (fun index => if index = 0 then 42 else 0) 50 = some [42] := by
+  native_decide
+
+/-! ## 2. A module importing one function of a two-function host -/
+
+def writeOnly : Module :=
+  { imports :=
+      [ { «module» := "stdio", name := "write",
+          params := [.i32, .i32], results := [] } ]
+    funcs := [{ body := [.const 1, .const 0, .call 0] }]
+    memory := some
+      { pagesMin := 1
+        data := [{ offset := some 0, bytes := [9] }] }
+    exports := [{ name := "emit", funcIdx := 1 }] }
+
+theorem writeOnly_covered : covers writeOnly = true := by native_decide
+
+def writeOnlyOutput (fuel : Nat) : Option (List UInt8) :=
+  match SmallStep.initConfig { module := writeOnly, host := envFor writeOnly }
+      1 { (writeOnly.initialStore (α := State)) with host := default } [] with
+  | .error _ => none
+  | .ok config =>
+    match (SmallStep.runSteps fuel config).result with
+    | .success _ final => some final.wasm.host.stdio.output
+    | _ => none
+
+/-- The declared import reaches `write`, because it was resolved by name. -/
+theorem writeOnly_emits : writeOnlyOutput 30 = some [9] := by native_decide
+
+/-- The hazard this avoids, stated as a fact rather than a warning: under the
+hand-built positional environment the same module's `call 0` lands on `read`,
+which writes memory and returns a count instead of emitting anything. -/
+theorem writeOnly_positional_env_resolves_read :
+    StdIO.env.funcs[0]?.map HostFn.results = some [.i32] := by native_decide
+
+/-- Whereas name-keyed resolution gives it the arity `write` actually has. -/
+theorem writeOnly_named_env_resolves_write :
+    (envFor writeOnly).funcs[0]?.map HostFn.results = some [] := by
+  native_decide
+
+/-! ## 3. A module importing nothing -/
+
+def pure : Module :=
+  { funcs := [{ body := [.const 7], results := [.i32] }]
+    exports := [{ name := "seven", funcIdx := 0 }] }
+
+/-- Import-free modules are served by the empty environment definitionally, so
+adopting the universal host costs them nothing. -/
+theorem pure_env : envFor pure = HostEnv.empty := rfl
+
+theorem pure_covered : covers pure = true := by native_decide
+
+end Wasm.Examples.UniversalHost

--- a/interpreter/Interpreter/Wasm/Host/Registry.lean
+++ b/interpreter/Interpreter/Wasm/Host/Registry.lean
@@ -1,0 +1,225 @@
+import Interpreter.Wasm.Host
+
+/-!
+# Name-keyed host registries
+
+`HostEnv.funcs` is *positional*: `funcs[i]` must be the resolver for
+`m.imports[i]`, because that is how `call i` finds it. A fixed `HostEnv` value
+therefore serves exactly one import list, which is why each host today proves
+`env_satisfies` under the hypothesis `m.imports = imports` — the module has to
+declare precisely that host's imports, in precisely that order.
+
+A *registry* removes the hypothesis. It is keyed by `ImportDecl` rather than by
+position, and builds the positional list on demand, per module, walking that
+module's own imports in its own order. Resolution is total: an import no
+registered entry claims resolves to a stub that traps, so `envFor` never fails
+and a module may declare imports from several hosts at once, in any order.
+
+The payoff is `HostRegistry.envFor_satisfies`: a registry environment satisfies
+its own spec for *every* module, with no hypothesis at all. `envFor` and
+`specFor` are the same walk over `m.imports`, so they agree by construction.
+
+This generalises `Near.resolveEnv?`, and supplies the "subset/order variant"
+that `Near/Proof.lean` notes is missing there.
+
+`Store.mapHost` and `HostFn.lift` let one host's functions run inside a larger
+host state — the mechanism behind `Interpreter.Wasm.Host.Universal`.
+-/
+
+namespace Wasm
+
+/-! ## Component lenses
+
+`Store` has one host-dependent field, `host`; the Wasm core never inspects it.
+Relabelling it preserves every Wasm-visible resource, which is what lets one
+host's functions run inside a composite host state. -/
+
+/-- Replace a store's host state, changing its type. -/
+@[inline] def Store.mapHost (f : α → β) (st : Store α) : Store β :=
+  { st with host := f st.host }
+
+/-- A view of one component `α` inside a composite host state `β`. The two laws
+hold by `rfl` for a record field, which is the only way this is ever built. -/
+structure HostLens (β α : Type) where
+  get : β → α
+  set : β → α → β
+  get_set : ∀ whole part, get (set whole part) = part := by intro _ _; rfl
+  set_get : ∀ whole, set whole (get whole) = whole := by intro _; rfl
+
+/-- The `α`-view of a composite store. -/
+@[inline] def Store.focus (l : HostLens β α) (st : Store β) : Store α :=
+  st.mapHost l.get
+
+/-- Paste a component's result store back into the composite one. Wasm-core
+fields come from `inner` — a host function may legitimately have written
+memory — while the host slot widens `inner`'s component against `outer`. -/
+@[inline] def Store.unfocus (l : HostLens β α) (outer : β) (inner : Store α) :
+    Store β :=
+  inner.mapHost (l.set outer)
+
+/-! ## Lifting a host function into a larger host state -/
+
+/-- Run `f`'s component view of the store, then widen whatever it returns. -/
+def HostFn.lift (l : HostLens β α) (f : HostFn α) : HostFn β where
+  params := f.params
+  results := f.results
+  invoke := fun st args =>
+    match f.invoke (st.focus l) args with
+    | .Return values inner => .Return values (Store.unfocus l st.host inner)
+    | .Trap inner message => .Trap (Store.unfocus l st.host inner) message
+    | .Throw inner tag values => .Throw (Store.unfocus l st.host inner) tag values
+
+/-! A lifted call is the component's call, with the composite host state carried
+around it. These three turn a fact about the component into a fact about the
+lifted function, which is what a proof under a composite host state needs — and
+they let `HostFn.lift` stay out of the `simp` set, where unfolding it would
+expand a whole `Store` update at every host call. -/
+
+theorem HostFn.lift_invoke_return (l : HostLens β α) (f : HostFn α)
+    (st : Store β) (args : List Value) {values : List Value} {inner : Store α}
+    (h : f.invoke (st.focus l) args = .Return values inner) :
+    (f.lift l).invoke st args =
+      .Return values (Store.unfocus l st.host inner) := by
+  simp [HostFn.lift, h]
+
+theorem HostFn.lift_invoke_trap (l : HostLens β α) (f : HostFn α)
+    (st : Store β) (args : List Value) {inner : Store α} {message : String}
+    (h : f.invoke (st.focus l) args = .Trap inner message) :
+    (f.lift l).invoke st args =
+      .Trap (Store.unfocus l st.host inner) message := by
+  simp [HostFn.lift, h]
+
+theorem HostFn.lift_invoke_throw (l : HostLens β α) (f : HostFn α)
+    (st : Store β) (args : List Value) {inner : Store α} {tag : Nat}
+    {values : List Value}
+    (h : f.invoke (st.focus l) args = .Throw inner tag values) :
+    (f.lift l).invoke st args =
+      .Throw (Store.unfocus l st.host inner) tag values := by
+  simp [HostFn.lift, h]
+
+/-! ## Registries -/
+
+/-- Import declarations name the same function when module, name and signature
+all agree. -/
+def ImportDecl.matches (a b : ImportDecl) : Bool :=
+  a.«module» == b.«module» && a.name == b.name &&
+    a.params == b.params && a.results == b.results
+
+/-- One registered host import: the declaration a module writes to reach it,
+the function behind it, the contract a proof sees, and the fact they agree.
+
+`contract` and `sound` default to the exact contract — "the result is what the
+function computes" — which is what every host in the repo uses today, and which
+`sound` discharges by `rfl`. A host wanting an implementation-hiding contract
+overrides both fields. -/
+structure HostEntry (α : Type) where
+  decl : ImportDecl
+  fn : HostFn α
+  contract : HostContract α := fun st args result => result = fn.invoke st args
+  sound : ∀ st args, contract st args (fn.invoke st args) := by intro _ _; rfl
+
+/-- Everything a host offers, keyed by declaration rather than by position. -/
+abbrev HostRegistry (α : Type) := List (HostEntry α)
+
+/-- Pair a host's existing positional import list with its aligned resolvers.
+
+A host already maintains those two lists — `imports` and `env.funcs` — and the
+interpreter already relies on them lining up, since that alignment is what makes
+`call i` find the right function. `ofImports` reuses exactly that invariant
+rather than restating every declaration a second time, so a host's registry is
+one line and cannot drift from its imports. -/
+def HostRegistry.ofImports (imports : List ImportDecl) (funcs : List (HostFn α)) :
+    HostRegistry α :=
+  (imports.zip funcs).map fun p => { decl := p.fst, fn := p.snd }
+
+/-- Run a registered entry inside a larger host state. The lifted entry takes
+the exact contract of the lifted function; a component's own abstract contract
+is recovered through its own lemmas, not carried through the lift. -/
+def HostEntry.lift (l : HostLens β α) (entry : HostEntry α) : HostEntry β where
+  decl := entry.decl
+  fn := entry.fn.lift l
+
+/-- Lift a whole registry into a larger host state. -/
+def HostRegistry.lift (l : HostLens β α) (reg : HostRegistry α) :
+    HostRegistry β :=
+  reg.map (HostEntry.lift l)
+
+/-- Register an existing host as a component of a composite host state: the
+host's own `imports` and `env.funcs`, plus the field of the composite state it
+occupies, named by that field's getter and setter.
+
+This is the *entire* cost of adding a host to a composite one, and it asks the
+host for nothing it does not already have — a host is written exactly as
+`Host/StdIO.lean` and `Host/Random.lean` are written, and never mentions
+registries, composition, or any other host.
+
+The two lens laws are auto-params: for a record field they close by `rfl`, so a
+call site writes only the projection and the update, and no `HostLens` is ever
+named. -/
+def HostRegistry.component (imports : List ImportDecl) (funcs : List (HostFn α))
+    (get : β → α) (set : β → α → β)
+    (get_set : ∀ whole part, get (set whole part) = part := by intro _ _; rfl)
+    (set_get : ∀ whole, set whole (get whole) = whole := by intro _; rfl) :
+    HostRegistry β :=
+  (HostRegistry.ofImports imports funcs).lift { get, set, get_set, set_get }
+
+/-- What an import resolves to when no entry claims it: a function of the
+declared shape that traps, naming the import it could not find. -/
+def HostFn.unresolved (decl : ImportDecl) : HostFn α where
+  params := decl.params
+  results := decl.results
+  invoke := fun st _ =>
+    .Trap st s!"no host function registered for {decl.«module»}.{decl.name}"
+
+/-- The entry a declared import resolves to, first match wins. -/
+def HostRegistry.entryFor (reg : HostRegistry α) (decl : ImportDecl) :
+    HostEntry α :=
+  match reg.find? (fun entry => ImportDecl.matches entry.decl decl) with
+  | some entry => entry
+  | none => { decl, fn := HostFn.unresolved decl }
+
+/-- Whether every import `m` declares is claimed by some entry. A module that
+does not pass this check still runs — its unclaimed imports trap — so specs
+carry it as an explicit smoke test rather than relying on it silently. -/
+def HostRegistry.covers (reg : HostRegistry α) (m : Module) : Bool :=
+  m.imports.all fun decl =>
+    (reg.find? (fun entry => ImportDecl.matches entry.decl decl)).isSome
+
+/-- The positional environment `m` sees under this registry. -/
+def HostRegistry.envFor (reg : HostRegistry α) (m : Module) : HostEnv α :=
+  { funcs := m.imports.map fun decl => (reg.entryFor decl).fn }
+
+/-- The positional spec matching `envFor`, entry by entry. -/
+def HostRegistry.specFor (reg : HostRegistry α) (m : Module) : HostSpec α :=
+  { contracts := m.imports.map fun decl => (reg.entryFor decl).contract }
+
+@[simp] theorem HostRegistry.envFor_nil (reg : HostRegistry α)
+    (m : Module) (h : m.imports = []) : reg.envFor m = HostEnv.empty := by
+  simp [HostRegistry.envFor, HostEnv.empty, h]
+
+theorem HostRegistry.envFor_getElem? (reg : HostRegistry α) (m : Module)
+    {i : Nat} (hi : i < m.imports.length) :
+    (reg.envFor m).funcs[i]? = some (reg.entryFor m.imports[i]).fn := by
+  simp [HostRegistry.envFor, List.getElem?_map, List.getElem?_eq_getElem hi]
+
+theorem HostRegistry.specFor_getElem? (reg : HostRegistry α) (m : Module)
+    {i : Nat} (hi : i < m.imports.length) :
+    (reg.specFor m).contracts[i]? = some (reg.entryFor m.imports[i]).contract := by
+  simp [HostRegistry.specFor, List.getElem?_map, List.getElem?_eq_getElem hi]
+
+/-- A registry environment satisfies its own spec for **every** module, with no
+hypothesis on the module's imports.
+
+This is what lets a proof stop choosing a host. The per-host `env_satisfies`
+theorems each require `m.imports = thatHost.imports`; here the environment and
+the spec are the same walk over `m.imports`, so they line up by construction
+whatever the module declares — a subset, a different order, or a mixture of
+several hosts. -/
+theorem HostRegistry.envFor_satisfies (reg : HostRegistry α) (m : Module) :
+    (reg.envFor m).Satisfies m (reg.specFor m) := by
+  intro i hi
+  exact ⟨(reg.entryFor m.imports[i]).fn, (reg.entryFor m.imports[i]).contract,
+    reg.envFor_getElem? m hi, reg.specFor_getElem? m hi,
+    (reg.entryFor m.imports[i]).sound⟩
+
+end Wasm

--- a/interpreter/Interpreter/Wasm/Host/Universal.lean
+++ b/interpreter/Interpreter/Wasm/Host/Universal.lean
@@ -1,0 +1,108 @@
+import Interpreter.Wasm.Host.Registry
+import Interpreter.Wasm.Host.StdIO
+import Interpreter.Wasm.Host.Random
+
+/-!
+# The universal host
+
+One host environment offering every host function the interpreter knows about,
+so a specification never has to choose a host.
+
+A module is served by `Universal.envFor «module»` whatever it imports: all of
+`StdIO`, all of `Random`, some of each, in any order, or nothing at all. The
+functions a module does not import are still present in the state and simply
+unreachable — no `call` resolves to them.
+
+`Universal.State` is a plain record with one field per host, each defaulted.
+Adding a host means adding a field and one `component` term, both here; the host
+itself is written in the ordinary way and needs no knowledge that this file
+exists. Because every field has a default, existing construction sites keep
+compiling, and because the record is what specifications name, existing theorems
+keep holding — a bigger state is still the same type constructor.
+
+`envFor_satisfies` needs no hypothesis about the module's imports, which is the
+concrete sense in which a proof stops choosing a host: the environment and the
+spec are both built by walking `m.imports`, so they agree by construction.
+-/
+
+namespace Wasm.Universal
+
+/-- The composite host state: one field per host, each defaulted so that adding
+a host later leaves existing construction sites untouched. -/
+structure State where
+  stdio : StdIO.State := default
+  random : Random.State := default
+deriving Inhabited
+
+/-- Every host function the interpreter knows, over the composite state.
+
+Each host contributes one `component` term: its own `imports` and `env.funcs`,
+and the field it occupies. This is the only file in the repo that knows hosts
+get composed at all — a host is written exactly as `Host/StdIO.lean` and
+`Host/Random.lean` are, and mentions none of this. -/
+def registry : HostRegistry State :=
+  .component StdIO.imports StdIO.env.funcs
+      State.stdio (fun whole part => { whole with stdio := part })
+  ++ .component Random.imports Random.env.funcs
+      State.random (fun whole part => { whole with random := part })
+
+/-- The environment `m` sees: its own imports, resolved by name, in its own
+order. -/
+def envFor (m : Module) : HostEnv State := registry.envFor m
+
+/-- The specification matching `envFor m`, entry for entry. -/
+def specFor (m : Module) : HostSpec State := registry.specFor m
+
+/-- The universal environment satisfies the universal specification for **every**
+module, with no hypothesis on what that module imports.
+
+Compare `StdIO.env_satisfies`, which holds only when `m.imports = StdIO.imports`
+exactly. -/
+theorem envFor_satisfies (m : Module) : (envFor m).Satisfies m (specFor m) :=
+  registry.envFor_satisfies m
+
+/-- No two entries claim the same `(module, name)`. Resolution takes the first
+match, so a duplicate key would silently shadow a host function; this is the
+guard against that, and a new host must keep it true. -/
+theorem registry_keys_nodup :
+    (registry.map fun entry => (entry.decl.«module», entry.decl.name)).Nodup := by
+  native_decide
+
+/-- Whether every import `m` declares is one the universal host implements.
+A spec carries this as a smoke test: an unimplemented import still runs, but
+traps, and this check says so up front rather than letting the trap masquerade
+as program behaviour. -/
+def covers (m : Module) : Bool := registry.covers m
+
+/-- An import-free module sees the empty environment. -/
+@[simp] theorem envFor_of_no_imports (m : Module) (h : m.imports = []) :
+    envFor m = HostEnv.empty :=
+  registry.envFor_nil m h
+
+/-! ## Starting a run -/
+
+/-- Start with `input` readable on `stdio` and no entropy consumed. -/
+def State.ofInput (input : List UInt8) : State :=
+  { stdio := StdIO.State.ofInput input }
+
+/-- Start with `input` readable on `stdio` and `oracle` supplying `random`. -/
+def State.ofInputAndOracle (input : List UInt8) (oracle : Random.Oracle) :
+    State :=
+  { stdio := StdIO.State.ofInput input
+    random := Random.State.ofOracle oracle }
+
+/-- Export `op` of `m`, started under the universal host in state `initial`,
+terminates having returned no values and left a host state satisfying `post`.
+
+This is the host-agnostic entry point: `m` may import anything. -/
+def Runs (m : Module) (op : String) (initial : State) (post : State → Prop) :
+    Prop :=
+  RunsWith (envFor m) m op initial post
+
+/-- Export `op` of `m`, run on `input`, terminates having written exactly
+`output` — the `StdIO` reading of `Runs`, available to any module regardless of
+what else it imports. -/
+def RunsBytes (m : Module) (op : String) (input output : List UInt8) : Prop :=
+  Runs m op (State.ofInput input) fun final => final.stdio.output = output
+
+end Wasm.Universal


### PR DESCRIPTION
Adds a **universal host**: one host that contains every other host's functions.

Today each host is its own separate environment — `StdIO` has `read`/`write`, `Random` has `get` — and a specification has to pick one up front. That breaks down whenever a module doesn't match a host exactly: if it needs functions from two different hosts, or only some of one host's functions, no existing environment fits it.

`Wasm.Universal` is a single host holding all of them:

```lean
def registry : HostRegistry State :=
  .component StdIO.imports StdIO.env.funcs
      State.stdio (fun whole part => { whole with stdio := part })
  ++ .component Random.imports Random.env.funcs
      State.random (fun whole part => { whole with random := part })
```

It looks up whatever a module imports **by name**, so it serves any module: all of one host, part of one, a mix of several, or nothing at all. A spec just writes `Universal.envFor «module»` and never chooses a host again.

**Adding a new host to it** is one field on `Universal.State` and one `component` line, both in `Host/Universal.lean`. The host's own file doesn't change — that's why `Host/StdIO.lean` and `Host/Random.lean` aren't in this diff. Hosts are still written exactly the way they are today.

Builds green: interpreter 3333, codelib 3531, programs 3565. `Examples/UniversalHost.lean` runs a module that imports `random.get` and `stdio.write` together, and one that imports only `stdio.write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
