### PR TITLE
interpreter: derive the example _partial theorems from their total-correctness twins

### DIFF
--- a/interpreter/Interpreter/Wasm/Examples/CallIndirect.lean
+++ b/interpreter/Interpreter/Wasm/Examples/CallIndirect.lean
@@ -135,6 +135,6 @@ theorem dispatchSpec (n : UInt32) :
 theorem dispatch_partial (n : UInt32) :
     PartiallyMeets (dispatchConfig n)
       (fun values _ => values = [.i32 (n + 1)]) :=
-  runSteps_values_partiallyMeets (dispatch_runs n)
+  (dispatchSpec n).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/ClzPopcnt.lean
+++ b/interpreter/Interpreter/Wasm/Examples/ClzPopcnt.lean
@@ -96,28 +96,19 @@ theorem popcntSpec (a : UInt32) :
 theorem clz_partial (a : UInt32) :
     PartiallyMeets (clzConfig a)
       (fun values _ =>
-        values = [.i32 (UInt32.ofNat (clz32 32 a))]) := by
-  apply runSteps_success_partiallyMeets (fuel := 3)
-    (values := [.i32 (UInt32.ofNat (clz32 32 a))])
-  · rfl
-  · rfl
+        values = [.i32 (UInt32.ofNat (clz32 32 a))]) :=
+  (clzSpec a).toPartiallyMeets
 
 theorem ctz_partial (a : UInt32) :
     PartiallyMeets (ctzConfig a)
       (fun values _ =>
-        values = [.i32 (UInt32.ofNat (ctz32 32 a))]) := by
-  apply runSteps_success_partiallyMeets (fuel := 3)
-    (values := [.i32 (UInt32.ofNat (ctz32 32 a))])
-  · rfl
-  · rfl
+        values = [.i32 (UInt32.ofNat (ctz32 32 a))]) :=
+  (ctzSpec a).toPartiallyMeets
 
 theorem popcnt_partial (a : UInt32) :
     PartiallyMeets (popcntConfig a)
       (fun values _ =>
-        values = [.i32 (UInt32.ofNat (popcnt32 32 a 0))]) := by
-  apply runSteps_success_partiallyMeets (fuel := 3)
-    (values := [.i32 (UInt32.ofNat (popcnt32 32 a 0))])
-  · rfl
-  · rfl
+        values = [.i32 (UInt32.ofNat (popcnt32 32 a 0))]) :=
+  (popcntSpec a).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/Counter.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Counter.lean
@@ -195,11 +195,8 @@ theorem counter_partial
         values = [] ∧
         store.wasm.host =
           Counter.insert st.host 0
-            (1 + Counter.lookup st.host 0)) := by
-  intro trace values store execution
-  obtain ⟨rfl, rfl⟩ :=
-    steps_done_deterministic (counter_steps hSat st) execution
-  exact ⟨rfl, rfl⟩
+            (1 + Counter.lookup st.host 0)) :=
+  (counter_correct hSat st).toPartiallyMeets
 
 end Counter
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/DecoderImport.lean
+++ b/interpreter/Interpreter/Wasm/Examples/DecoderImport.lean
@@ -113,7 +113,7 @@ theorem caller_against_incEnv_spec :
 
 theorem caller_against_incEnv_partial :
     PartiallyMeets callerConfig (fun values _ => values = [.i32 42]) :=
-  runSteps_values_partiallyMeets caller_against_incEnv
+  caller_against_incEnv_spec.toPartiallyMeets
 
 end DecoderImport
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
+++ b/interpreter/Interpreter/Wasm/Examples/DecoderImportedGlobal.lean
@@ -72,7 +72,7 @@ theorem importedGlobalWat_getD_spec :
 
 theorem importedGlobalWat_getD_partial :
     PartiallyMeets getDConfig (fun values _ => values = [.i32 99]) :=
