### PR TITLE
codelib: add an address-ladder lemma for the repeated (base + n).toNat rewrites

### DIFF
--- a/codelib/CodeLib/RustStd/Array/SmallStep.lean
+++ b/codelib/CodeLib/RustStd/Array/SmallStep.lean
@@ -26,25 +26,9 @@ theorem fatPtrArithmetic {α} {st : Store α} {p dataPtr len : UInt32}
     ((p + 4) + 2).toNat = (p + 4).toNat + 2 ∧
     ((p + 4) + 3).toNat = (p + 4).toNat + 3 := by
   have hroom := h.noWrap
-  have step (n : Nat) (hn : n < 4294967296)
-      (hroom : p.toNat + n < 4294967296) :
-      (p + UInt32.ofNat n).toNat = p.toNat + n :=
-    UInt32.add_ofNat_toNat_noWrap p n hn hroom
-  have hp1 := step 1 (by decide) (by omega)
-  have hp2 := step 2 (by decide) (by omega)
-  have hp3 := step 3 (by decide) (by omega)
-  have hp4 := step 4 (by decide) (by omega)
-  have hp5 := step 5 (by decide) (by omega)
-  have hp6 := step 6 (by decide) (by omega)
-  have hp7 := step 7 (by decide) (by omega)
-  have hp4' : (p + 4).toNat = p.toNat + 4 := by simpa using hp4
-  have hp5' : (p + 5).toNat = p.toNat + 5 := by simpa using hp5
-  have hp6' : (p + 6).toNat = p.toNat + 6 := by simpa using hp6
-  have hp7' : (p + 7).toNat = p.toNat + 7 := by simpa using hp7
-  refine ⟨hp1, hp2, hp3, hp4, ?_, ?_, ?_⟩
-  · rw [UInt32.add_assoc, show (4 + 1 : UInt32) = 5 by decide, hp5', hp4']
-  · rw [UInt32.add_assoc, show (4 + 2 : UInt32) = 6 by decide, hp6', hp4']
-  · rw [UInt32.add_assoc, show (4 + 3 : UInt32) = 7 by decide, hp7', hp4']
+  obtain ⟨hp1, hp2, hp3, hp4, _hp5, _hp6, _hp7⟩ := UInt32.addSteps8 p hroom
+  obtain ⟨h41, h42, h43⟩ := UInt32.addSteps4 (p + 4) (by omega)
+  exact ⟨hp1, hp2, hp3, hp4, h41, h42, h43⟩
 
 theorem fatPtrHeap_agrees {α} {st : Store α} {p dataPtr len : UInt32}
     (resolve : Nat → Option Mem)
@@ -102,30 +86,8 @@ theorem fatPtrHeap_pointsTo
       pointsTo (GF := WasmHeapGF α) (H := WasmHeapMap)
         address (DFrac.own 1) byte) ⊢
       pointsTo_u32 0 p dataPtr ∗ pointsTo_u32 0 (p + 4) len := by
-  have hp (n : Nat) (hn : n < 4294967296)
-      (hr : p.toNat + n < 4294967296) :
-      (p + UInt32.ofNat n).toNat = p.toNat + n :=
-    UInt32.add_ofNat_toNat_noWrap p n hn hr
-  have hp1 := hp 1 (by decide) (by omega)
-  have hp2 := hp 2 (by decide) (by omega)
-  have hp3 := hp 3 (by decide) (by omega)
-  have hp4 := hp 4 (by decide) (by omega)
-  have hp5 := hp 5 (by decide) (by omega)
-  have hp6 := hp 6 (by decide) (by omega)
-  have hp7 := hp 7 (by decide) (by omega)
-  have hp1' : (p + 1).toNat = p.toNat + 1 := by simpa using hp1
-  have hp2' : (p + 2).toNat = p.toNat + 2 := by simpa using hp2
-  have hp3' : (p + 3).toNat = p.toNat + 3 := by simpa using hp3
-  have hp4' : (p + 4).toNat = p.toNat + 4 := by simpa using hp4
-  have hp5' : (p + 5).toNat = p.toNat + 5 := by simpa using hp5
-  have hp6' : (p + 6).toNat = p.toNat + 6 := by simpa using hp6
-  have hp7' : (p + 7).toNat = p.toNat + 7 := by simpa using hp7
-  have h41 : ((p + 4) + 1).toNat = (p + 4).toNat + 1 := by
-    rw [UInt32.add_assoc, show (4 + 1 : UInt32) = 5 by decide, hp5', hp4']
-  have h42 : ((p + 4) + 2).toNat = (p + 4).toNat + 2 := by
-    rw [UInt32.add_assoc, show (4 + 2 : UInt32) = 6 by decide, hp6', hp4']
-  have h43 : ((p + 4) + 3).toNat = (p + 4).toNat + 3 := by
-    rw [UInt32.add_assoc, show (4 + 3 : UInt32) = 7 by decide, hp7', hp4']
+  obtain ⟨hp1, hp2, hp3, hp4', _hp5, _hp6, _hp7⟩ := UInt32.addSteps8 p hroom
+  obtain ⟨h41, h42, h43⟩ := UInt32.addSteps4 (p + 4) (by omega)
   have fresh (q : MemoryKey) (hq : p.toNat + 4 ≤ q.addr.toNat) :
       get? (store32Heap ∅ 0 p dataPtr) q = none := by
     unfold store32Heap
