### PR TITLE
interpreter: extract the shared block/loop/if WP proof structure

### DIFF
--- a/interpreter/Interpreter/Wasm/Wp/Block.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Block.lean
@@ -1,4 +1,4 @@
-import Interpreter.Wasm.Wp.Defs
+import Interpreter.Wasm.Wp.Structural
 import Interpreter.Wasm.Semantics.Lemmas
 
 /-! ### Block / if-then-else: structural, no measure required.
@@ -6,7 +6,12 @@ import Interpreter.Wasm.Semantics.Lemmas
     Neither iterates; control either falls through, breaks out at level 0
     (exiting the construct), or propagates an outer break/return/trap. The
     rules are one-sided sufficient conditions — provide the body's `wp`
-    against the right outcome continuation. -/
+    against the right outcome continuation.
+
+    Both are `wp_of_body_dispatch` (see `Wp/Structural.lean`) applied with this
+    construct's unfolding lemma: all the fuel reasoning lives there, and only
+    the three continuations a structured construct interprets are handled
+    here. -/
 
 namespace Wasm
 
@@ -23,92 +28,36 @@ theorem wp_block_cons {ps rs : Nat} {body rest : Program} {Q : Assertion α}
             | other                => Q other)
           st s env) :
     wp m (.block ps rs body :: rest) Q st s env := by
-  unfold wp at h ⊢
-  obtain ⟨Nb, hN⟩ := h
-  by_cases hOOF : ∀ f ≥ Nb, exec f m st s body env = .OutOfFuel
-  · -- body always OutOfFuel: block propagates OutOfFuel; hN gives Q OutOfFuel.
-    refine ⟨Nb + 1, fun fuel hfuel => ?_⟩
+  refine wp_of_body_dispatch h ?_ ?_ ?_ ?_ ?_
+  · -- Forwarded continuations: the block is transparent to them.
+    intro f cont hcont hbody
+    cases cont <;>
+      first
+        | exact (hcont : False).elim
+        | rw [exec_block_cons, hbody]
+  · intro cont hcont hQ
+    cases cont <;>
+      first
+        | exact (hcont : False).elim
+        | exact hQ
+  · -- Fall-through: carry on with `rest` on the trimmed stack.
+    intro N st' s' hQ hstable
+    refine wp_of_eventually_eq (N := N + 1) ?_ hQ
+    intro fuel hfuel
     obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-    have hbf : exec f m st s body env = .OutOfFuel := hOOF f (by omega)
-    have hpre := hN f (by omega)
-    rw [hbf] at hpre
-    rw [exec_block_cons, hbf]
-    exact hpre
-  · push Not at hOOF
-    obtain ⟨f₀, hf₀, hf₀_ne⟩ := hOOF
-    have hk_stable : ∀ f' ≥ f₀, exec f' m st s body env = exec f₀ m st s body env := fun f' hf' =>
-      exec_fuel_mono hf' hf₀_ne
-    have hQ_at := hN f₀ hf₀
-    cases hk : exec f₀ m st s body env with
-    | OutOfFuel => exact absurd hk hf₀_ne
-    | Fallthrough r' s' =>
-      rw [hk] at hQ_at
-      obtain ⟨Nr, hNr⟩ := hQ_at
-      refine ⟨max (f₀ + 1) Nr, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .Fallthrough r' s' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hNr _ (by omega)
-    | Break n r' s' =>
-      cases n with
-      | zero =>
-        rw [hk] at hQ_at
-        obtain ⟨Nr, hNr⟩ := hQ_at
-        refine ⟨max (f₀ + 1) Nr, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Break 0 r' s' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_block_cons, hbody]
-        exact hNr _ (by omega)
-      | succ n' =>
-        rw [hk] at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Break (n'+1) r' s' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_block_cons, hbody]
-        exact hQ_at
-    | Return r' vs =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .Return r' vs := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hQ_at
-    | Trap r' msg =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .Trap r' msg := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hQ_at
-    | Invalid msg =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .Invalid msg := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hQ_at
-    | ReturnCall fid st' vs =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .ReturnCall fid st' vs := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hQ_at
-    | Throwing tag targs st' s' =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s body env = .Throwing tag targs st' s' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_block_cons, hbody]
-      exact hQ_at
+    rw [exec_block_cons, hstable f (by omega)]
+  · -- `br 0` exits the block, landing exactly where fall-through does.
+    intro N st' s' hQ hstable
+    refine wp_of_eventually_eq (N := N + 1) ?_ hQ
+    intro fuel hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    rw [exec_block_cons, hstable f (by omega)]
+  · -- An outer break sheds one level and propagates.
+    intro N k st' s' hQ hstable
+    refine wp_of_eventually_const (N := N + 1) (cont := .Break k st' s') ?_ hQ
+    intro fuel hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    rw [exec_block_cons, hstable f (by omega)]
 
 /-- `iff` rule: dispatch on the top-of-stack i32 condition, then reason like
     a block on the chosen branch. Stack precondition: `.i32 c :: vs` on top. -/