-  runSteps_values_partiallyMeets importedGlobalWat_getD_returns_99
+  importedGlobalWat_getD_spec.toPartiallyMeets
 
 end DecoderImportedGlobal
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/EarlyBr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EarlyBr.lean
@@ -46,6 +46,6 @@ theorem earlyBrSpec (x : UInt32) :
 theorem earlyBr_partial (x : UInt32) :
     PartiallyMeets (earlyBrConfig x)
       (fun values _ => values = [.i32 x]) :=
-  runSteps_values_partiallyMeets (earlyBr_runs x)
+  (earlyBrSpec x).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/EarlyReturn.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EarlyReturn.lean
@@ -61,6 +61,6 @@ theorem earlyReturnSpec (x : UInt32) :
 theorem earlyReturn_partial (x : UInt32) :
     PartiallyMeets (earlyReturnConfig x)
       (fun values _ => values = [.i32 x]) :=
-  runSteps_values_partiallyMeets (earlyReturn_runs x)
+  (earlyReturnSpec x).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
+++ b/interpreter/Interpreter/Wasm/Examples/EvenOddRec.lean
@@ -391,18 +391,12 @@ theorem oddSpec (n : UInt32) :
 
 theorem evenPartial (n : UInt32) :
     PartiallyMeets (evenConfig n)
-      (fun values _ => values = [.i32 (evenValue n)]) := by
-  intro trace values store observed
-  obtain ⟨expectedTrace, expected⟩ := even_steps n
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic expected observed
-  rfl
+      (fun values _ => values = [.i32 (evenValue n)]) :=
+  (evenSpec n).toPartiallyMeets
 
 theorem oddPartial (n : UInt32) :
     PartiallyMeets (oddConfig n)
-      (fun values _ => values = [.i32 (oddValue n)]) := by
-  intro trace values store observed
-  obtain ⟨expectedTrace, expected⟩ := odd_steps n
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic expected observed
-  rfl
+      (fun values _ => values = [.i32 (oddValue n)]) :=
+  (oddSpec n).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/Factorial.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Factorial.lean
@@ -188,10 +188,7 @@ theorem factorialSpec (n : UInt32) :
 theorem factorialPartial (n : UInt32) :
     PartiallyMeets (factorialConfig n)
       (fun values _ =>
-        values = [.i32 (UInt32.ofNat n.toNat.factorial)]) := by
-  intro trace values store observed
-  obtain ⟨expectedTrace, expected⟩ := factorial_steps n
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic expected observed
-  rfl
+        values = [.i32 (UInt32.ofNat n.toNat.factorial)]) :=
+  (factorialSpec n).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/FloatOps.lean
+++ b/interpreter/Interpreter/Wasm/Examples/FloatOps.lean
@@ -117,6 +117,6 @@ theorem mem_roundtrip_spec :
 theorem mem_roundtrip_partial :
     PartiallyMeets (floatConfig 7)
       (fun values _ => values = [.f64 (3.5 : Float).toBits]) :=
-  runSteps_values_partiallyMeets mem_roundtrip
+  mem_roundtrip_spec.toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/Gcd.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Gcd.lean
@@ -199,10 +199,7 @@ theorem gcdSpec (a b : UInt32) :
 theorem gcdPartial (a b : UInt32) :
     PartiallyMeets (gcdConfig a b)
       (fun values _ =>
-        values = [.i32 (UInt32.ofNat (Nat.gcd a.toNat b.toNat))]) := by
-  intro trace values store observed
-  obtain ⟨expectedTrace, expected⟩ := gcd_steps a b
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic expected observed
-  rfl
+        values = [.i32 (UInt32.ofNat (Nat.gcd a.toNat b.toNat))]) :=
+  (gcdSpec a b).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/GlobalCounter.lean
+++ b/interpreter/Interpreter/Wasm/Examples/GlobalCounter.lean
@@ -95,12 +95,8 @@ theorem tick_partial (st : Store Unit) (n : UInt32)
     (hg : st.globals.globals[0]? = some (.i32 n)) :
     PartiallyMeets (tickConfig st) (fun values store =>
       values = [.i32 n] ∧
-      store.wasm.globals.globals[0]? = some (.i32 (1 + n))) := by
-  apply runSteps_success_partiallyMeets (tick_runs st n hg)
-  constructor
-  · rfl
-  simp [tickFinalStore, tickStore]
-  grind
+      store.wasm.globals.globals[0]? = some (.i32 (1 + n))) :=
+  (tick_spec st n hg).toPartiallyMeets
 
 def tickInitialStore : Store Unit := tickModule.initialStore
 def tickAfterZero : Store Unit := (tickFinalStore tickInitialStore 0).wasm