@@ -188,30 +150,8 @@ theorem wp_loadFatPtr
         .localGet index :: .load32 0 :: .localGet index :: .load32 4 :: code,
         arity, remainder, controls, calls⟩ :
         Wasm.SmallStep.Expr α) @ s; E {{ Φ }} := by
-  have hp (n : Nat) (hn : n < 4294967296)
-      (hr : p.toNat + n < 4294967296) :
-      (p + UInt32.ofNat n).toNat = p.toNat + n :=
-    UInt32.add_ofNat_toNat_noWrap p n hn hr
-  have hp1 : (p + 1).toNat = p.toNat + 1 := by
-    simpa using hp 1 (by decide) (by omega)
-  have hp2 : (p + 2).toNat = p.toNat + 2 := by
-    simpa using hp 2 (by decide) (by omega)
-  have hp3 : (p + 3).toNat = p.toNat + 3 := by
-    simpa using hp 3 (by decide) (by omega)
-  have hp4 : (p + 4).toNat = p.toNat + 4 := by
-    simpa using hp 4 (by decide) (by omega)
-  have hp5 : ((p + 4) + 1).toNat = (p + 4).toNat + 1 := by
-    have h5 : (p + 5).toNat = p.toNat + 5 := by
-      simpa using hp 5 (by decide) (by omega)
-    rw [UInt32.add_assoc, show (4 + 1 : UInt32) = 5 by decide, h5, hp4]
-  have hp6 : ((p + 4) + 2).toNat = (p + 4).toNat + 2 := by
-    have h6 : (p + 6).toNat = p.toNat + 6 := by
-      simpa using hp 6 (by decide) (by omega)
-    rw [UInt32.add_assoc, show (4 + 2 : UInt32) = 6 by decide, h6, hp4]
-  have hp7 : ((p + 4) + 3).toNat = (p + 4).toNat + 3 := by
-    have h7 : (p + 7).toNat = p.toNat + 7 := by
-      simpa using hp 7 (by decide) (by omega)
-    rw [UInt32.add_assoc, show (4 + 3 : UInt32) = 7 by decide, h7, hp4]
+  obtain ⟨hp1, hp2, hp3, hp4, _h5, _h6, _h7⟩ := UInt32.addSteps8 p hroom
+  obtain ⟨hp5, hp6, hp7⟩ := UInt32.addSteps4 (p + 4) (by omega)
   iintro >Hdata >Hlen Hwp
   iapply Wasm.SmallStep.wp_localGet hget
   inext

--- a/codelib/CodeLib/RustStd/MemCopyLoop.lean
+++ b/codelib/CodeLib/RustStd/MemCopyLoop.lean
@@ -139,22 +139,10 @@ theorem copyWords_loadStoreIteration_wp
     Mem.words32_slotAddr_toNat dst i.toNat (by omega)
   have hsrcNat : srcAddress.toNat = src.toNat + 4 * i.toNat :=
     Mem.words32_slotAddr_toNat src i.toNat (by omega)
-  have addressSteps (address : UInt32)
-      (hroom : address.toNat + 4 ≤ 4294967296) :
-      (address + 1).toNat = address.toNat + 1 ∧
-      (address + 2).toNat = address.toNat + 2 ∧
-      (address + 3).toNat = address.toNat + 3 := by
-    have step (k : Nat) (hk : k < 4294967296)
-        (hfit : address.toNat + k < 4294967296) :
-        (address + UInt32.ofNat k).toNat = address.toNat + k :=
-      UInt32.add_ofNat_toNat_noWrap address k hk hfit
-    exact ⟨by simpa using step 1 (by decide) (by omega),
-      by simpa using step 2 (by decide) (by omega),
-      by simpa using step 3 (by decide) (by omega)⟩
   obtain ⟨hd1, hd2, hd3⟩ :=
