### PR TITLE
Define the packed word codec once and migrate both stream examples

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -4,6 +4,7 @@ import CodeLib.Entry
 import CodeLib.Equivalence
 import CodeLib.UInt32
 import CodeLib.UInt64
+import CodeLib.WordCodec
 import CodeLib.RustStd.Frame
 import CodeLib.RustStd.Region
 import CodeLib.RustStd.MemArray

--- a/codelib/CodeLib/Examples/MergeSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/MergeSort/StdIO.lean
@@ -1,6 +1,7 @@
 import CodeLib.Examples.MergeSort.TotalProof
 import CodeLib.Examples.Quicksort
 import CodeLib.RustStd.MemArray
+import CodeLib.WordCodec
 import Interpreter.Wasm.Host.StdIO
 
 /-!
@@ -36,47 +37,66 @@ def decodeWord (b₀ b₁ b₂ b₃ : UInt8) : UInt32 :=
   b₀.toUInt32 ||| (b₁.toUInt32 <<< 8) |||
     (b₂.toUInt32 <<< 16) ||| (b₃.toUInt32 <<< 24)
 
+/-- `decodeWord` on the four-byte chunks `WordCodec.deserialize` hands it. The
+fallback case is unreachable: chunks are always exactly `width` bytes long. -/
+def decodeChunk : List UInt8 → UInt32
+  | b₀ :: b₁ :: b₂ :: b₃ :: _ => decodeWord b₀ b₁ b₂ b₃
+  | _ => 0
+
+/-- The packed little-endian codec for 32-bit words. Everything below the word
+level — `serialize`, `deserialize`, and the round trip between them — comes
+from `Wasm.WordCodec`; only this four-byte round trip is proved here, because
+`bv_decide` decides a concrete bit width. -/
+def codec : WordCodec UInt32 where
+  width := 4
+  encode := encodeWord
+  decode := decodeChunk
+  width_pos := by decide
+  encode_length := fun _ => rfl
+  decode_encode := by
+    intro value
+    simp only [encodeWord, decodeChunk, decodeWord]
+    bv_decide
+
 /-- Packed little-endian serialization of a list of 32-bit words. -/
 def serialize (values : List UInt32) : List UInt8 :=
-  values.flatMap encodeWord
+  codec.serialize values
 
 /-- Decode a packed little-endian byte sequence. A trailing partial word is
 rejected rather than silently ignored. -/
-def deserialize : List UInt8 → Option (List UInt32)
-  | [] => some []
-  | b₀ :: b₁ :: b₂ :: b₃ :: rest =>
-      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ :: ·)
-  | _ => none
+def deserialize (bytes : List UInt8) : Option (List UInt32) :=
+  codec.deserialize bytes
 
 @[simp] theorem decode_encode (value : UInt32) :
     decodeWord
       (value &&& 0xff).toUInt8
       (((value >>> 8) &&& 0xff).toUInt8)
       (((value >>> 16) &&& 0xff).toUInt8)
-      (((value >>> 24) &&& 0xff).toUInt8) = value := by
-  simp only [decodeWord]
-  bv_decide
+      (((value >>> 24) &&& 0xff).toUInt8) = value :=
+  codec.decode_encode value
+
+theorem serialize_nil : serialize [] = [] := rfl
+
+theorem serialize_cons (value : UInt32) (values : List UInt32) :
+    serialize (value :: values) = encodeWord value ++ serialize values := rfl
+
+theorem deserialize_nil : deserialize [] = some [] :=
+  codec.deserialize_nil
+
+/-- The defining equation this example used to carry for its own `deserialize`,
+recovered from the generic codec at width four. -/
+theorem deserialize_cons (b₀ b₁ b₂ b₃ : UInt8) (rest : List UInt8) :
+    deserialize (b₀ :: b₁ :: b₂ :: b₃ :: rest) =
+      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ :: ·) :=
+  codec.deserialize_append [b₀, b₁, b₂, b₃] rest rfl
 
 @[simp] theorem deserialize_serialize (values : List UInt32) :
-    deserialize (serialize values) = some values := by
-  induction values with
-  | nil => rfl
-  | cons value values ih =>
-      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
-        List.nil_append, deserialize, decode_encode]
-      change (deserialize (serialize values)).map (value :: ·) = some (value :: values)
-      rw [ih]
-      rfl
+    deserialize (serialize values) = some values :=
+  codec.deserialize_serialize values
 
 @[simp] theorem serialize_length (values : List UInt32) :