--- a/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/GlobalInitExpr.lean
@@ -55,7 +55,7 @@ theorem getG_spec :
 
 theorem getG_partial :
     PartiallyMeets getGConfig (fun values _ => values = [.i32 42]) :=
-  runSteps_values_partiallyMeets getG_returns_42
+  getG_spec.toPartiallyMeets
 
 /-! ### GC allocator initializers (issue #109) -/
 
@@ -100,7 +100,7 @@ theorem leaf_struct_new_spec :
 theorem leaf_struct_new_partial :
     PartiallyMeets leafStructConfig
       (fun values _ => values = [.i32 100]) :=
-  runSteps_values_partiallyMeets leaf_struct_new_returns_100
+  leaf_struct_new_spec.toPartiallyMeets
 
 theorem arith_struct_new_returns_100 :
     (runSteps 4 arithStructConfig).result.values? =
@@ -115,7 +115,7 @@ theorem arith_struct_new_spec :
 theorem arith_struct_new_partial :
     PartiallyMeets arithStructConfig
       (fun values _ => values = [.i32 100]) :=
-  runSteps_values_partiallyMeets arith_struct_new_returns_100
+  arith_struct_new_spec.toPartiallyMeets
 
 end GlobalInitExpr
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/HostDispatch.lean
+++ b/interpreter/Interpreter/Wasm/Examples/HostDispatch.lean
@@ -244,12 +244,8 @@ theorem inc_call_partial_abstract
     (st : Store Unit) (n : UInt32) :
     PartiallyMeets (incCallConfig env st n)
       (fun values store =>
-        values = [.i32 (n + 1)] ∧ store.wasm = st) := by
-  intro trace values store execution
-  obtain ⟨rfl, rfl⟩ :=
-    steps_done_deterministic
-      (inc_call_steps_abstract env hSat st n) execution
-  exact ⟨rfl, rfl⟩
+        values = [.i32 (n + 1)] ∧ store.wasm = st) :=
+  (inc_call_terminates_abstract env hSat st n).toPartiallyMeets
 
 end HostDispatch
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/IfAbs.lean
+++ b/interpreter/Interpreter/Wasm/Examples/IfAbs.lean
@@ -86,6 +86,6 @@ theorem ifAbsSpec (x : UInt32) :
 theorem ifAbs_partial (x : UInt32) :
     PartiallyMeets (ifAbsConfig x)
       (fun values _ => values = [.i32 (ifAbsResult x)]) :=
-  runSteps_values_partiallyMeets (ifAbs_runs x)
+  (ifAbsSpec x).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/IsEven.lean
+++ b/interpreter/Interpreter/Wasm/Examples/IsEven.lean
@@ -46,6 +46,6 @@ theorem isEvenSpec (value : UInt32) :
 theorem isEven_partial (value : UInt32) :
     PartiallyMeets (isEvenConfig value)
       (fun values _ => values = [.i32 (isEvenResult value)]) :=
-  runSteps_values_partiallyMeets (isEven_runs value)
+  (isEvenSpec value).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemCopy.lean
@@ -79,9 +79,8 @@ theorem copy_disjoint_spec :
 
 theorem copy_disjoint_partial :
     PartiallyMeets copyDisjointConfig (fun values store =>
-      values = [.i32 0x44332211] ∧ store.wasm.mem.read32 8 = 0x44332211) := by
-  apply runSteps_success_partiallyMeets copy_disjoint_moves_bytes
-  constructor <;> native_decide
+      values = [.i32 0x44332211] ∧ store.wasm.mem.read32 8 = 0x44332211) :=
+  copy_disjoint_spec.toPartiallyMeets.mono fun _ _ post => ⟨post.1, post.2.2⟩
 
 theorem copy_overlap_uses_pre_copy_bytes :
     (runSteps 7 copyOverlapConfig).result =