-    addressSteps dstAddress (by rw [hdstNat]; omega)
+    UInt32.addSteps4 dstAddress (by rw [hdstNat]; omega)
   obtain ⟨hs1, hs2, hs3⟩ :=
-    addressSteps srcAddress (by rw [hsrcNat]; omega)
+    UInt32.addSteps4 srcAddress (by rw [hsrcNat]; omega)
   iintro ⟨HR, Hdst, Hsrc⟩
   ihave Hfocused :
       pointsTo_u32 0 (src + 4 * UInt32.ofNat pre.length) value ∗
@@ -699,22 +687,10 @@ theorem copyWords_loadStoreIteration_twp
     Mem.words32_slotAddr_toNat dst i.toNat (by omega)
   have hsrcNat : srcAddress.toNat = src.toNat + 4 * i.toNat :=
     Mem.words32_slotAddr_toNat src i.toNat (by omega)
-  have addressSteps (address : UInt32)
-      (hroom : address.toNat + 4 ≤ 4294967296) :
-      (address + 1).toNat = address.toNat + 1 ∧
-      (address + 2).toNat = address.toNat + 2 ∧
-      (address + 3).toNat = address.toNat + 3 := by
-    have step (k : Nat) (hk : k < 4294967296)
-        (hfit : address.toNat + k < 4294967296) :
-        (address + UInt32.ofNat k).toNat = address.toNat + k :=
-      UInt32.add_ofNat_toNat_noWrap address k hk hfit
-    exact ⟨by simpa using step 1 (by decide) (by omega),
-      by simpa using step 2 (by decide) (by omega),
-      by simpa using step 3 (by decide) (by omega)⟩
   obtain ⟨hd1, hd2, hd3⟩ :=
-    addressSteps dstAddress (by rw [hdstNat]; omega)
+    UInt32.addSteps4 dstAddress (by rw [hdstNat]; omega)
   obtain ⟨hs1, hs2, hs3⟩ :=
-    addressSteps srcAddress (by rw [hsrcNat]; omega)
+    UInt32.addSteps4 srcAddress (by rw [hsrcNat]; omega)
   iintro ⟨HR, Hdst, Hsrc⟩
   ihave Hfocused :
       pointsTo_u32 0 (src + 4 * UInt32.ofNat pre.length) value ∗

--- a/codelib/CodeLib/RustStd/MemFillLoop.lean
+++ b/codelib/CodeLib/RustStd/MemFillLoop.lean
@@ -132,24 +132,8 @@ theorem fillWords_storeIteration_wp
     exact UInt32.add_comm _ _
   have haddrNat : address.toNat = base.toNat + 8 * i.toNat := by
     exact Mem.words64_slotAddr_toNat base i.toNat (by omega)
-  have hstep (k : Nat) (hk : k < 4294967296)
-      (hfit : address.toNat + k < 4294967296) :
-      (address + UInt32.ofNat k).toNat = address.toNat + k :=
-    UInt32.add_ofNat_toNat_noWrap address k hk hfit
-  have h1 : (address + 1).toNat = address.toNat + 1 := by
-    simpa using hstep 1 (by decide) (by omega)
-  have h2 : (address + 2).toNat = address.toNat + 2 := by
-    simpa using hstep 2 (by decide) (by omega)
-  have h3 : (address + 3).toNat = address.toNat + 3 := by
-    simpa using hstep 3 (by decide) (by omega)
-  have h4 : (address + 4).toNat = address.toNat + 4 := by
-    simpa using hstep 4 (by decide) (by omega)
-  have h5 : (address + 5).toNat = address.toNat + 5 := by
-    simpa using hstep 5 (by decide) (by omega)
-  have h6 : (address + 6).toNat = address.toNat + 6 := by
-    simpa using hstep 6 (by decide) (by omega)
-  have h7 : (address + 7).toNat = address.toNat + 7 := by
-    simpa using hstep 7 (by decide) (by omega)
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7⟩ :=
+    UInt32.addSteps8 address (by omega)
   iintro ⟨HR, Harray⟩
   icases array64At_fill_next 0 base i.toNat value old suffix $$ Harray with
     ⟨Hold, Hreassemble⟩

--- a/codelib/CodeLib/RustStd/U64/AbsDiff.lean
+++ b/codelib/CodeLib/RustStd/U64/AbsDiff.lean
@@ -87,34 +87,8 @@ theorem absDiff_smallStep_wp_to_return
   have h8 : ((sp - 16) + 8).toNat = (sp - 16).toNat + 8 := by
     simpa using UInt32.add_ofNat_toNat_noWrap (sp - 16) 8
       (by omega) (by omega)
