### PR TITLE
interpreter: let wp_run take simp arguments and drop its inert entries

### DIFF
--- a/interpreter/Interpreter/Wasm/Wp/Tactic.lean
+++ b/interpreter/Interpreter/Wasm/Wp/Tactic.lean
@@ -10,13 +10,26 @@ import Interpreter.Wasm.Wp.Block
 
 namespace Wasm
 
-macro "wp_run" : tactic => `(tactic|
-  simp only [wp_simp,
-    -- Helpers
-    Locals.get, Locals.set?,
-    Function.toLocals, Function.numParams, Function.numLocals,
-    List.take, List.drop, List.replicate, List.length, List.map,
-    ValueType.zero, List.headD])
+/-- Symbolically execute straight-line code: reduce the atomic `wp_*_cons`
+equations together with the frame helpers they expose, stopping at control-flow
+boundaries (`block`, `loop`, `iff`, `call`).
+
+`wp_run [foo, bar]` appends `foo, bar` to that fixed set, so a proof needing one
+extra rewrite (a local hypothesis, a numeric simproc, a memory lemma) can add it
+rather than fork the whole list. -/
+syntax (name := wpRun) "wp_run" (Lean.Parser.Tactic.simpArgs)? : tactic
+
+macro_rules
+  | `(tactic| wp_run $[[$args,*]]?) => do
+    let extra := args.map (·.getElems) |>.getD #[]
+    `(tactic|
+      simp only [wp_simp,
+        -- Helpers
+        Locals.get, Locals.set?,
+        Function.toLocals, Function.numParams,
+        List.take, List.drop, List.replicate, List.length, List.map,
+        ValueType.zero,
+        $extra,*])
 
 macro "wp_done" : tactic => `(tactic| (wp_run; first | rfl | grind))
 

--- a/programs/lean/Project/NumIntegerOpt3/Spec.lean
+++ b/programs/lean/Project/NumIntegerOpt3/Spec.lean
@@ -131,12 +131,9 @@ theorem mod3_gcd_zero_smallStep (a b : UInt64) (hz : a = 0 ∨ b = 0) :
 lemmas plus list/`Nat` reductions (no memory lemmas — this build never
 touches linear memory). -/
 local macro "drive" : tactic => `(tactic|
-  simp only [wp_simp, Locals.get, Locals.set?,
-    Function.toLocals, Function.numParams, Function.numLocals,
-    List.length_cons, List.length_nil,
+  wp_run [List.length_cons, List.length_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ, List.set_cons_zero, List.set_cons_succ,
     List.reverse_cons, List.reverse_nil, List.nil_append, List.cons_append, List.singleton_append,
-    List.take, List.drop, List.replicate, List.map, ValueType.zero, List.headD,
     Nat.reduceLT, Nat.reduceAdd, Nat.reduceMul, Nat.reduceSub, reduceIte, Nat.reduceLeDiff,
     UInt32.reduceAdd, UInt32.reduceToNat, gt_iff_lt])
 

--- a/programs/lean/Project/SwapElements/Spec.lean
+++ b/programs/lean/Project/SwapElements/Spec.lean
@@ -134,11 +134,7 @@ theorem func1_swap (env : HostEnv Unit) (st1 : Store Unit) (ptr len i j loc : UI
   apply wp_block_cons
   apply wp_block_cons
   apply wp_block_cons
-  simp only [wp_simp, Locals.get, Locals.set?, Function.toLocals,
-    Function.numParams, List.take, List.drop, 
-    List.length, List.map, ValueType.zero, 
-    List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
-    
+  wp_run [List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ,
     List.set_cons_zero, List.set_cons_succ,
     Nat.reduceLT, Nat.reduceAdd, Nat.reduceSub, reduceIte,
@@ -237,15 +233,11 @@ theorem func4_swap (env : HostEnv Unit) (st : Store Unit) (ptr len i j : UInt32)
   unfold func4
   wp_run
   rw [hsp]
-  simp only [wp_simp, 
-    
-    List.length, 
-    List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
-    List.length_cons, 
+  wp_run [List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
+    List.length_cons,
     List.getElem?_cons_zero, List.getElem?_cons_succ,
     List.set_cons_zero, List.set_cons_succ,
-    UInt32.reduceSub, UInt32.reduceAdd, Nat.reduceAdd, Nat.reduceSub, Nat.reduceLT, reduceIte,
-    ]
+    UInt32.reduceSub, UInt32.reduceAdd, Nat.reduceAdd, Nat.reduceSub, Nat.reduceLT, reduceIte]
   apply wp_call_tw (func3_writes env _ 1048568 ptr len 1048652 []
     (by show (1048568 : UInt32).toNat + 8 ≤ st.mem.pages * 65536; rw [tn68]; omega))
   rintro sta vsa ⟨rfl, hga, hpa, hma⟩
@@ -257,12 +249,7 @@ theorem func4_swap (env : HostEnv Unit) (st : Store Unit) (ptr len i j : UInt32)
     rw [hma, Mem.read32_write32_disjoint _ _ _ _ (by rw [tn68, tn72]; omega),
         Mem.read32_write32_same]
   have hrptr : sta.mem.read32 1048568 = ptr := by rw [hma, Mem.read32_write32_same]
-  simp only [wp_simp, Locals.get, Locals.set?, 
-    
-    List.length, 
-    
-    
-    List.getElem?_cons_zero, List.getElem?_cons_succ,
+  wp_run [List.getElem?_cons_zero, List.getElem?_cons_succ,
     List.set_cons_zero, List.set_cons_succ,
     UInt32.reduceToNat, UInt32.reduceAdd, Nat.reduceAdd, Nat.reduceSub, Nat.reduceLT, reduceIte,
     hrlen, hrptr,

--- a/programs/lean/Project/SwapElementsOpt3/Spec.lean
+++ b/programs/lean/Project/SwapElementsOpt3/Spec.lean
@@ -75,10 +75,7 @@ theorem func0_swap (env : HostEnv Unit) (st : Store Unit) (ptr len i j : UInt32)
   unfold func0Def func0
   apply wp_block_cons
   apply wp_block_cons
-  simp only [wp_simp, Locals.get, Locals.set?, Function.toLocals,
-    Function.numParams, List.take, List.drop,
-    List.length, List.map, ValueType.zero,
-    List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
+  wp_run [List.reverse_cons, List.reverse_nil, List.cons_append, List.nil_append, List.append_nil,
     List.getElem?_cons_zero, List.getElem?_cons_succ,
     List.set_cons_zero, List.set_cons_succ,
     Nat.reduceLT, Nat.reduceAdd, Nat.reduceSub, reduceIte,


### PR DESCRIPTION
`wp_run` was a fixed `simp only` with no argument slot, so any call site needing one extra lemma forked the whole list.

Makes it `syntax` + `macro_rules` with an optional `simpArgs`, and collapses the five forked blocks in `SwapElements/Spec.lean`, `SwapElementsOpt3/Spec.lean` and `NumIntegerOpt3/Spec.lean` (whose local `drive` macro is adapted, not deleted). Also drops `Function.numLocals` and `List.headD`, which cannot appear in a wp goal.

Green (3599 jobs).