### PR TITLE
interpreter: dedup the decoder folded-operand loop and the validator address-type test

### DIFF
--- a/interpreter/Interpreter/Wasm/Decoder/Wat.lean
+++ b/interpreter/Interpreter/Wasm/Decoder/Wat.lean
@@ -1450,25 +1450,13 @@ private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
       -- Reuse the linear parsers for the immediates, then treat the
       -- remaining forms as folded operand sub-expressions.
       let (instr, leftover) ← parseInstr ctx (.atom op :: rest)
-      let mut acc : List Wasm.Instruction := []
-      for s in leftover do
-        match s with
-        | .list ys =>
-          let sub ← parseFolded ctx ys
-          acc := acc ++ sub
-        | .atom a => .error s!"folded {op}: unexpected atom operand '{a}'"
+      let acc ← foldedOperands ctx s!"folded {op}" leftover
       .ok (acc ++ instr)
     | "call_indirect" | "return_call_indirect" => do
       let mk : Nat → Nat → Wasm.Instruction :=
         if op == "call_indirect" then .callIndirect else .returnCallIndirect
       let (instr, leftover) ← parseCallIndirect ctx mk rest
-      let mut acc : List Wasm.Instruction := []
-      for sx in leftover do
-        match sx with
-        | .list ys =>
-          let sub ← parseFolded ctx ys
-          acc := acc ++ sub
-        | .atom a => .error s!"folded {op}: unexpected atom operand '{a}'"
+      let acc ← foldedOperands ctx s!"folded {op}" leftover
       .ok (acc ++ instr)
     | "return_call" =>
       foldedWithImmediate ctx (resolveNamed ctx.funcIds "function")
