### PR TITLE
codelib: import the IEEE32 float axioms only where they are used

### DIFF
--- a/codelib/CodeLib.lean
+++ b/codelib/CodeLib.lean
@@ -32,7 +32,6 @@ import CodeLib.RustStd.Option
 import CodeLib.Near.State
 import CodeLib.Near.Env
 import CodeLib.Near.Proof
-import CodeLib.IEEE32.Exec
 import CodeLib.SepLogic.WasmHeap
 import CodeLib.SepLogic.WasmRules
 import CodeLib.SepLogic.SmallStepLanguage

--- a/codelib/CodeLib/IEEE32/Exec.lean
+++ b/codelib/CodeLib/IEEE32/Exec.lean
@@ -3,7 +3,21 @@ import Std.Tactic.BVDecide
 
 open Wasm
 
-/-! Pure bitvector IEEE 754 f32 operations and bridge axioms for `float_trunc` proofs. -/
+/-!
+Pure bitvector IEEE 754 f32 operations and bridge axioms for `float_trunc` proofs.
+
+**These bridge axioms are trusted, not proved.** The five `axiom` declarations
+below (`beq_ax`, `isNaN_ax`, `ble_ax`, `blt_ax`, `satI32S_eq`) assert that Lean's
+opaque `Float32`/`Float` externs agree with the bitvector model defined here;
+they are the only axioms in this repository beyond Lean's own. Anything that
+imports this module and uses them — including everything proved further down
+this file — is therefore *not* axiom-free. Check what a given result rests on
+with `#print axioms <name>`.
+
+For that reason the `CodeLib` umbrella does **not** import this module: import
+`CodeLib.IEEE32.Exec` explicitly in the (few) files that need the bridge, so the
+axioms stay out of the ambient environment of everything else.
+-/
 
 namespace IEEE32Exec
 

--- a/codelib/lakefile.toml
+++ b/codelib/lakefile.toml
@@ -18,6 +18,10 @@ rev = "e7a0a43814c4f1154ca0c8049883ca56c2288b86"
 name = "CodeLib"
 roots = [
   "CodeLib",
+  # Not reachable from the `CodeLib` umbrella on purpose: it declares the float
+  # bridge axioms, which should not enter every downstream module's environment.
+  # It is still a root so the codelib build keeps checking it.
+  "CodeLib.IEEE32.Exec",
   "CodeLib.Examples.Gcd",
   "CodeLib.Examples.MergeSort.StdIO",
   "CodeLib.Examples.Quicksort.Proof",

--- a/programs/lean/Project/FloatTrunc/Spec.lean
+++ b/programs/lean/Project/FloatTrunc/Spec.lean
@@ -1,4 +1,5 @@
 import Project.FloatTrunc.Program
+import CodeLib.IEEE32.Exec
 
 /-!
 # Specification for `float_trunc`


### PR DESCRIPTION
`CodeLib/IEEE32/Exec.lean` declares the repo's five `axiom`s, bridging Lean's opaque `Float32` externs to a bitvector model. `CodeLib.lean` imported it unconditionally, so all five sat in the environment of every downstream module including every generated `Program.lean`.

Drops the umbrella import, adds it directly to `FloatTrunc/Spec.lean`, and keeps the module as an explicit lakefile root so the codelib build still checks it. Docstring now says these are trusted, not proved.

Green (3599 jobs).