### PR TITLE
docs: correct docstrings that describe a repo state that no longer exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ Three layers, kept deliberately small:
 
 ## Public spec API: don't expose fuel
 
-`run` takes an explicit `fuel : Nat` so that it terminates syntactically, but fuel is a proof obligation, not part of what a wasm function "does". User-facing specs should never mention fuel — no `∃ fuel, run … fuel = some rs` and no fixed numeric fuel in the statement. Use the fuel-free predicates from `Interpreter/Wasm/Spec/Termination.lean` instead:
+`run` takes an explicit `fuel : Nat` so that it terminates syntactically, but fuel is a proof obligation, not part of what a wasm function "does". User-facing specs should never mention fuel — no `∃ fuel, run … fuel = some rs` and no fixed numeric fuel in the statement. Use the fuel-free predicates from `Interpreter/Wasm/Spec/Defs.lean` instead (`Spec/Termination.lean` re-exports them and adds the `FuncSpec` bridge):
 
 - `Wasm.TerminatesWith env m entry initial args P` — total correctness (some fuel succeeds, result satisfies `P`). Discharge via `TerminatesWith.of_run` / `of_run_eq` by exhibiting a concrete fuel internally.
 - `Wasm.PartiallyMeets env m entry initial args P` — partial correctness (every terminating fuel-bounded run satisfies `P`).