@@ -127,92 +76,35 @@ theorem wp_iff_cons {ps rs : Nat} {thn els rest : Program} {Q : Assertion α}
                 | other                => Q other)
               st { s with values := vs } env) :
     wp m (.iff ps rs thn els :: rest) Q st s env := by
-  unfold wp at hBody ⊢
-  set body := if c ≠ 0 then thn else els with hbody_def
-  set s' : Locals := { s with values := vs } with hs'_def
-  obtain ⟨Nb, hN⟩ := hBody
-  by_cases hOOF : ∀ f ≥ Nb, exec f m st s' body env = .OutOfFuel
-  · refine ⟨Nb + 1, fun fuel hfuel => ?_⟩
+  refine wp_of_body_dispatch hBody ?_ ?_ ?_ ?_ ?_
+  · -- Forwarded continuations: the chosen branch's result passes through.
+    intro f cont hcont hbody
+    cases cont <;>
+      first
+        | exact (hcont : False).elim
+        | rw [exec_iff_cons hStack, hbody]
+  · intro cont hcont hQ
+    cases cont <;>
+      first
+        | exact (hcont : False).elim
+        | exact hQ
+  · -- Fall-through: carry on with `rest` on the trimmed stack.
+    intro N st' s' hQ hstable
+    refine wp_of_eventually_eq (N := N + 1) ?_ hQ
+    intro fuel hfuel
     obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-    have hbf : exec f m st s' body env = .OutOfFuel := hOOF f (by omega)
-    have hpre := hN f (by omega)
-    rw [hbf] at hpre
-    rw [exec_iff_cons hStack, hbf]
-    exact hpre
-  · push Not at hOOF
-    obtain ⟨f₀, hf₀, hf₀_ne⟩ := hOOF
-    have hk_stable : ∀ f' ≥ f₀, exec f' m st s' body env = exec f₀ m st s' body env := fun f' hf' =>
-      exec_fuel_mono hf' hf₀_ne
-    have hQ_at := hN f₀ hf₀
-    cases hk : exec f₀ m st s' body env with
-    | OutOfFuel => exact absurd hk hf₀_ne
-    | Fallthrough r' s'' =>
-      rw [hk] at hQ_at
-      obtain ⟨Nr, hNr⟩ := hQ_at
-      refine ⟨max (f₀ + 1) Nr, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .Fallthrough r' s'' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hNr _ (by omega)
-    | Break n r' s'' =>
-      cases n with
-      | zero =>
-        rw [hk] at hQ_at
-        obtain ⟨Nr, hNr⟩ := hQ_at
-        refine ⟨max (f₀ + 1) Nr, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s' body env = .Break 0 r' s'' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_iff_cons hStack, hbody]
-        exact hNr _ (by omega)
-      | succ n' =>
-        rw [hk] at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s' body env = .Break (n'+1) r' s'' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_iff_cons hStack, hbody]
-        exact hQ_at
-    | Return r' vs' =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .Return r' vs' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hQ_at
-    | Trap r' msg =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .Trap r' msg := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hQ_at
-    | Invalid msg =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .Invalid msg := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hQ_at
-    | ReturnCall fid st'' vs' =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .ReturnCall fid st'' vs' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hQ_at
-    | Throwing tag targs st'' s'' =>
-      rw [hk] at hQ_at
-      refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbody : exec f m st s' body env = .Throwing tag targs st'' s'' := by
-        rw [hk_stable f (by omega), hk]
-      rw [exec_iff_cons hStack, hbody]
-      exact hQ_at
+    rw [exec_iff_cons hStack, hstable f (by omega)]
+  · -- `br 0` exits the `if`, landing exactly where fall-through does.
+    intro N st' s' hQ hstable
+    refine wp_of_eventually_eq (N := N + 1) ?_ hQ
+    intro fuel hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    rw [exec_iff_cons hStack, hstable f (by omega)]
+  · -- An outer break sheds one level and propagates.
+    intro N k st' s' hQ hstable
+    refine wp_of_eventually_const (N := N + 1) (cont := .Break k st' s') ?_ hQ
+    intro fuel hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    rw [exec_iff_cons hStack, hstable f (by omega)]
 
 end Wasm

