### PR TITLE
Fix Codex worktree setup for generated Wasm

### DIFF
--- a/scripts/codex-worktree-setup.sh
+++ b/scripts/codex-worktree-setup.sh
@@ -88,6 +88,12 @@ if [[ "${source_tree}" != "${worktree}" ]]; then
     # Third-party sources and their cached oleans (Mathlib, Iris, and transitives).
     clone_tree "${source_tree}/.lake/packages" "${worktree}/.lake/packages"
 
+    # Generated Lean modules read these WAT files at compile time. Seed them as
+    # a cache; the verifier build below refreshes them for the selected commit.
+    clone_tree \
+        "${source_tree}/programs/rust/build" \
+        "${worktree}/programs/rust/build"
+
     # Project-owned Lake artifacts. Keep these worktree-local so simultaneous
     # builds cannot overwrite one another.
     package_dirs=(
@@ -119,5 +125,14 @@ if [[ "${seeded_artifacts}" == true && "${dependency_manifests_differ}" == true 
     lake -d "${worktree}/programs/lean" exe cache get
 fi
 
+echo "Building the Rust-to-Wasm inputs required by generated Lean modules..."
+(
+    cd "${worktree}/programs"
+    lake -d ../verifier exe verifier build
+)
+
 echo "Reconciling the cloned artifacts with this worktree..."
-lake -d "${worktree}/programs/lean" build
+(
+    cd "${worktree}/programs/lean"
+    lake build
+)


### PR DESCRIPTION
## Summary

- seed generated Rust-to-Wasm artifacts when warming a Codex worktree
- rebuild the WAT inputs before compiling generated Lean modules
- run `lake build` from `programs/lean` so compile-time relative WAT paths resolve correctly

This PR is based directly on `main` and can merge before #197.

## Verification

- `bash -n scripts/codex-worktree-setup.sh`
- `git diff --check`
- Rust-to-Wasm verifier build for all 14 crates
- `lake build` from `programs/lean` (3575 jobs passed)