-    (serialize values).length = 4 * values.length := by
-  induction values with
-  | nil => rfl
-  | cons value values ih =>
-      change (List.flatMap encodeWord values).length = 4 * values.length at ih
-      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
-        List.nil_append, List.length_cons, Nat.mul_add]
-      omega
+    (serialize values).length = 4 * values.length :=
+  codec.serialize_length values
 
 theorem writeBytes_encodeWord (mem : Mem) (base value : UInt32) :
     mem.writeBytes base.toNat (encodeWord value) = mem.write32 base value := by
@@ -110,14 +130,14 @@ theorem writeBytes_serialize (mem : Mem) (base : UInt32)
       writeWordArray mem base values := by
   induction values generalizing mem base with
   | nil =>
-      simp only [serialize, List.flatMap_nil, writeWordArray]
+      simp only [serialize_nil, writeWordArray]
       cases mem
       simp only [Mem.writeBytes, List.length_nil, Nat.add_zero]
       congr
       funext i
       rw [dif_neg (by omega)]
   | cons value values ih =>
-      simp only [serialize, List.flatMap_cons, writeWordArray]
+      simp only [serialize_cons, writeWordArray]
       rw [Mem.writeBytes_append, writeBytes_encodeWord]
       simp only [List.length_cons, Nat.mul_add] at hfit
       have hbase : (base + 4).toNat = base.toNat + 4 := by
@@ -153,11 +173,11 @@ theorem deserialize_readBytes (mem : Mem) (base : UInt32) (count : Nat)
       some (readWordArray mem base count) := by
   induction count generalizing base with
   | zero =>
-      rfl
+      exact deserialize_nil
   | succ count ih =>
       rw [show 4 * (count + 1) = 4 + 4 * count by omega]
       rw [readBytes_four_add]
-      simp only [List.cons_append, List.nil_append, deserialize]
+      simp only [List.cons_append, List.nil_append, deserialize_cons]
       have hbase : (base + 4).toNat = base.toNat + 4 := by
         simp only [UInt32.toNat_add, UInt32.reduceToNat]
         rw [Nat.mod_eq_of_lt]

--- a/codelib/CodeLib/Examples/SelectionSort/StdIO.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/StdIO.lean
@@ -1,5 +1,6 @@
 import CodeLib.Examples.SelectionSort.TotalProof
 import CodeLib.RustStd.MemArray
+import CodeLib.WordCodec
 import Interpreter.Wasm.Host.StdIO
 import Mathlib.Data.List.Sort
 
@@ -45,15 +46,34 @@ def decodeWord (b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ : UInt8) : UInt64 :=
     (b₄.toUInt64 <<< 32) ||| (b₅.toUInt64 <<< 40) |||
     (b₆.toUInt64 <<< 48) ||| (b₇.toUInt64 <<< 56)
 
+/-- `decodeWord` on the eight-byte chunks `WordCodec.deserialize` hands it. The
+fallback case is unreachable: chunks are always exactly `width` bytes long. -/
+def decodeChunk : List UInt8 → UInt64
+  | b₀ :: b₁ :: b₂ :: b₃ :: b₄ :: b₅ :: b₆ :: b₇ :: _ =>
+      decodeWord b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇
+  | _ => 0
+
+/-- The packed little-endian codec for unsigned 64-bit words. Everything below
+the word level — `serialize`, `deserialize`, and the round trip between them —
+comes from `Wasm.WordCodec`; only this eight-byte round trip is proved here,
+because `bv_decide` decides a concrete bit width. -/
+def codec : WordCodec UInt64 where
+  width := 8
+  encode := encodeWord
+  decode := decodeChunk
+  width_pos := by decide
+  encode_length := fun _ => rfl
+  decode_encode := by
+    intro value
+    simp only [encodeWord, decodeChunk, decodeWord]
+    bv_decide
+
 def serialize (values : List UInt64) : List UInt8 :=
-  values.flatMap encodeWord
+  codec.serialize values
 
 /-- Reject a trailing partial word instead of silently ignoring it. -/
-def deserialize : List UInt8 → Option (List UInt64)
-  | [] => some []
-  | b₀ :: b₁ :: b₂ :: b₃ :: b₄ :: b₅ :: b₆ :: b₇ :: rest =>
-      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ :: ·)
-  | _ => none
+def deserialize (bytes : List UInt8) : Option (List UInt64) :=
+  codec.deserialize bytes
 
 @[simp] theorem decode_encode (value : UInt64) :
     decodeWord