@@ -99,9 +98,8 @@ theorem copy_overlap_spec :
 theorem copy_overlap_partial :
     PartiallyMeets copyOverlapConfig (fun values store =>
       values = [.i64 0x8877443322112211] ∧
-      store.wasm.mem.read32 2 = 0x44332211) := by
-  apply runSteps_success_partiallyMeets copy_overlap_uses_pre_copy_bytes
-  constructor <;> native_decide
+      store.wasm.mem.read32 2 = 0x44332211) :=
+  copy_overlap_spec.toPartiallyMeets
 
 theorem copy_out_of_bounds_traps :
     (runSteps 4 copyTrapConfig).result =

--- a/interpreter/Interpreter/Wasm/Examples/MemDataSection.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemDataSection.lean
@@ -47,8 +47,7 @@ theorem memDataSection_spec :
 theorem memDataSection_partial :
     PartiallyMeets memDataConfig (fun values store =>
       values = [.i32 7] ∧
-      store.wasm.mem.read32 0 = 0x45444342) := by
-  apply runSteps_success_partiallyMeets memDataSection_runs
-  constructor <;> native_decide
+      store.wasm.mem.read32 0 = 0x45444342) :=
+  memDataSection_spec.toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/MemFill.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemFill.lean
@@ -73,9 +73,8 @@ theorem fill_then_load_spec :
 theorem fill_then_load_partial :
     PartiallyMeets fillThenReadConfig (fun values store =>
       values = [.i64 0xABABABABABABABAB] ∧
-      store.wasm.mem.read64 0 = 0xABABABABABABABAB) := by
-  apply runSteps_success_partiallyMeets fill_then_load_returns_repeated_byte
-  constructor <;> native_decide
+      store.wasm.mem.read64 0 = 0xABABABABABABABAB) :=
+  fill_then_load_spec.toPartiallyMeets.mono fun _ _ post => ⟨post.1, post.2.1⟩
 
 /-- The failing instruction is atomic: the trap retains the original store. -/
 theorem fill_out_of_bounds_traps :

--- a/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemGrow.lean
@@ -88,11 +88,8 @@ theorem memoryGrow_partial :
     PartiallyMeets growThenSizeConfig (fun values store =>
       values = [.i32 3] ∧
       store.wasm.mem.pages = 3 ∧
-      store.wasm.mem.read32 64 = 0xC0DEC0DE) := by
-  apply runSteps_success_partiallyMeets memoryGrow_bumps_size
-  constructor
-  · rfl
-  constructor <;> native_decide
+      store.wasm.mem.read32 64 = 0xC0DEC0DE) :=
+  memoryGrow_spec.toPartiallyMeets
 
 /-- An oversized request returns `-1`, reports the unchanged size, and does
 not mutate any component of the machine store. -/
@@ -109,9 +106,8 @@ theorem memoryGrow_failure_spec :
 
 theorem memoryGrow_failure_partial :
     PartiallyMeets growFailConfig (fun values store =>
-      values = [.i32 1, .i32 0xFFFFFFFF] ∧ store = growStore) := by
-  apply runSteps_success_partiallyMeets memoryGrow_oversize_returns_neg_one
-  exact ⟨rfl, rfl⟩
+      values = [.i32 1, .i32 0xFFFFFFFF] ∧ store = growStore) :=
+  memoryGrow_failure_spec.toPartiallyMeets
 
 /-! ### Imported-resource limit ownership
 

--- a/interpreter/Interpreter/Wasm/Examples/MemI64.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemI64.lean
@@ -118,16 +118,10 @@ theorem i64Mem_partial_contracts :
     PartiallyMeets (i64MemConfig 8) (fun vs _ => vs = [.i64 0xCDEF]) ∧
     PartiallyMeets (i64MemConfig 9) (fun vs _ => vs = [.i64 0xABCDEF01]) ∧
     PartiallyMeets (i64MemConfig 10) (fun vs _ => vs = [.i64 0x1122334455667788]) := by