--- a/interpreter/Interpreter/Wasm/Wp/Loop.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Loop.lean
@@ -1,4 +1,4 @@
-import Interpreter.Wasm.Wp.Defs
+import Interpreter.Wasm.Wp.Structural
 import Interpreter.Wasm.Semantics.Lemmas
 
 /-! ### Loop with a variant.
@@ -78,139 +78,75 @@ theorem wp_loop_cons {ps rs : Nat} {body rest : Program} {Q : Assertion α}
             | other              => Q other)
           st s env) :
     wp m (.loop ps rs body :: rest) Q st s env := by
-  unfold wp
   suffices key : ∀ n, ∀ st s, Inv st s → μ st s = n →
-      ∃ N, ∀ fuel ≥ N, Q (exec fuel m st s (.loop ps rs body :: rest) env) by
+      wp m (.loop ps rs body :: rest) Q st s env by
     exact key _ st s hInit rfl
   intro n
   induction n using Nat.strong_induction_on with
   | _ n IH =>
     intro st s hInv hμ
-    have hBody := hStep st s hInv
-    unfold wp at hBody
-    obtain ⟨Nb, hNb⟩ := hBody
-    by_cases hOOF : ∀ f ≥ Nb, exec f m st s body env = .OutOfFuel
-    · refine ⟨Nb + 1, fun fuel hfuel => ?_⟩
+    refine wp_of_body_dispatch (hStep st s hInv) ?_ ?_ ?_ ?_ ?_
+    · -- Forwarded continuations: the loop is transparent to them.
+      intro f cont hcont hbody
+      cases cont <;>
+        first
+          | exact (hcont : False).elim
+          | rw [exec_loop_cons_unfold, hbody]
+    · intro cont hcont hQ
+      cases cont <;>
+        first
+          | exact (hcont : False).elim
+          | exact hQ
+    · -- Fall-through leaves the loop and carries on with `rest`.
+      intro N st' s' hQ hstable
+      refine wp_of_eventually_eq (N := N + 1) ?_ hQ
+      intro fuel hfuel
       obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-      have hbf : exec f m st s body env = .OutOfFuel := hOOF f (by omega)