@@ -207,4 +207,9 @@ When writing or updating a spec theorem (tagged `@[spec_of …]` / `@[proves …
 
 ## Examples
 
-Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built Wasm module and proves theorems about it using the WP tactic layer. The standard pattern: state the property, apply `wp_run` to reduce to a concrete computation, then close with `simp` / `omega` / domain lemmas. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.
+Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built (or WAT-decoded) Wasm module plus the `SmallStep.Config` that starts it, and proves theorems against the small-step machine. The WP tactic layer is *not* used here — no example calls `wp_run`. Two idioms carry the directory:
+
+- **Concrete inputs.** Pin `(runSteps n config).result` with `rfl` or `native_decide`. The decoder-oriented examples go through the total projections in `Examples/Harness.lean` (`runValues` / `runTrapMsg` / `runInvalidMsg` / `decodeOrDefault`) so `native_decide` can evaluate them.
+- **Symbolic inputs.** Exhibit the trace explicitly: `apply Steps.cons` once per named `Step` constructor, closing side conditions with `decide` / `simp` / `omega` / domain lemmas. Loops state an invariant at an intermediate `Config` and are closed by `Nat.strong_induction_on` over a decreasing measure (see `Factorial.lean`, `SimpleLoop.lean`, `Gcd.lean`).
+
+The fuel-free statement comes last: lift the run with `runSteps_eq_success_of_steps` / `runSteps_values_terminates` / `runSteps_values_partiallyMeets` / `runSteps_trapped_trapsWith` into `SmallStep.TerminatesWith` / `PartiallyMeets` / `TrapsWith`. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Three layers, kept deliberately small:
 
 ## Public spec API: don't expose fuel
 
-`run` takes an explicit `fuel : Nat` so that it terminates syntactically, but fuel is a proof obligation, not part of what a wasm function "does". User-facing specs should never mention fuel — no `∃ fuel, run … fuel = some rs` and no fixed numeric fuel in the statement. Use the fuel-free predicates from `Interpreter/Wasm/Spec/Termination.lean` instead:
+`run` takes an explicit `fuel : Nat` so that it terminates syntactically, but fuel is a proof obligation, not part of what a wasm function "does". User-facing specs should never mention fuel — no `∃ fuel, run … fuel = some rs` and no fixed numeric fuel in the statement. Use the fuel-free predicates from `Interpreter/Wasm/Spec/Defs.lean` instead (`Spec/Termination.lean` re-exports them and adds the `FuncSpec` bridge):
 
 - `Wasm.TerminatesWith env m entry initial args P` — total correctness (some fuel succeeds, result satisfies `P`). Discharge via `TerminatesWith.of_run` / `of_run_eq` by exhibiting a concrete fuel internally.
 - `Wasm.PartiallyMeets env m entry initial args P` — partial correctness (every terminating fuel-bounded run satisfies `P`).
@@ -93,4 +93,9 @@ Prefer new host state to be a record of defaulted fields, and never tag `HostFn.
 
 ## Examples
 
-Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built Wasm module and proves theorems about it using the WP tactic layer. The standard pattern: state the property, apply `wp_run` to reduce to a concrete computation, then close with `simp` / `omega` / domain lemmas. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.
+Examples live in `interpreter/Interpreter/Wasm/Examples/`. Each file defines a hand-built (or WAT-decoded) Wasm module plus the `SmallStep.Config` that starts it, and proves theorems against the small-step machine. The WP tactic layer is *not* used here — no example calls `wp_run`. Two idioms carry the directory:
+
+- **Concrete inputs.** Pin `(runSteps n config).result` with `rfl` or `native_decide`. The decoder-oriented examples go through the total projections in `Examples/Harness.lean` (`runValues` / `runTrapMsg` / `runInvalidMsg` / `decodeOrDefault`) so `native_decide` can evaluate them.
+- **Symbolic inputs.** Exhibit the trace explicitly: `apply Steps.cons` once per named `Step` constructor, closing side conditions with `decide` / `simp` / `omega` / domain lemmas. Loops state an invariant at an intermediate `Config` and are closed by `Nat.strong_induction_on` over a decreasing measure (see `Factorial.lean`, `SimpleLoop.lean`, `Gcd.lean`).
+
+The fuel-free statement comes last: lift the run with `runSteps_eq_success_of_steps` / `runSteps_values_terminates` / `runSteps_values_partiallyMeets` / `runSteps_trapped_trapsWith` into `SmallStep.TerminatesWith` / `PartiallyMeets` / `TrapsWith`. New examples should follow this pattern; browse the existing examples directory to find one close to what you are doing and mirror its structure.

--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -307,15 +307,13 @@ def parseF32Lit (s : String) : Except Err UInt32 := do
     let base : UInt32 := 0x7F800000 ||| UInt32.ofNat (p % 0x800000)
     .ok (if neg then base ||| 0x80000000 else base)
 
-/-- Decode a value-type atom. Numeric types and the two reference types
-of wasm 2.0 (`funcref`, `externref`) are modelled directly. Types from
-proposals the interpreter doesn't yet model (SIMD, GC) are accepted at
-the decoder level — silently normalised to `i32` — so that modules
-which include such types in *signatures* still decode. Functions whose
-bodies actually touch those types will hit `unreachable` (because the
-corresponding instructions are also lowered to `unreachable`), giving
-the testsuite runner a chance to run any supported exports declared in
-the same module. -/
+/-- Decode a value-type atom. Numeric types, the two reference types of
+wasm 2.0 (`funcref`, `externref`), `exnref` and the SIMD `v128` map to
+their own constructor; the GC abstract reference types (`anyref`,
+`eqref`, `i31ref`, `structref`, `arrayref`, `nullref`) map to the
+nullable `ValueType.ref` form over the matching `GcHeapType`.
+`nullfuncref` / `nullexternref` collapse onto `funcref` / `externref`,
+which already carry their own null. -/
 private def atomToValueType? : String → Option Wasm.ValueType
   | "i32"       => some .i32
   | "i64"       => some .i64
@@ -341,11 +339,11 @@ private def isNullFuncrefHeapType (ht : String) : Bool :=
 private def isNullExternrefHeapType (ht : String) : Bool :=
   ht == "extern" || ht == "noextern"
 
-/-- Decode a reference value-type written in list form, e.g.
-`(ref func)`, `(ref null extern)`, `(ref $t)`. Symbolic and numeric heap
-types refer to the type table — pre-GC those are function types, so they
-map to `funcref`; GC heap types keep the `i32` placeholder used for
-unmodelled proposals. -/
+/-- Decode a heap-type atom: the `func` of `(ref func)`, the `extern` of
+`(ref null extern)`, the `$t` of `(ref $t)`. The abstract heap types each
+map to their own `GcHeapType` constructor; symbolic (`$t`) and numeric
+atoms refer to the module's type table and become `.named` / `.concrete`,
+resolved to an index during validation. -/
 private def atomToHeapType (ht : String) : Wasm.GcHeapType :=
   if ht == "any" then .any
   else if ht == "eq" then .eq

--- a/interpreter/Interpreter/Wasm/Host.lean
+++ b/interpreter/Interpreter/Wasm/Host.lean
@@ -15,9 +15,9 @@ runtime data, not Wasm-visible program state. Keeping it separate means
 existing `Store` invariants don't need to mention the host.
 
 For reasoning, programs are stated parametric over any `HostEnv`
-satisfying a `HostSpec` (introduced in a later milestone) — the
-contracts in a `HostSpec` constrain what the host is *allowed* to do,
-without committing to a particular implementation.
+satisfying a `HostSpec` (defined below) — the contracts in a `HostSpec`
+constrain what the host is *allowed* to do, without committing to a
+particular implementation.
 -/
 
 namespace Wasm

--- a/interpreter/Interpreter/Wasm/Semantics.lean
+++ b/interpreter/Interpreter/Wasm/Semantics.lean
@@ -6,7 +6,7 @@ import Interpreter.Wasm.Host
 
 namespace Wasm
 
-/-! ## Numeric helpers (carried over from `Interpreter.Core.Interp`). -/
+/-! ## Numeric helpers. -/
 
 /-- Number of leading zero bits in a 32-bit word; 32 if zero. -/
 def clz32 : Nat → UInt32 → Nat

--- a/interpreter/Interpreter/Wasm/SmallStep.lean
+++ b/interpreter/Interpreter/Wasm/SmallStep.lean
@@ -5,15 +5,14 @@ set_option maxHeartbeats 2000000
 /-!
 # Small-step WebAssembly machine
 
-This file is the first vertical slice of the Iris migration.  The existing
-fuel-bounded interpreter remains available as a regression oracle, but none of
-the definitions below call `execOne`, `exec`, or `run`.
+This machine is the authoritative semantics.  The fuel-bounded big-step
+interpreter remains available as a regression oracle, but none of the
+definitions below call `execOne`, `exec`, or `run`.
 
 The relational `Step` relation is the semantic interface.  `stepChecked?` is
-its deterministic executable presentation for the instruction families ported
-so far.  An `InternalError` denotes a configuration which validation should
-have ruled out, or an instruction family which has not yet been migrated; it is
-not a Wasm trap.
+its deterministic executable presentation.  An `InternalError` denotes a
+configuration which validation should have ruled out — a malformed operand
+stack, an out-of-range index, an unresolved import; it is not a Wasm trap.
 -/
 
 namespace Wasm

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -8,9 +8,10 @@ namespace Wasm
 Wasm's numeric types `i32`, `i64`, `f32`, `f64`, plus the `funcref`
 reference type needed for tables and `call_indirect`. Floats are carried
 by their IEEE-754 bit pattern (`f32` as `UInt32`, `f64` as `UInt64`); the
-operations live in `Interpreter.Wasm.Float`. Other reference types remain
-out of scope. Memory loads/stores, globals, tables, and indirect calls are
-supported. -/
+operations live in `Interpreter.Wasm.Float`. The remaining wasm 3.0 types
+are modelled too: `externref`, `exnref`, the SIMD `v128`, the managed
+`anyref`, and the precise `ref nullable heap` form validation uses.
+Memory loads/stores, globals, tables, and indirect calls are supported. -/
 
 /-- A heap type used by both static reference types and GC cast/test
 instructions. `named` preserves a symbolic source reference until module
@@ -260,11 +261,12 @@ deriving Repr, Inhabited, DecidableEq
 
 /-! ## Instructions
 
-The instruction set mirrors `Interpreter.Core.Ast.Instr` minus the
-features that require a `Store` (tables, `call_indirect`).
-Naming follows Core where applicable; the two historical Wasm differences
-(`and`, `br_if`) are kept for backward compatibility with the existing
-examples. -/
+One constructor per modelled Wasm instruction, including the ones that
+reach into the `Store` (memories, globals, tables, `call_indirect`).
+Constructor names are the Wasm mnemonics in camelCase: the `i32` arms are
+unsuffixed (`add`, `load32`), their `i64` counterparts carry an `I64`
+suffix (`addI64`, `load64`), and the float arms keep their type prefix
+(`f32Add`). `br_if` retains its underscore. -/
 
 inductive Instruction where
   -- Constants / locals
@@ -640,8 +642,9 @@ structure DataSegment where
   offsetExpr : Program := []
 deriving Repr, Inhabited
 
-/-- Declaration of a single linear memory. Wasm allows at most one
-memory per module. -/
+/-- Declaration of a single linear memory. `Module.memory` holds the
+default memory; the multi-memory proposal's further memories live in
+`Module.extraMemories`. -/
 structure MemDecl where
   pagesMin : UInt32
   pagesMax : Option UInt32 := none
@@ -714,9 +717,10 @@ structure GcTypeDef where
   recGroup : Option Nat := none
 deriving Repr, Inhabited
 
-/-- Declaration of a single table. The interpreter only models
-`funcref` tables; the size bounds are the declared minimum and (optional)
-declared maximum. A freshly instantiated table has `min` null refs. -/
+/-- Declaration of a single table. `elemType` is the declared element
+type, defaulting to `funcref`; the size bounds are the declared minimum
+and (optional) declared maximum. A freshly instantiated table holds `min`
+copies of `elemType`'s zero value. -/
 structure TableDecl where
   min      : Nat
   max      : Option Nat := none

--- a/interpreter/Interpreter/Wasm/Validate.lean
+++ b/interpreter/Interpreter/Wasm/Validate.lean
@@ -12,8 +12,11 @@ It is deliberately run **only** on modules an `assert_invalid` /
 `assert_malformed` command already declares ill-formed (see the testsuite
 harness), so it never rejects a module a normal `(module …)` command would
 accept — a too-aggressive check can only make an already-invalid module
-pass for a slightly different reason, never break a valid one. A full
-operand-stack type checker (for the `type mismatch` cases) is future work.
+pass for a slightly different reason, never break a valid one. The
+`type mismatch` cases are covered by an operand-stack type checker
+(`Program.checkTypes`, run per function body by `Module.checkFuncStraight`
+as `Module.validate`'s last step), itself partial: it gives up and accepts
+the function as soon as it meets an instruction it does not model.
 -/
 
 namespace Wasm
@@ -874,9 +877,10 @@ def StorageType.vt : StorageType → ValueType
   | .val vt   => vt
   | .packed _ => .i32
 
-/-- The static value type a global exposes. The `type` field was dropped
-from `GlobalDecl` (it was unused at runtime), so recover the declared type
-from the initializer value the decoder stored. -/
+/-- The value type of a runtime value, as seen by the stack checker. Used
+to recover a global's static type when `GlobalDecl.declaredType` is absent
+— decoded modules always retain the source declaration, but hand-built
+ones leave it `none`. -/
 def Value.toValueType : Value → ValueType
   | .i32 _       => .i32
   | .i64 _       => .i64


### PR DESCRIPTION
Comments and markdown only — no Lean term changed. Each claim was re-checked against current source before rewriting.

What was wrong:
- `Syntax.lean` / `Semantics.lean` referenced `Interpreter.Core.Ast.Instr` and `Interpreter.Core.Interp`. There is no `Interpreter/Core` directory.
- `Syntax.lean` said other reference types are "out of scope" (directly above `externref`/`v128`/`exnref`/`anyref`), "at most one memory per module" (`Module.extraMemories` exists), "only models funcref tables" (`TableDecl.elemType : ValueType`), and that `callIndirect`/table instructions are excluded (all implemented).
- `Validate.lean` said an operand-stack type checker "is future work" — it exists as `Program.checkTypes`. Documented as *partial* (it returns `none` on unmodelled instructions, which `checkFuncStraight` then accepts). Also said `type` was dropped from `GlobalDecl`; `declaredType` is there.
- `SmallStep.lean` still called itself "the first vertical slice of the Iris migration" with an unmigrated instruction family. There is none.
- `Host.lean` said `HostSpec` arrives "in a later milestone"; it is 66 lines below.
- `Decoder/Wat.lean` claimed SIMD/GC types are "silently normalised to i32"; the body returns `.v128`, `.eq`, `.i31`, `.structT`, `.arrayT`, `.noneT`.
- `CLAUDE.md`/`AGENTS.md` pointed at `Spec/Termination.lean` for `TerminatesWith`/`PartiallyMeets` (they live in `Spec/Defs.lean`), and said examples use `wp_run` — **no example does**; the section now describes the two idioms actually in use.

Verified: `lake build Project --wfail` green (3599 jobs).