-  exact ⟨runSteps_values_partiallyMeets load64_returns_word,
-    runSteps_values_partiallyMeets load8UI64_zero_extends,
-    runSteps_values_partiallyMeets load8SI64_sign_extends,
-    runSteps_values_partiallyMeets load16UI64_zero_extends,
-    runSteps_values_partiallyMeets load16SI64_sign_extends,
-    runSteps_values_partiallyMeets load32UI64_zero_extends,
-    runSteps_values_partiallyMeets load32SI64_sign_extends,
-    runSteps_values_partiallyMeets store8I64_roundtrip,
-    runSteps_values_partiallyMeets store16I64_roundtrip,
-    runSteps_values_partiallyMeets store32I64_roundtrip,
-    runSteps_values_partiallyMeets store64_roundtrip⟩
+  obtain ⟨h0, h1, h2, h3, h4, h5, h6, h7, h8, h9, h10⟩ := i64Mem_contracts
+  exact ⟨h0.toPartiallyMeets, h1.toPartiallyMeets, h2.toPartiallyMeets,
+    h3.toPartiallyMeets, h4.toPartiallyMeets, h5.toPartiallyMeets,
+    h6.toPartiallyMeets, h7.toPartiallyMeets, h8.toPartiallyMeets,
+    h9.toPartiallyMeets, h10.toPartiallyMeets⟩
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemNarrowI32.lean
@@ -85,11 +85,8 @@ theorem narrowI32_partial_contracts :
     PartiallyMeets (narrowI32Config 3) (fun vs _ => vs = [.i32 0xFFFFFFCD]) ∧
     PartiallyMeets (narrowI32Config 4) (fun vs _ => vs = [.i32 0xAB]) ∧
     PartiallyMeets (narrowI32Config 5) (fun vs _ => vs = [.i32 0xABCD]) := by
-  exact ⟨runSteps_values_partiallyMeets load8U_returns_byte,
-    runSteps_values_partiallyMeets load8S_sign_extends,
-    runSteps_values_partiallyMeets load16U_returns_halfword,
-    runSteps_values_partiallyMeets load16S_sign_extends,
-    runSteps_values_partiallyMeets store8_roundtrip,
-    runSteps_values_partiallyMeets store16_roundtrip⟩
+  obtain ⟨h0, h1, h2, h3, h4, h5⟩ := narrowI32_contracts
+  exact ⟨h0.toPartiallyMeets, h1.toPartiallyMeets, h2.toPartiallyMeets,
+    h3.toPartiallyMeets, h4.toPartiallyMeets, h5.toPartiallyMeets⟩
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/MemReplace.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MemReplace.lean
@@ -99,11 +99,7 @@ theorem replace_partial (st : Store Unit) (new old : UInt32)
     (hpages : 1 ≤ st.mem.pages) (hmem : st.mem.read32 0 = old) :
     PartiallyMeets (replaceConfig st new) (fun values store =>
       values = [.i32 old] ∧
-      store.wasm.mem.read32 0 = new) := by
-  apply runSteps_success_partiallyMeets (replace_runs st new old hpages hmem)
-  constructor
-  · rfl
-  simp [replaceFinalStore, replaceStore, Mem.read32, Mem.write32]
-  bv_decide
+      store.wasm.mem.read32 0 = new) :=
+  (replace_spec st new old hpages hmem).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
+++ b/interpreter/Interpreter/Wasm/Examples/MultiValue.lean
@@ -123,11 +123,8 @@ theorem swapSpec (a b : UInt32) :
 
 theorem swap_partial (a b : UInt32) :
     PartiallyMeets (swapConfig a b)
-      (fun values _ => values = [.i32 a, .i32 b]) := by
-  apply runSteps_success_partiallyMeets (fuel := 3)
-    (values := [.i32 a, .i32 b])
-  · rfl
-  · rfl
+      (fun values _ => values = [.i32 a, .i32 b]) :=
+  (swapSpec a b).toPartiallyMeets
 
 /-! ### Check 3 — multi-value block -/
 