-      have hpre := hNb f (by omega)
-      rw [hbf] at hpre
-      rw [exec_loop_cons_unfold, hbf]
-      exact hpre
-    · push Not at hOOF
-      obtain ⟨f₀, hf₀, hf₀_ne⟩ := hOOF
-      have hk_stable : ∀ f' ≥ f₀, exec f' m st s body env = exec f₀ m st s body env := fun f' hf' =>
-        exec_fuel_mono hf' hf₀_ne
-      have hQ_at := hNb f₀ hf₀
-      cases hk : exec f₀ m st s body env with
-      | OutOfFuel => exact absurd hk hf₀_ne
-      | Fallthrough st' s' =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        obtain ⟨Nr, hNr⟩ := hQ_at
-        refine ⟨max (f₀ + 1) Nr, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Fallthrough st' s' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hNr _ (by omega)
-      | Break k' st' s' =>
-        cases k' with
-        | zero =>
-          rw [hk] at hQ_at
-          simp only at hQ_at
-          obtain ⟨hInv', hμ_lt⟩ := hQ_at
-          set trimmed : Locals :=
-            { s' with values := s'.values.take ps ++ s.values.drop ps } with htrimmed
-          have hμ_lt' : μ st' trimmed < n := by omega
-          obtain ⟨N_inner, hN_inner⟩ := IH (μ st' trimmed) hμ_lt' st' trimmed hInv' rfl
-          refine ⟨max (f₀ + 1) (N_inner + 1), fun fuel hfuel => ?_⟩
-          obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-          have hbody : exec f m st s body env = .Break 0 st' s' := by
-            rw [hk_stable f (by omega), hk]
-          rw [exec_loop_cons_unfold, hbody]
-          simp only
-          by_cases hOf : execOne f m st' trimmed (.loop ps rs body) env = .OutOfFuel
-          · rw [hOf]
-            have hf_eq : exec f m st' trimmed (.loop ps rs body :: rest) env = .OutOfFuel := by
-              simp only [exec, hOf]
-            have hIH := hN_inner f (by omega)
-            rw [hf_eq] at hIH
-            exact hIH
-          · have h_mono : execOne (f+1) m st' trimmed (.loop ps rs body) env = execOne f m st' trimmed (.loop ps rs body) env :=
-              execOne_fuel_mono (Nat.le_succ _) hOf
-            have h_unfold : exec (f+1) m st' trimmed (.loop ps rs body :: rest) env =
-                  (match execOne (f+1) m st' trimmed (.loop ps rs body) env with
-                   | .Fallthrough r s => exec (f+1) m r s rest env
-                   | other => other) := by
-              simp only [exec]; rfl
-            have h_eq : exec (f+1) m st' trimmed (.loop ps rs body :: rest) env =
-                  (match execOne f m st' trimmed (.loop ps rs body) env with
-                   | .Fallthrough r s => exec (f+1) m r s rest env
-                   | other => other) := by rw [h_unfold, h_mono]
-            rw [← h_eq]
-            exact hN_inner (f+1) (by omega)
-        | succ k' =>
-          rw [hk] at hQ_at
-          simp only at hQ_at
-          refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-          obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-          have hbody : exec f m st s body env = .Break (k'+1) st' s' := by
-            rw [hk_stable f (by omega), hk]
-          rw [exec_loop_cons_unfold, hbody]
-          simp only
-          exact hQ_at
-      | Return st' vs =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Return st' vs := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hQ_at
-      | Trap st' msg =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Trap st' msg := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hQ_at
-      | Invalid msg =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Invalid msg := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hQ_at
-      | ReturnCall fid st' vs =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .ReturnCall fid st' vs := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hQ_at
-      | Throwing tag targs st' s' =>
-        rw [hk] at hQ_at
-        simp only at hQ_at
-        refine ⟨f₀ + 1, fun fuel hfuel => ?_⟩
-        obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
-        have hbody : exec f m st s body env = .Throwing tag targs st' s' := by
-          rw [hk_stable f (by omega), hk]
-        rw [exec_loop_cons_unfold, hbody]
-        simp only
-        exact hQ_at
+      rw [exec_loop_cons_unfold, hstable f (by omega)]
+    · -- `br 0` re-enters the loop: the invariant holds again on the trimmed
+      -- stack and the measure has dropped, so the induction hypothesis applies.
+      -- The re-entry is the one place where the two sides run at different
+      -- fuel: the inner `execOne` gets `f`, the recursive `exec` gets `f + 1`.
+      intro N st' s' hQ hstable
+      have hQ' : Inv st' { s' with values := s'.values.take ps ++ s.values.drop ps }
+          ∧ μ st' { s' with values := s'.values.take ps ++ s.values.drop ps } < μ st s := hQ
+      obtain ⟨hInv', hμ_lt⟩ := hQ'
+      set trimmed : Locals :=
+        { s' with values := s'.values.take ps ++ s.values.drop ps } with htrimmed
+      have hμ_lt' : μ st' trimmed < n := by omega
+      have hIH := IH (μ st' trimmed) hμ_lt' st' trimmed hInv' rfl
+      unfold wp at hIH ⊢
+      obtain ⟨N_inner, hN_inner⟩ := hIH
+      refine ⟨max (N + 1) (N_inner + 1), fun fuel hfuel => ?_⟩
+      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+      rw [exec_loop_cons_unfold, hstable f (by omega)]
+      simp only
+      by_cases hOf : execOne f m st' trimmed (.loop ps rs body) env = .OutOfFuel
+      · rw [hOf]
+        have hf_eq : exec f m st' trimmed (.loop ps rs body :: rest) env = .OutOfFuel := by
+          simp only [exec, hOf]
+        have hres := hN_inner f (by omega)
+        rw [hf_eq] at hres
+        exact hres
+      · have h_mono : execOne (f+1) m st' trimmed (.loop ps rs body) env = execOne f m st' trimmed (.loop ps rs body) env :=
+          execOne_fuel_mono (Nat.le_succ _) hOf
+        have h_unfold : exec (f+1) m st' trimmed (.loop ps rs body :: rest) env =
+              (match execOne (f+1) m st' trimmed (.loop ps rs body) env with
+               | .Fallthrough r s => exec (f+1) m r s rest env
+               | other => other) := by
+          simp only [exec]; rfl
+        have h_eq : exec (f+1) m st' trimmed (.loop ps rs body :: rest) env =
+              (match execOne f m st' trimmed (.loop ps rs body) env with
+               | .Fallthrough r s => exec (f+1) m r s rest env
+               | other => other) := by rw [h_unfold, h_mono]
+        rw [← h_eq]
+        exact hN_inner (f+1) (by omega)
+    · -- An outer break sheds one level and propagates.
+      intro N k st' s' hQ hstable
+      refine wp_of_eventually_const (N := N + 1) (cont := .Break k st' s') ?_ hQ
+      intro fuel hfuel
+      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+      rw [exec_loop_cons_unfold, hstable f (by omega)]
 
 /-- For any fuel, executing a single `.br 0` is either `OutOfFuel` (when fuel = 0)
     or `Break 0 st s` (when fuel ≥ 1). -/

--- a/interpreter/Interpreter/Wasm/Wp/Structural.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Structural.lean
@@ -1,0 +1,150 @@
+import Interpreter.Wasm.Wp.Defs
+import Interpreter.Wasm.Semantics.Lemmas
+
+/-! ### The skeleton shared by the structural rules.
+
+`block`, `loop` and `if` all reason the same way: run the body at one less
+fuel, then react to the continuation the body produced. Everything fuel-shaped
+in that argument is common to the three — the `OutOfFuel` split, the
+`exec_fuel_mono` stabilisation, and the continuations the construct merely
+forwards — so it is written here once, in `wp_of_body_dispatch`.
+
+The reaction is deliberately *not* factored as a
+`Continuation α → Continuation α` transformer: on fall-through a structured
+construct re-enters `exec (fuel + 1) … rest`, so what it does with a
+continuation depends on the fuel it was handed as well as on the continuation
+itself. The three arms a construct interprets are therefore left as goals about
+`wp m prog Q st s env`, with the body's stabilised behaviour supplied as a
+hypothesis; a rule discharges them with `wp_of_eventually_eq` (control leaves
+the construct and carries on with the rest of the program) or
+`wp_of_eventually_const` (an outer break, which sheds one level and so is no
+more the identity than the other two). -/
+
+namespace Wasm
+
+/-- The continuations a structured construct forwards unchanged.
+
+`Fallthrough` and `Break` are the two a `block` / `loop` / `if` interprets;
+every other continuation — traps, returns, `OutOfFuel` — passes straight
+through, in the semantics and in the rule's postcondition alike. -/
+def Continuation.IsPassthrough {α : Type} : Continuation α → Prop
+  | .Fallthrough _ _ => False
+  | .Break _ _ _     => False
+  | _                => True
+
+/-- `wp` from an eventually constant `exec`: if every fuel from `N` on runs
+`prog` to `cont`, the postcondition only has to hold of `cont`. -/
+theorem wp_of_eventually_const {α : Type} {m : Module} {env : HostEnv α}
+    {st : Store α} {s : Locals} {prog : Program} {Q : Assertion α}
+    {N : Nat} {cont : Continuation α}
+    (hconst : ∀ f ≥ N, exec f m st s prog env = cont) (hQ : Q cont) :
+    wp m prog Q st s env := by
+  unfold wp
+  refine ⟨N, fun f hf => ?_⟩
+  rw [hconst f hf]
+  exact hQ
+
+/-- `wp` transported along an eventual agreement: if from `N` on, running
+`prog` from `(st, s)` *is* running `prog'` from `(st', s')` at the same fuel,
+then a `wp` for the latter is a `wp` for the former. This is what a structured
+construct does once control has left it and the rest of the program takes
+over. -/
+theorem wp_of_eventually_eq {α : Type} {m : Module} {env : HostEnv α}
+    {st st' : Store α} {s s' : Locals} {prog prog' : Program} {Q : Assertion α}
+    {N : Nat}
+    (heq : ∀ f ≥ N, exec f m st s prog env = exec f m st' s' prog' env)
+    (hcont : wp m prog' Q st' s' env) :
+    wp m prog Q st s env := by
+  unfold wp at hcont ⊢
+  obtain ⟨Nr, hNr⟩ := hcont
+  refine ⟨max N Nr, fun f hf => ?_⟩
+  rw [heq f (by omega)]
+  exact hNr f (by omega)
+
+/-- Fuel stabilisation of a body's `wp` — the `by_cases` / `exec_fuel_mono`
+preamble every structural rule opens with.
+
+Either the body diverges, in which case no fuel makes `exec` return and the
+body's `wp` already records `Qb .OutOfFuel`; or `exec` on the body is pinned,
+from some fuel on, to a single non-`OutOfFuel` continuation that `Qb`
+describes. -/
+theorem wp_stabilise {α : Type} {m : Module} {env : HostEnv α}
+    {st : Store α} {s : Locals} {body : Program} {Qb : Assertion α}
+    (h : wp m body Qb st s env) :
+    (Qb .OutOfFuel ∧ ∃ N : Nat, ∀ f ≥ N, exec f m st s body env = .OutOfFuel) ∨
+      ∃ (N : Nat) (cont : Continuation α), cont ≠ .OutOfFuel ∧ Qb cont ∧
+        ∀ f ≥ N, exec f m st s body env = cont := by
+  unfold wp at h
+  obtain ⟨Nb, hN⟩ := h
+  by_cases hOOF : ∀ f ≥ Nb, exec f m st s body env = .OutOfFuel
+  · have hQ := hN Nb le_rfl
+    rw [hOOF Nb le_rfl] at hQ
+    exact .inl ⟨hQ, Nb, hOOF⟩
+  · push Not at hOOF
+    obtain ⟨f₀, hf₀, hf₀_ne⟩ := hOOF
+    exact .inr ⟨f₀, exec f₀ m st s body env, hf₀_ne, hN f₀ hf₀,
+      fun f hf => exec_fuel_mono hf hf₀_ne⟩
+
+/-- The body-dispatch step shared by `wp_block_cons`, `wp_iff_cons` and
+`wp_loop_cons`.
+
+`prog` runs `body` from `(st, sb)` at one less fuel and then reacts to the
+continuation the body produced. This lemma does the fuel bookkeeping: it
+stabilises the body and settles every continuation the construct forwards —
+`hFwd` in the semantics, `hQFwd` in the postcondition, `OutOfFuel` included.
+
+Three arms are left to the caller, one per continuation a structured construct
+interprets: fall-through, `Break 0`, and `Break (k+1)`. Each is handed the fuel
+`N` from which the body's result is pinned, and has to prove the rule's own
+goal from it. -/
+theorem wp_of_body_dispatch {α : Type} {m : Module} {env : HostEnv α}
+    {st : Store α} {s sb : Locals} {body prog : Program} {Q Qb : Assertion α}
+    (hBody : wp m body Qb st sb env)
+    (hFwd : ∀ (f : Nat) (cont : Continuation α), cont.IsPassthrough →
+      exec f m st sb body env = cont → exec (f + 1) m st s prog env = cont)
+    (hQFwd : ∀ cont : Continuation α, cont.IsPassthrough → Qb cont → Q cont)
+    (hFall : ∀ (N : Nat) (st' : Store α) (s' : Locals),
+      Qb (.Fallthrough st' s') →
+      (∀ f ≥ N, exec f m st sb body env = .Fallthrough st' s') →
+      wp m prog Q st s env)
+    -- The break levels are given in constructor form (`Nat.zero`, `k.succ`
+    -- rather than `0`, `k + 1`) so that a construct's own matcher reduces on
+    -- these continuations without unfolding `OfNat`/`Nat.add`: the callers'
+    -- closing `rfl`s run at reducible transparency.
+    (hBreak0 : ∀ (N : Nat) (st' : Store α) (s' : Locals),
+      Qb (.Break Nat.zero st' s') →
+      (∀ f ≥ N, exec f m st sb body env = .Break Nat.zero st' s') →
+      wp m prog Q st s env)
+    (hBreakSucc : ∀ (N k : Nat) (st' : Store α) (s' : Locals),
+      Qb (.Break k.succ st' s') →
+      (∀ f ≥ N, exec f m st sb body env = .Break k.succ st' s') →
+      wp m prog Q st s env) :
+    wp m prog Q st s env := by
+  rcases wp_stabilise hBody with ⟨hQoof, Nb, hoof⟩ | ⟨N, cont, _, hQ, hstable⟩
+  · -- The body never returns: the construct runs out of fuel with it.
+    refine wp_of_eventually_const (N := Nb + 1) (cont := .OutOfFuel) ?_
+      (hQFwd .OutOfFuel trivial hQoof)
+    intro fuel hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    exact hFwd f .OutOfFuel trivial (hoof f (by omega))
+  · by_cases hfwd : cont.IsPassthrough
+    · -- Nothing to interpret: the body's continuation passes through.
+      refine wp_of_eventually_const (N := N + 1) (cont := cont) ?_
+        (hQFwd cont hfwd hQ)
+      intro fuel hfuel
+      obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+      exact hFwd f cont hfwd (hstable f (by omega))
+    · cases cont with
+      | Fallthrough st' s' => exact hFall N st' s' hQ hstable
+      | Break k st' s' =>
+        cases k with
+        | zero => exact hBreak0 N st' s' hQ hstable
+        | succ k => exact hBreakSucc N k st' s' hQ hstable
+      | Return _ _ => exact absurd trivial hfwd
+      | Trap _ _ => exact absurd trivial hfwd
+      | Invalid _ => exact absurd trivial hfwd
+      | OutOfFuel => exact absurd trivial hfwd
+      | ReturnCall _ _ _ => exact absurd trivial hfwd
+      | Throwing _ _ _ _ => exact absurd trivial hfwd
+
+end Wasm


### PR DESCRIPTION
`wp_block_cons` and `wp_iff_cons` differed in 44 lines, every one a binder rename or the unfolding lemma; the Block and Loop tails differed only by one interleaved `simp only`.

Extracts the shared fuel-stabilisation preamble and body dispatch into `Wp/Structural.lean`. The continuation transformer is fuel-indexed (the Fallthrough arm re-enters `exec (fuel+1)`) and the caller keeps three branches — `.Break (k+1) ↦ .Break k` is not the identity either.

Statements unchanged. Green (3600 jobs).