-  have h9 : (((sp - 16) + 8) + 1).toNat =
-      ((sp - 16) + 8).toNat + 1 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 1
-      (by omega) (by omega)
-  have h10 : (((sp - 16) + 8) + 2).toNat =
-      ((sp - 16) + 8).toNat + 2 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 2
-      (by omega) (by omega)
-  have h11 : (((sp - 16) + 8) + 3).toNat =
-      ((sp - 16) + 8).toNat + 3 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 3
-      (by omega) (by omega)
-  have h12 : (((sp - 16) + 8) + 4).toNat =
-      ((sp - 16) + 8).toNat + 4 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 4
-      (by omega) (by omega)
-  have h13 : (((sp - 16) + 8) + 5).toNat =
-      ((sp - 16) + 8).toNat + 5 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 5
-      (by omega) (by omega)
-  have h14 : (((sp - 16) + 8) + 6).toNat =
-      ((sp - 16) + 8).toNat + 6 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 6
-      (by omega) (by omega)
-  have h15 : (((sp - 16) + 8) + 7).toNat =
-      ((sp - 16) + 8).toNat + 7 := by
-    simpa using UInt32.add_ofNat_toNat_noWrap ((sp - 16) + 8) 7
-      (by omega) (by omega)
+  obtain ⟨h9, h10, h11, h12, h13, h14, h15⟩ :=
+    UInt32.addSteps8 ((sp - 16) + 8) (by omega)
   iintro ⟨HR, Hglobal, Hscratch⟩
   simp only [absDiffBody]
   iapply Wasm.SmallStep.wp_globalGet $$ Hglobal

--- a/codelib/CodeLib/SepLogic/WasmHeap.lean
+++ b/codelib/CodeLib/SepLogic/WasmHeap.lean
@@ -1170,6 +1170,39 @@ theorem UInt32.add_ofNat_toNat_noWrap (addr : UInt32) (n : Nat)
     UInt32.toNat_ofNat_of_lt' (by simpa only [UInt32.size] using hn)]
   omega
 
+omit inst in
+/-- Address ladder for a 4-byte access at `addr`: given room for the whole
+word, none of `addr + 1 … addr + 3` wraps, so each `toNat` is the obvious sum.
+Stated with numerals (`addr + 1`, not `addr + UInt32.ofNat 1`) because that is
+the shape the `load32` / `store32` rules and their callers write. -/
+theorem UInt32.addSteps4 (addr : UInt32) (hroom : addr.toNat + 4 ≤ 4294967296) :
+    (addr + 1).toNat = addr.toNat + 1 ∧
+    (addr + 2).toNat = addr.toNat + 2 ∧
+    (addr + 3).toNat = addr.toNat + 3 :=
+  ⟨by simpa using UInt32.add_ofNat_toNat_noWrap addr 1 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 2 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 3 (by decide) (by omega)⟩
+
+omit inst in
+/-- Address ladder for an 8-byte access at `addr`: given room for the whole
+word, none of `addr + 1 … addr + 7` wraps. The numeral form matches the
+`load64` / `store64` premises. -/
+theorem UInt32.addSteps8 (addr : UInt32) (hroom : addr.toNat + 8 ≤ 4294967296) :
+    (addr + 1).toNat = addr.toNat + 1 ∧
+    (addr + 2).toNat = addr.toNat + 2 ∧
+    (addr + 3).toNat = addr.toNat + 3 ∧
+    (addr + 4).toNat = addr.toNat + 4 ∧
+    (addr + 5).toNat = addr.toNat + 5 ∧
+    (addr + 6).toNat = addr.toNat + 6 ∧
+    (addr + 7).toNat = addr.toNat + 7 :=
+  ⟨by simpa using UInt32.add_ofNat_toNat_noWrap addr 1 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 2 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 3 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 4 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 5 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 6 (by decide) (by omega),
+    by simpa using UInt32.add_ofNat_toNat_noWrap addr 7 (by decide) (by omega)⟩
+
 /-- The `n`th little-endian byte of a 32-bit word. -/
 def u32Byte (v : UInt32) (n : Nat) : UInt8 :=
   match n with


### PR DESCRIPTION
The `(X + k).toNat = X.toNat + k` no-wrap rewrite was hand-rolled four different ways inside `RustStd/`: a 31-line block in `U64/AbsDiff.lean`, `hp1..hp7` then `hp1'..hp7'` in `Array/SmallStep.lean`, a local `hstep` in `MemFillLoop.lean`, and an `addressSteps` helper duplicated twice in `MemCopyLoop.lean`.

Adds `addSteps4`/`addSteps8` next to the base lemma and uses them at those four sites.

**−141/+48.** Green (3599 jobs).