@@ -64,31 +84,32 @@ def deserialize : List UInt8 → Option (List UInt64)
       (((value >>> 32) &&& 0xff).toUInt8)
       (((value >>> 40) &&& 0xff).toUInt8)
       (((value >>> 48) &&& 0xff).toUInt8)
-      (((value >>> 56) &&& 0xff).toUInt8) = value := by
-  simp only [decodeWord]
-  bv_decide
+      (((value >>> 56) &&& 0xff).toUInt8) = value :=
+  codec.decode_encode value
+
+theorem serialize_nil : serialize [] = [] := rfl
+
+theorem serialize_cons (value : UInt64) (values : List UInt64) :
+    serialize (value :: values) = encodeWord value ++ serialize values := rfl
+
+theorem deserialize_nil : deserialize [] = some [] :=
+  codec.deserialize_nil
+
+/-- The defining equation this example used to carry for its own `deserialize`,
+recovered from the generic codec at width eight. -/
+theorem deserialize_cons (b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ : UInt8)
+    (rest : List UInt8) :
+    deserialize (b₀ :: b₁ :: b₂ :: b₃ :: b₄ :: b₅ :: b₆ :: b₇ :: rest) =
+      (deserialize rest).map (decodeWord b₀ b₁ b₂ b₃ b₄ b₅ b₆ b₇ :: ·) :=
+  codec.deserialize_append [b₀, b₁, b₂, b₃, b₄, b₅, b₆, b₇] rest rfl
 
 @[simp] theorem deserialize_serialize (values : List UInt64) :
-    deserialize (serialize values) = some values := by
-  induction values with
-  | nil => rfl
-  | cons value values ih =>
-      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
-        List.nil_append, deserialize, decode_encode]
-      change (deserialize (serialize values)).map (value :: ·) =
-        some (value :: values)
-      rw [ih]
-      rfl
+    deserialize (serialize values) = some values :=
+  codec.deserialize_serialize values
 
 @[simp] theorem serialize_length (values : List UInt64) :
-    (serialize values).length = 8 * values.length := by
-  induction values with
-  | nil => rfl
-  | cons value values ih =>
-      change (List.flatMap encodeWord values).length = 8 * values.length at ih
-      simp only [serialize, List.flatMap_cons, encodeWord, List.cons_append,
-        List.nil_append, List.length_cons, Nat.mul_add]
-      omega
+    (serialize values).length = 8 * values.length :=
+  codec.serialize_length values
 
 /-! ## Link each sort against the `StdIO` ABI -/
 

--- a/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
+++ b/codelib/CodeLib/Examples/SelectionSort/StdIOProof.lean
@@ -237,14 +237,14 @@ theorem writeBytes_serialize (mem : Mem) (base : UInt32)
       writeWordArray64 mem base values := by
   induction values generalizing mem base with
   | nil =>
-      simp only [serialize, List.flatMap_nil, writeWordArray64]
+      simp only [serialize_nil, writeWordArray64]
       cases mem
       simp only [Mem.writeBytes, List.length_nil, Nat.add_zero]
       congr
       funext i
       rw [dif_neg (by omega)]
   | cons value values ih =>
-      simp only [serialize, List.flatMap_cons, writeWordArray64]
+      simp only [serialize_cons, writeWordArray64]
       rw [Mem.writeBytes_append, writeBytes_encodeWord]
       simp only [List.length_cons, Nat.mul_add] at hfit
       have hbase : (base + 8).toNat = base.toNat + 8 :=
@@ -1005,11 +1005,11 @@ theorem deserialize_readBytes64 (mem : Mem) (base : UInt32) (count : Nat)
     deserialize (mem.readBytes base.toNat (8 * count)) =
       some (readWordArray64 mem base count) := by
   induction count generalizing base with
-  | zero => rfl
+  | zero => exact deserialize_nil
   | succ count ih =>
       rw [show 8 * (count + 1) = 8 + 8 * count by omega]
       rw [readBytes_eight_add]
-      simp only [List.cons_append, List.nil_append, deserialize]
+      simp only [List.cons_append, List.nil_append, deserialize_cons]
       have hbase : (base + 8).toNat = base.toNat + 8 := by
         apply UInt32.add_ofNat_toNat_noWrap base 8 (by decide)
         simp only [UInt32.size] at hfit ⊢

