### PR TITLE
Fix main build: adapt #183 total-correctness proofs to iris-lean bump

### DIFF
--- a/codelib/CodeLib/Examples/MergeSort/Adequacy.lean
+++ b/codelib/CodeLib/Examples/MergeSort/Adequacy.lean
@@ -328,7 +328,7 @@ theorem mergesort_partiallyMeets
     PartiallyMeets (mergeSortConfig source temporary input scratch)
       (fun _values store => ∃ output, SortedPermutation input output ∧
         readWordArray store.wasm.mem source input.length = output) := by
-  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets.{0}
+  apply wasm_smallStep_heap_globals_runtime_store_partiallyMeets
     (α := Unit)
     (σ := mergeSortHeap source temporary input scratch)
     (globalσ := (∅ : WasmGlobalMap Value))
@@ -367,7 +367,7 @@ theorem mergesort_terminatesWith
     TerminatesWith (mergeSortConfig source temporary input scratch)
       (fun _values store => ∃ output, SortedPermutation input output ∧
         readWordArray store.wasm.mem source input.length = output) := by
-  apply wasm_smallStep_heap_store_terminates.{0}
+  apply wasm_smallStep_heap_store_terminates
     (α := Unit)
     (σ := mergeSortHeap source temporary input scratch)
   · exact mergeSortHeap_agrees source temporary input scratch hbound_s hbound_t

--- a/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
+++ b/codelib/CodeLib/SepLogic/SmallStepAdequacy.lean
@@ -1609,7 +1609,7 @@ theorem wasm_smallStep_heap_globals_runtime_store_terminates
   · apply wasm_smallStep_heap_globals_runtime_store_adequacy
       config σ globalσ post hagree hinBounds hglobals
     intro gs
-    exact (htwp .hasLC).trans twp.to_wp
+    exact (htwp .hasLC).trans (wand_entails twp.to_wp)
 
 /-- Relational partial-correctness form of state-sensitive authoritative
 adequacy. -/

--- a/programs/lean/Project/FloatReinterpret/Spec.lean
+++ b/programs/lean/Project/FloatReinterpret/Spec.lean
@@ -3427,7 +3427,7 @@ theorem twp_func11_body_smallStep_wp
 theorem check_abs_terminatesWith (x : UInt32) :
     Wasm.SmallStep.TerminatesWith (checkAbsConfig x)
       (fun rs _store => ∃ b : UInt32, rs = [.i32 b]) := by
-  apply wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+  apply wasm_smallStep_heap_globals_runtime_store_terminates
     (α := Unit)
     (σ := exportHeap) (globalσ := func1Globals)
     (post := fun rs _store => ∃ b : UInt32, rs = [.i32 b])
@@ -3446,7 +3446,7 @@ theorem check_abs_terminatesWith (x : UInt32) :
 theorem check_copysign_terminatesWith (x y : UInt32) :
     Wasm.SmallStep.TerminatesWith (checkCopysignConfig x y)
       (fun rs _store => ∃ b : UInt32, rs = [.i32 b]) := by
-  apply wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+  apply wasm_smallStep_heap_globals_runtime_store_terminates
     (α := Unit)
     (σ := exportHeap) (globalσ := func1Globals)
     (post := fun rs _store => ∃ b : UInt32, rs = [.i32 b])

--- a/programs/lean/Project/FloatRound/Spec.lean
+++ b/programs/lean/Project/FloatRound/Spec.lean
@@ -2202,7 +2202,7 @@ theorem twp_func6_body_smallStep_wp
 theorem check_round_terminatesWith (x : UInt32) :
     Wasm.SmallStep.TerminatesWith (checkRoundConfig x)
       (fun rs _store => ∃ b : UInt32, rs = [.i32 b]) := by
-  apply wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+  apply wasm_smallStep_heap_globals_runtime_store_terminates
     (α := Unit)
     (σ := roundHeap) (globalσ := roundGlobals)
     (post := fun rs _store => ∃ b : UInt32, rs = [.i32 b])