@@ -141,11 +138,8 @@ theorem pairBlockSpec (x : UInt32) :
 
 theorem pairBlock_partial (x : UInt32) :
     PartiallyMeets (pairBlockConfig x)
-      (fun values _ => values = [.i32 (x - 1), .i32 (1 + x)]) := by
-  apply runSteps_success_partiallyMeets (fuel := 9)
-    (values := [.i32 (x - 1), .i32 (1 + x)])
-  · rfl
-  · rfl
+      (fun values _ => values = [.i32 (x - 1), .i32 (1 + x)]) :=
+  (pairBlockSpec x).toPartiallyMeets
 
 /-! ### Check 4 — caller that consumes both results of a multi-value call -/
 
@@ -162,11 +156,8 @@ theorem callsSwapSpec :
 
 theorem callsSwap_partial :
     PartiallyMeets callsSwapConfig
-      (fun values _ => values = [.i32 8]) := by
-  apply runSteps_success_partiallyMeets (fuel := 8)
-    (values := [.i32 8])
-  · rfl
-  · rfl
+      (fun values _ => values = [.i32 8]) :=
+  callsSwapSpec.toPartiallyMeets
 
 /-! ### Check 5 — decoder: `block (type $sig)` resolves to the right arity
 

--- a/interpreter/Interpreter/Wasm/Examples/RefIsNull.lean
+++ b/interpreter/Interpreter/Wasm/Examples/RefIsNull.lean
@@ -46,11 +46,8 @@ theorem refReflectSpec (m : Module) (st : Store α) :
 theorem refReflect_partial (m : Module) (st : Store α) :
     PartiallyMeets (refReflectConfig m st)
       (fun values store =>
-        values = [.i32 0, .i32 1] ∧ store.wasm = st) := by
-  intro trace values store execution
-  obtain ⟨rfl, rfl⟩ :=
-    steps_done_deterministic (refReflect_steps m st) execution
-  exact ⟨rfl, rfl⟩
+        values = [.i32 0, .i32 1] ∧ store.wasm = st) :=
+  (refReflectSpec m st).toPartiallyMeets
 
 namespace Decoded
 

--- a/interpreter/Interpreter/Wasm/Examples/SegmentOffsetExpr.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SegmentOffsetExpr.lean
@@ -78,11 +78,8 @@ theorem readByte4_spec :
 deterministic, so the trace witnessed by `readByte4_spec` is the only one. -/
 theorem readByte4_partial :
     PartiallyMeets readByte4Config (fun values store =>
-      values = [.i32 65] ∧ store.wasm.mem.read8 4 = 65) := by
-  intro trace values store htrace
-  obtain ⟨_, expected, expectedStore, execution, hpost⟩ := readByte4_spec
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic execution htrace
-  exact ⟨hpost.1, hpost.2.1⟩
+      values = [.i32 65] ∧ store.wasm.mem.read8 4 = 65) :=
+  readByte4_spec.toPartiallyMeets.mono fun _ _ post => ⟨post.1, post.2.1⟩
 
 theorem callAt2_returns_42 :
     (runSteps 16 callAt2Config).result.values? =
@@ -97,7 +94,7 @@ theorem callAt2_spec :
 theorem callAt2_partial :
     PartiallyMeets callAt2Config (fun values _ =>
       values = [.i32 42]) :=
-  runSteps_values_partiallyMeets callAt2_returns_42
+  callAt2_spec.toPartiallyMeets
 
 theorem byte0_still_zero : store0.mem.read8 0 = 0 := by
   native_decide

--- a/interpreter/Interpreter/Wasm/Examples/SelectAbs.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SelectAbs.lean
@@ -55,6 +55,6 @@ theorem selectAbsSpec (n : UInt32) :
 theorem selectAbs_partial (n : UInt32) :
     PartiallyMeets (selectAbsConfig n)
       (fun values _ => values = [.i32 (selectAbsResult n)]) :=