--- a/codelib/CodeLib/WordCodec.lean
+++ b/codelib/CodeLib/WordCodec.lean
@@ -1,0 +1,150 @@
+/-!
+# Fixed-width word codecs for packed byte streams
+
+`WordCodec W` packages the three things a byte-stream example needs in order to
+move a `List W` across the `StdIO` host ABI: a fixed `width` in bytes, an
+`encode` that lays one word down as exactly `width` bytes, and a `decode` that
+reads one word back out of a `width`-byte chunk.
+
+The list-level plumbing — `serialize`, `deserialize`, and the round trip
+between them — is defined and proved once here, for every width at once. Only
+the word-level round trip is supplied per codec, as the `decode_encode` field:
+it is a statement about a concrete bit width, so it is discharged by
+`bv_decide` at the instantiation site and cannot be proved generically.
+
+`decode` is total. `deserialize` returns `Option` for exactly one reason: a
+trailing run of fewer than `width` bytes is rejected rather than silently
+dropped, so a successful decode has consumed every byte it was given.
+`deserialize_serialize_append_eq_none` is that property stated as a theorem.
+
+Consumers: `CodeLib.Examples.MergeSort.StdIO` instantiates it at four-byte
+`UInt32` words, `CodeLib.Examples.SelectionSort.StdIO` at eight-byte `UInt64`
+words. Before this module the two examples each carried their own copy of the
+definitions and both proofs below.
+-/
+
+namespace Wasm
+
+/-- A packed byte encoding of `W` in fixed-size words.
+
+`encode` and `decode` are inverse at the word level (`decode_encode`), and
+`encode` always produces exactly `width` bytes (`encode_length`). Those two
+facts are everything `serialize`/`deserialize` need. -/
+structure WordCodec (W : Type) where
+  /-- Number of bytes one word occupies in the stream. -/
+  width : Nat
+  /-- Lay one word down as exactly `width` bytes. -/
+  encode : W → List UInt8
+  /-- Read one word back out of a `width`-byte chunk. Total: `deserialize`
+  only ever applies it to chunks of exactly `width` bytes, so a codec is free
+  to return anything on other inputs. -/
+  decode : List UInt8 → W
+  /-- A zero-width word would leave `deserialize` with nothing to consume. -/
+  width_pos : 0 < width
+  encode_length : ∀ value, (encode value).length = width
+  decode_encode : ∀ value, decode (encode value) = value
+
+namespace WordCodec
+
+variable {W : Type} (codec : WordCodec W)
+
+/-- Packed serialization of a list of words: each word in turn, no framing. -/
+def serialize (values : List W) : List UInt8 :=
+  values.flatMap codec.encode
+
+@[simp] theorem serialize_nil : codec.serialize [] = [] := rfl
+
+@[simp] theorem serialize_cons (value : W) (values : List W) :
+    codec.serialize (value :: values) =
+      codec.encode value ++ codec.serialize values := rfl
+
+@[simp] theorem serialize_length (values : List W) :
+    (codec.serialize values).length = codec.width * values.length := by
+  induction values with
+  | nil => simp
+  | cons value values ih =>
+      rw [serialize_cons, List.length_append, codec.encode_length, ih,
+        List.length_cons, Nat.mul_succ]
+      omega
+
+/-- Decode a packed byte stream. A trailing run of fewer than `width` bytes is
+rejected rather than silently ignored, so `some` means every byte was
+consumed. -/
+def deserialize (codec : WordCodec W) : List UInt8 → Option (List W)
+  | [] => some []
+  | first :: rest =>
+      if (first :: rest).length < codec.width then none
+      else
+        (deserialize codec ((first :: rest).drop codec.width)).map
+          (codec.decode ((first :: rest).take codec.width) :: ·)
+termination_by bytes => bytes.length
+decreasing_by
+  have hpos := codec.width_pos
+  simp only [List.length_drop, List.length_cons]
+  omega
+
+@[simp] theorem deserialize_nil : codec.deserialize [] = some [] := by
+  simp [deserialize]
+
+/-- Fewer than `width` bytes left, and not none left, is a partial word. -/
+theorem deserialize_eq_none_of_length_lt (bytes : List UInt8)
+    (hne : bytes ≠ []) (hshort : bytes.length < codec.width) :
+    codec.deserialize bytes = none := by
+  match bytes with
+  | [] => exact absurd rfl hne
+  | first :: rest =>
+      rw [deserialize]
+      exact if_pos hshort
+
+/-- Peel one whole word off the front of a stream. This is the equation the
+concrete codecs re-export at a literal width, so that proofs written against
+the hand-rolled `deserialize` keep working unchanged. -/
+theorem deserialize_append (chunk rest : List UInt8)
+    (hchunk : chunk.length = codec.width) :
+    codec.deserialize (chunk ++ rest) =
+      (codec.deserialize rest).map (codec.decode chunk :: ·) := by
+  match chunk, hchunk with
+  | [], hchunk =>
+      exact absurd hchunk.symm (Nat.ne_of_gt codec.width_pos)
+  | first :: cs, hchunk =>
+      have hlength : ((first :: cs) ++ rest).length = codec.width + rest.length := by
+        rw [List.length_append, hchunk]
+      show codec.deserialize (first :: (cs ++ rest)) = _
+      rw [deserialize]
+      rw [if_neg (by
+        show ¬ ((first :: (cs ++ rest)).length < codec.width)
+        rw [show (first :: (cs ++ rest)) = ((first :: cs) ++ rest) from rfl,
+          hlength]
+        omega)]
+      rw [show (first :: (cs ++ rest)) = ((first :: cs) ++ rest) from rfl,
+        ← hchunk, List.take_left, List.drop_left]
+
+@[simp] theorem deserialize_serialize (values : List W) :
+    codec.deserialize (codec.serialize values) = some values := by
+  induction values with
+  | nil => simp
+  | cons value values ih =>
+      rw [serialize_cons,
+        codec.deserialize_append _ _ (codec.encode_length value), ih,
+        codec.decode_encode]
+      rfl
+
+/-- A trailing partial word is rejected, not dropped: appending fewer than
+`width` extra bytes to a well-formed stream makes the whole stream fail to
+decode. This is the only way `deserialize` produces `none`. -/
+theorem deserialize_serialize_append_eq_none (values : List W)
+    (trailing : List UInt8) (hne : trailing ≠ [])
+    (hshort : trailing.length < codec.width) :
+    codec.deserialize (codec.serialize values ++ trailing) = none := by
+  induction values with
+  | nil =>
+      rw [serialize_nil, List.nil_append]
+      exact codec.deserialize_eq_none_of_length_lt trailing hne hshort
+  | cons value values ih =>
+      rw [serialize_cons, List.append_assoc,
+        codec.deserialize_append _ _ (codec.encode_length value), ih]
+      rfl
+
+end WordCodec
+
+end Wasm