--- a/programs/lean/Project/FloatTrunc/Spec.lean
+++ b/programs/lean/Project/FloatTrunc/Spec.lean
@@ -887,7 +887,7 @@ theorem twp_check
 theorem check_terminatesWith (x : UInt32) :
     Wasm.SmallStep.TerminatesWith (checkConfig x)
       (fun rs _store => rs = []) := by
-  apply wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+  apply wasm_smallStep_heap_globals_runtime_store_terminates
     (α := Unit)
     (σ := func0Heap) (globalσ := func0Globals)
     (post := fun rs _store => rs = [])

--- a/programs/lean/Project/NumInteger/Spec.lean
+++ b/programs/lean/Project/NumInteger/Spec.lean
@@ -7957,7 +7957,7 @@ theorem func2_terminatesWith :
         (fun rs _store =>
           rs = [.i64 (UInt64.ofNat (Nat.gcd a.toNat b.toNat))]) := by
   intro a b
-  apply Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+  apply Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates
     (α := Unit)
     (σ := func0InitialHeap)
     (globalσ := func0GlobalHeap)

--- a/programs/lean/Project/SwapElements/SwapSepLogic.lean
+++ b/programs/lean/Project/SwapElements/SwapSepLogic.lean
@@ -2090,7 +2090,7 @@ theorem func4_distinct_store_terminatesWith
   have hj7 : (addressJ + 7).toNat = addressJ.toNat + 7 := by
     simpa using UInt32.add_ofNat_toNat_noWrap addressJ 7 (by omega) (by omega)
   apply
-    Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+    Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates
       (α := Unit) (σ := σ) (globalσ := globalσ)
   · exact hagree
   · exact hinBounds
@@ -2177,7 +2177,7 @@ theorem func4_alias_store_terminatesWith
   have h7 : (address + 7).toNat = address.toNat + 7 := by
     simpa using UInt32.add_ofNat_toNat_noWrap address 7 (by omega) (by omega)
   apply
-    Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates.{0}
+    Wasm.SmallStep.wasm_smallStep_heap_globals_runtime_store_terminates
       (α := Unit) (σ := σ) (globalσ := globalσ)
   · exact hagree
   · exact hinBounds


### PR DESCRIPTION
## Problem

`main` is currently **broken**. It was green at `5b72be7` and fails at `043faa1` (the squash merge of #183).

PR #183 was authored against iris-lean *before* the upstream-master update landed on main as `5b72be7`. Its CI was green against that stale base, and there was no textual conflict, so the merge went through and broke the trunk.

CI failure on main:

```
error: CodeLib/SepLogic/SmallStepAdequacy.lean:1612:30: Application type mismatch: The argument
  twp.to_wp
has type
  ⊢ WP ?e @ ?s ; ?E [{ ?Φ }] -∗ WP ?e @ ?s ; ?E {{ ?Φ }}
but is expected to have type
  WP config.expr [{ ... }] ⊢ WP config.expr {{ ... }}
```

## Fix

Two API changes from the iris-lean bump needed adapting:

1. **`twp.to_wp` is now a wand** (`⊢ P -∗ Q`) rather than an entailment, so the term-mode `Entails.trans` application no longer typechecks. Wrapped in `wand_entails` (`Iris.BI.DerivedLaws`). Line 1612 was the only term-mode call site — every other one already uses `iapply twp.to_wp`, which handles the wand form.

2. **Several adequacy theorems lost a universe parameter**, invalidating nine explicit `.{0}` annotations across `MergeSort/Adequacy.lean` and five program spec files. Removed them; Lean infers the levels.

The four `No goals to be solved` errors were cascades from the failed `apply`, not independent problems.

## No semantic change

**No theorem statement is modified** — these are proof-term adaptations only. That matters here: the affected bridge is the TWP→WP adequacy underpinning every total-correctness claim in the corpus, so a fix that quietly weakened it would hollow out those claims. No `sorry`, no `axiom`.

## Verification

Built locally, both green:

- `codelib` — 3530 jobs
- `programs/lean` — 3564 jobs

## Follow-up worth considering

`main` has **no required status checks** (`required_checks: null`); branch protection only requires a review. Nothing enforces that a PR's CI reflects current main, which is exactly how this landed. Adding required checks with up-to-date-branch enforcement would close this class of breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)