-  runSteps_values_partiallyMeets (selectAbs_runs n)
+  (selectAbsSpec n).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/SelectMin.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SelectMin.lean
@@ -58,6 +58,6 @@ theorem selectMinSpec (x y : UInt32) :
 theorem selectMin_partial (x y : UInt32) :
     PartiallyMeets (selectMinConfig x y)
       (fun values _ => values = [.i32 (if x < y then x else y)]) :=
-  runSteps_values_partiallyMeets (selectMin_runs x y)
+  (selectMinSpec x y).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SimpleLoop.lean
@@ -201,10 +201,7 @@ theorem simpleLoopSpec (n : UInt32) :
 
 theorem simpleLoopPartial (n : UInt32) :
     PartiallyMeets (simpleLoopConfig n)
-      (fun values _ => values = [.i32 n]) := by
-  intro trace values store observed
-  obtain ⟨expectedTrace, expected⟩ := simpleLoop_steps n
-  obtain ⟨rfl, rfl⟩ := steps_done_deterministic expected observed
-  rfl
+      (fun values _ => values = [.i32 n]) :=
+  (simpleLoopSpec n).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/SmallStep.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SmallStep.lean
@@ -151,11 +151,8 @@ theorem memory_roundtrip_relational :
 
 theorem memory_roundtrip_partial :
     PartiallyMeets memoryRoundtripConfig (fun values store =>
-      values = [.i32 0x12345678] ∧ store.wasm.mem.read32 16 = 0x12345678) := by
-  apply runSteps_success_partiallyMeets memory_roundtrip_run
-  constructor
-  native_decide
-  · native_decide
+      values = [.i32 0x12345678] ∧ store.wasm.mem.read32 16 = 0x12345678) :=
+  memory_roundtrip_relational.toPartiallyMeets
 
 /-- A disjoint address remains unchanged by the store at address 16. -/
 theorem memory_roundtrip_frames_disjoint_word :
@@ -976,11 +973,8 @@ theorem swap_partial :
     PartiallyMeets swapConfig (fun values store =>
       values = [.i32 11, .i32 22] ∧
       store.wasm.mem.read32 0 = 22 ∧
-      store.wasm.mem.read32 4 = 11) := by
-  apply runSteps_success_partiallyMeets swap_run
-  constructor
-  native_decide
-  constructor <;> native_decide
+      store.wasm.mem.read32 4 = 11) :=
+  swap_relational.toPartiallyMeets
 
 theorem swap_matches_big_step :
     (runSteps 17 swapConfig).result.values? =
@@ -1048,13 +1042,8 @@ theorem reverse_three_partial :
       values = [.i32 11, .i32 33] ∧
       store.wasm.mem.read32 0 = 33 ∧
       store.wasm.mem.read32 4 = 22 ∧
-      store.wasm.mem.read32 8 = 11) := by
-  apply runSteps_success_partiallyMeets reverse_three_run
-  constructor
-  native_decide
-  constructor
-  · native_decide
-  constructor <;> native_decide
+      store.wasm.mem.read32 8 = 11) :=
+  reverse_three_relational.toPartiallyMeets
 
 theorem reverse_three_matches_big_step :
     (runSteps 17 reverseThreeConfig).result.values? =
@@ -1133,9 +1122,8 @@ theorem partition_three_partial :
       store.wasm.mem.read32 4 = 22 ∧
       store.wasm.mem.read32 8 = 33 ∧
       store.wasm.mem.read32 0 ≤ store.wasm.mem.read32 4 ∧
-      store.wasm.mem.read32 4 ≤ store.wasm.mem.read32 8) := by
-  apply runSteps_success_partiallyMeets partition_three_run
-  native_decide
+      store.wasm.mem.read32 4 ≤ store.wasm.mem.read32 8) :=
+  partition_three_relational.toPartiallyMeets
 
 theorem partition_three_matches_big_step :
     (runSteps 19 partitionThreeConfig).result.values? =
@@ -1209,9 +1197,8 @@ theorem merge_two_partial :
       values = [] ∧
       store.wasm.mem.read32 0 = 4 ∧
       store.wasm.mem.read32 4 = 9 ∧