### PR DESCRIPTION
`MergeSort/StdIO.lean` and `SelectionSort/StdIO.lean` each define the same packed
little-endian codec — `encodeWord`, `decodeWord`, `serialize`, `deserialize`,
`decode_encode`, `deserialize_serialize`, `serialize_length`. They differ only in
word width: `UInt32` and four bytes, `UInt64` and eight. The two list-level proofs
are the same script written twice.

## What this does

Adds `codelib/CodeLib/WordCodec.lean` (no imports):

```lean
structure WordCodec (W : Type) where
  width : Nat
  encode : W → List UInt8
  decode : List UInt8 → W
  width_pos : 0 < width
  encode_length : ∀ value, (encode value).length = width
  decode_encode : ∀ value, decode (encode value) = value
```

`serialize`, `deserialize` and their lemmas are proved on top of it once, for
every width. Each example instantiates it and keeps its own `encodeWord` /
`decodeWord` verbatim.

A structure rather than a class, so a type can have more than one encoding and
`codec.width` still reduces to a numeral definitionally — the width literals
appear throughout the downstream buffer arithmetic.

Not made generic: the word-level `decode_encode`. `bv_decide` is fixed-width, so
each example discharges its own; a width-generic proof would be a hand-written
argument about digit expansions, larger than the duplication it removes.

## Preserved

Little-endian order, `Option` on decode, and rejection of a trailing partial
word — the last was an implicit catch-all match arm and is now a theorem,
`deserialize_serialize_append_eq_none`. Downstream statements are unchanged;
each example re-exports `serialize` / `deserialize` under the names it used.

## Build status

`main` does not currently build at `043faa1`: `CodeLib.SepLogic.SmallStepAdequacy`
fails at line 1612, matching CI run 32360968175. That is upstream of these
examples and unrelated to this branch.

Verified instead at `5b72be7`, the last green commit — three of the four modified
files are byte-identical between the two. Full `codelib` with `--wfail`, as CI
runs it: 3530 jobs, clean. `lake build CodeLib.WordCodec` also succeeds on
`043faa1`, since the new module imports nothing.

Draft until `main` builds again and this can be checked there.