@@ -1497,15 +1485,25 @@ private partial def parseFolded (ctx : Ctx) (xs : List Sexpr)
       -- immediate parsing to the linear parser, then treat the remaining
       -- `(...)` forms as folded operand sub-expressions.
       let (heads, rest') ← parseInstr ctx (.atom op :: rest)
-      let mut acc : List Wasm.Instruction := []
-      for s in rest' do
-        match s with
-        | .list ys =>
-          let sub ← parseFolded ctx ys
-          acc := acc ++ sub
-        | .atom a => .error s!"folded {op}: unexpected atom operand '{a}'"
+      let acc ← foldedOperands ctx s!"folded {op}" rest'
       .ok (acc ++ heads)
   | _ => .error "malformed folded form"
+
+/-- Parse the folded *operand* sub-expressions of a folded form. Every
+element of `ops` must be a `(...)` form; each is parsed as a nested folded
+form and the results are concatenated in source order, yielding the operand
+prefix that precedes the folded head instruction. `what` names the form
+being parsed in the error message for a stray atom operand. -/
+private partial def foldedOperands (ctx : Ctx) (what : String)
+    (ops : List Sexpr) : Except Err (List Wasm.Instruction) := do
+  let mut acc : List Wasm.Instruction := []
+  for s in ops do
+    match s with
+    | .list ys =>
+      let sub ← parseFolded ctx ys
+      acc := acc ++ sub
+    | .atom a => .error s!"{what}: unexpected atom operand '{a}'"
+  .ok acc
 
 private partial def foldedStructured (ctx : Ctx)
     (mk : List Wasm.ValueType → List Wasm.ValueType →
@@ -1550,13 +1548,7 @@ private partial def foldedWithImmediate (ctx : Ctx)
     (mkInstrs : Nat → List Wasm.Instruction)
     : List Sexpr → Except Err (List Wasm.Instruction)
   | .atom n :: ops => do
-    let mut acc : List Wasm.Instruction := []
-    for s in ops do
-      match s with
-      | .list ys =>
-        let sub ← parseFolded ctx ys
-        acc := acc ++ sub
-      | .atom a => .error s!"folded form: unexpected atom operand '{a}'"
+    let acc ← foldedOperands ctx "folded form" ops
     .ok (acc ++ mkInstrs (← resolve n))
   | _ => .error "folded form: missing immediate"
 
@@ -1572,13 +1564,7 @@ private partial def foldedOptTableIdx (ctx : Ctx) (mk : Nat → Wasm.Instruction
           pure ((← resolveNamed ctx.tableNames "table" a), rest)
         else .error s!"folded table op: unexpected atom operand '{a}'"
       | _ => pure (0, xs)
-    let mut acc : List Wasm.Instruction := []
-    for s in ops do
-      match s with
-      | .list ys =>
-        let sub ← parseFolded ctx ys
-        acc := acc ++ sub
-      | .atom a => .error s!"folded table op: unexpected atom operand '{a}'"
+    let acc ← foldedOperands ctx "folded table op" ops
     .ok (acc ++ [mk tableIdx])
 
 private partial def parseBrTable (ctx : Ctx) (toks : List Sexpr)
@@ -1618,13 +1604,7 @@ private partial def foldedBrTable (ctx : Ctx) (xs : List Sexpr)
   let targets := match revLabels with
     | _ :: rest => rest.reverse
     | [] => []
-  let mut acc : List Wasm.Instruction := []
-  for s in cur do
-    match s with
-    | .list ys =>
-      let sub ← parseFolded ctx ys
-      acc := acc ++ sub
-    | .atom a => .error s!"folded br_table: unexpected atom operand '{a}'"
+  let acc ← foldedOperands ctx "folded br_table" cur
   .ok (acc ++ [.brTable targets dflt])
 
 private partial def foldedSelect (ctx : Ctx) (xs : List Sexpr)
@@ -1632,13 +1612,7 @@ private partial def foldedSelect (ctx : Ctx) (xs : List Sexpr)
   let xs' := xs.filter fun
     | .list (.atom "result" :: _) => false
     | _ => true
-  let mut acc : List Wasm.Instruction := []
-  for s in xs' do
-    match s with
-    | .list ys =>
-      let sub ← parseFolded ctx ys
-      acc := acc ++ sub
-    | .atom a => .error s!"folded select: unexpected atom operand '{a}'"
+  let acc ← foldedOperands ctx "folded select" xs'
   .ok (acc ++ [.select])
 
 private partial def parseLocalTee (ctx : Ctx) (toks : List Sexpr)

--- a/interpreter/Interpreter/Wasm/Syntax.lean
+++ b/interpreter/Interpreter/Wasm/Syntax.lean
@@ -1047,6 +1047,20 @@ def Module.memoryCap (m : Module) : Nat :=
     | none   => Module.memoryHardCap
   | none => Module.memoryHardCap
 
+/-- The address type of a declared memory: `i64` for a memory64 memory,
+`i32` otherwise. This is the type of the operands and results the memory
+instructions of that memory speak — addresses, and the page counts of
+`memory.size` / `memory.grow`. -/
+def MemDecl.addressType (d : MemDecl) : ValueType :=
+  if d.is64 then .i64 else .i32
+
+/-- The address type of a declared table: `i64` for a table64 table, `i32`
+otherwise. This is the type of the operands and results the table
+instructions of that table speak — element indices, and the sizes of
+`table.size` / `table.grow`. -/
+def TableDecl.addressType (d : TableDecl) : ValueType :=
+  if d.is64 then .i64 else .i32
+
 /-- Whether the module's memory is 64-bit-addressed (memory64). -/
 def Module.memIs64 (m : Module) : Bool :=
   match m.memory with

--- a/interpreter/Interpreter/Wasm/Validate.lean
+++ b/interpreter/Interpreter/Wasm/Validate.lean
@@ -1022,28 +1022,27 @@ def Instruction.straightSig (m : Module) (locals : List ValueType)
   | .vShuffle _ => some ([.v128, .v128], [.v128])
   | .tableGet tableIndex =>
     (m.tableDecl? tableIndex).map fun table =>
-      ([if table.is64 then .i64 else .i32], [table.elemType])
+      ([table.addressType], [table.elemType])
   | .tableSet tableIndex =>
     (m.tableDecl? tableIndex).map fun table =>
-      ([table.elemType, if table.is64 then .i64 else .i32], [])
+      ([table.elemType, table.addressType], [])
   | .tableSize tableIndex =>
     (m.tableDecl? tableIndex).map fun table =>
-      ([], [if table.is64 then .i64 else .i32])
+      ([], [table.addressType])
   | .tableGrow tableIndex =>
     (m.tableDecl? tableIndex).map fun table =>
-      let addressType := if table.is64 then .i64 else .i32
+      let addressType := table.addressType
       ([addressType, table.elemType], [addressType])
   | .tableFill tableIndex =>
     (m.tableDecl? tableIndex).map fun table =>
-      let addressType := if table.is64 then .i64 else .i32
+      let addressType := table.addressType
       ([addressType, table.elemType, addressType], [])
   | .tableCopy destinationTableIndex sourceTableIndex =>
     (m.tableDecl? destinationTableIndex).bind fun destinationTable =>
       (m.tableDecl? sourceTableIndex).map fun sourceTable =>
-        let destinationType :=
-          if destinationTable.is64 then .i64 else .i32
-        let sourceType := if sourceTable.is64 then .i64 else .i32
-        let lengthType :=
+        let destinationType := destinationTable.addressType
+        let sourceType := sourceTable.addressType
+        let lengthType : ValueType :=
           if destinationTable.is64 && sourceTable.is64 then .i64 else .i32
         ([lengthType, sourceType, destinationType], [])
   | .call functionIndex =>
@@ -1052,7 +1051,7 @@ def Instruction.straightSig (m : Module) (locals : List ValueType)
   | .callIndirect typeIndex tableIndex =>
     (m.types[typeIndex]?).bind fun signature =>
       (m.tableDecl? tableIndex).map fun table =>
-        let selectorType := if table.is64 then .i64 else .i32
+        let selectorType := table.addressType
         (selectorType :: signature.params.reverse, signature.results)
   | .callRef typeIndex =>
     (m.types[typeIndex]?).map fun signature =>
@@ -1068,50 +1067,50 @@ def Instruction.straightSig (m : Module) (locals : List ValueType)
         | none => .funcref])
   | .tableInit tableIndex _ =>
     (m.tableDecl? tableIndex).map fun table =>
-      ([.i32, .i32, if table.is64 then .i64 else .i32], [])
+      ([.i32, .i32, table.addressType], [])
   | .elemDrop _ => some ([], [])
   | .memorySize =>
     m.memory.map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([], [addressType])
   | .memoryGrow =>
     m.memory.map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType], [addressType])
   | .memoryFill =>
     m.memory.map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType, .i32, addressType], [])
   | .memoryCopy =>
     m.memory.map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType, addressType, addressType], [])
   | .memoryInit _ =>
     m.memory.map fun memory =>