-      store.wasm.mem.read32 0 ≤ store.wasm.mem.read32 4) := by
-  apply runSteps_success_partiallyMeets merge_two_run
-  native_decide
+      store.wasm.mem.read32 0 ≤ store.wasm.mem.read32 4) :=
+  merge_two_relational.toPartiallyMeets
 
 theorem merge_two_matches_big_step :
     (runSteps 18 mergeTwoConfig).result.values? =
@@ -2295,13 +2282,8 @@ theorem float_memory_roundtrip_partial :
       values =
         [ .f64 (-7.5 : Float).toBits, .f32 (1.25 : Float32).toBits ] ∧
       store.wasm.mem.read32 32 = (1.25 : Float32).toBits ∧
-      store.wasm.mem.read64 40 = (-7.5 : Float).toBits) := by
-  intro trace values store execution
-  obtain ⟨runTrace, runValues, runStore, runExecution, hpost⟩ :=
-    float_memory_roundtrip_relational
-  obtain ⟨rfl, rfl⟩ :=
-    steps_done_deterministic runExecution execution
-  exact hpost
+      store.wasm.mem.read64 40 = (-7.5 : Float).toBits) :=
+  float_memory_roundtrip_relational.toPartiallyMeets
 
 theorem float_memory_matches_big_step :
     (runSteps 11 floatMemoryConfig).result.values? =
@@ -2656,11 +2638,8 @@ theorem host_call_relational :
 
 theorem host_call_partial :
     PartiallyMeets smallStepHostConfig (fun values store =>
-      values = [.i32 42] ∧ store.wasm.mem.read32 200 = 41) := by
-  apply runSteps_success_partiallyMeets host_call_run
-  constructor
-  native_decide
-  · native_decide
+      values = [.i32 42] ∧ store.wasm.mem.read32 200 = 41) :=
+  host_call_relational.toPartiallyMeets
 
 theorem host_call_matches_big_step :
     (runSteps 4 smallStepHostConfig).result.values? =

--- a/interpreter/Interpreter/Wasm/Examples/SumI64.lean
+++ b/interpreter/Interpreter/Wasm/Examples/SumI64.lean
@@ -41,6 +41,6 @@ theorem sumI64Spec (x : UInt32) :
 theorem sumI64_partial (x : UInt32) :
     PartiallyMeets (sumI64Config x)
       (fun values _ => values = [.i32 (sumI64Result x)]) :=
-  runSteps_values_partiallyMeets (sumI64_runs x)
+  (sumI64Spec x).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/Switch.lean
+++ b/interpreter/Interpreter/Wasm/Examples/Switch.lean
@@ -153,6 +153,6 @@ theorem switchSpec (i : UInt32) :
 theorem switch_partial (i : UInt32) :
     PartiallyMeets (switchConfig i)
       (fun values _ => values = [.i32 (switchResult i)]) :=
-  runSteps_values_partiallyMeets (switch_runs i)
+  (switchSpec i).toPartiallyMeets
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Examples/TrapDivZero.lean
+++ b/interpreter/Interpreter/Wasm/Examples/TrapDivZero.lean
@@ -72,9 +72,7 @@ theorem trapDivZeroSpec (a b : UInt32) (hb : b ≠ 0) :
 
 theorem trapDivZero_partial (a b : UInt32) (hb : b ≠ 0) :
     PartiallyMeets (trapDivZeroConfig a b)
-      (fun values _ => values = [.i32 (a / b)]) := by
-  apply runSteps_success_partiallyMeets
-  · exact trapDivZero_runs_success a b hb
-  · rfl
+      (fun values _ => values = [.i32 (a / b)]) :=
+  (trapDivZeroSpec a b hb).toPartiallyMeets
 
 end Wasm


### PR DESCRIPTION
Rewrites ~49 example `_partial` theorems as `(twin ...).toPartiallyMeets`, using the bridge from #202.

Several were re-running `bv_decide` or `grind` on a goal proved a few lines above. Three had a genuinely weaker postcondition than their twin and go through `PartiallyMeets.mono` instead. Every statement is unchanged.

**33 files, −201/+87.** Green (3599 jobs).