-      ([.i32, .i32, if memory.is64 then .i64 else .i32], [])
+      ([.i32, .i32, memory.addressType], [])
   | .dataDrop _ => some ([], [])
   | .memOp memoryIndex (.memoryInit _) =>
     (m.memoryDecl? memoryIndex).map fun memory =>
-      ([.i32, .i32, if memory.is64 then .i64 else .i32], [])
+      ([.i32, .i32, memory.addressType], [])
   | .memOp memoryIndex .memoryFill =>
     (m.memoryDecl? memoryIndex).map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType, .i32, addressType], [])
   | .memOp memoryIndex .memoryCopy =>
     (m.memoryDecl? memoryIndex).map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType, addressType, addressType], [])
   | .memOp memoryIndex .memorySize =>
     (m.memoryDecl? memoryIndex).map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([], [addressType])
   | .memOp memoryIndex .memoryGrow =>
     (m.memoryDecl? memoryIndex).map fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       ([addressType], [addressType])
   | .memOp memoryIndex operation =>
     (m.memoryDecl? memoryIndex).bind fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       (operation.scalarMemorySig addressType).orElse fun _ =>
         operation.simdMemorySig addressType
   | .gc op => match op with
@@ -1151,7 +1150,7 @@ def Instruction.straightSig (m : Module) (locals : List ValueType)
     | _ => none
   | operation =>
     m.memory.bind fun memory =>
-      let addressType := if memory.is64 then .i64 else .i32
+      let addressType := memory.addressType
       (operation.scalarMemorySig addressType).orElse fun _ =>
         operation.simdMemorySig addressType
 
@@ -1430,7 +1429,7 @@ partial def Program.checkTypes
             | throw "unknown table"
           if !resultTypesCompat m signature.results functionResults then
             throw "type mismatch"
-          let selectorType := if table.is64 then .i64 else .i32
+          let selectorType := table.addressType
           let next ← state.applySig m
             (selectorType :: signature.params.reverse, [])
           pure (some
@@ -1503,7 +1502,7 @@ def Module.validate (m : Module) : Except String Unit := do
         | some _ =>
             let some selectedMemory := m.memoryDecl? segment.memIdx
               | throw "unknown memory"
-            let addressType := if selectedMemory.is64 then .i64 else .i32
+            let addressType := selectedMemory.addressType
             match segment.offsetType with
             | some sourceType =>
                 if !m.vtCompat sourceType addressType then throw "type mismatch"
@@ -1528,7 +1527,7 @@ def Module.validate (m : Module) : Except String Unit := do
         let some table := m.tableDecl? tableIndex
           | throw "unknown table"
         if !m.vtCompat segmentType table.elemType then throw "type mismatch"
-        let addressType := if table.is64 then .i64 else .i32
+        let addressType := table.addressType
         match segment.offsetType with
         | some sourceType =>
             if !m.vtCompat sourceType addressType then throw "type mismatch"


### PR DESCRIPTION
Two local dedups:

- `Decoder/Wat.lean` repeated the folded-operand accumulation loop seven times; now one `private partial def`. No error string changes.
- `Validate.lean` wrote `if x.is64 then .i64 else .i32` ~25 times; now `MemDecl.addressType`/`TableDecl.addressType`. The one site that is really a min-of-two-widths rule (`destinationTable.is64 && sourceTable.is64`) is left alone.

Behaviour unchanged. Green (3599 jobs).