### PR TITLE
Simplify the mergesort public specification

### DIFF
--- a/programs/lean/Project/Mergesort/Adequacy.lean
+++ b/programs/lean/Project/Mergesort/Adequacy.lean
@@ -71,14 +71,9 @@ theorem startCallConfig_eq (input : List UInt32) :
 /-- Public postcondition before the final machine store is hidden. -/
 def entryPost (input : List UInt32) (outcome : ObservableOutcome)
     (store : MachineStore Universal.State) : Prop :=
-  match outcome with
-  | .done values =>
-      values = [] ∧
-        ∃ output : List UInt32,
-          store.wasm.host.stdio.output = serialize output ∧
-          SortedPermutation input output
-  | .trapped reason =>
-      reason = .host OOM.trapMessage ∧ store.wasm.host.oom.raised = true
+  let run : Project.Mergesort.Spec.RunOutcome := ⟨outcome, store.wasm.host⟩
+  Project.Mergesort.Spec.RanOutOfMemory run ∨
+    Project.Mergesort.Spec.Post input run
 
 /-- Public value inputs always produce a whole-word byte stream.  The
 body-level proof must use this fact at the `chunks_exact(4)` guard; the adequacy
@@ -309,7 +304,7 @@ private theorem DriverSuccess_public
   ispecialize Hfields $$ %store %observations
   ihave %hfields := Hfields $$ Hstate
   ipureintro
-  exact ⟨rfl, sorted, hfields.1, hfacts.1⟩
+  exact Or.inr ⟨sorted, ⟨rfl, hfields.1⟩, hfacts.1⟩
 
 /-- Every phase-classified OOM state contains the precise typed stream marker
 installed by the `talos.oom` host call. -/
@@ -366,7 +361,7 @@ private theorem DriverOOM_public
   ispecialize Hfields $$ %store %observations
   ihave %hfields := Hfields $$ Hstate
   ipureintro
-  exact ⟨rfl, hfields.2⟩
+  exact Or.inl ⟨rfl, hfields.2⟩
 
 /-- Apply the future main-function correctness theorem at the genuine exported
 call site.  This is the only bridge from entry resources to `Func3Spec`. -/
@@ -457,13 +452,13 @@ theorem entry_adequacy_of_func3
     Project.Mergesort.Spec.PublicEntrySpecification := by
   unfold Project.Mergesort.Spec.PublicEntrySpecification
   intro input
+  unfold Project.Mergesort.Spec.PartiallyRuns
   refine ⟨entryConfig input, ?_, ?_⟩
   · exact startCallConfig_eq input
   · intro trace outcome store hsteps
     have hpublic := entry_partiallyMeets_of_func3 hfunc3 input
       trace outcome store hsteps
-    cases outcome <;>
-      simpa [entryPost, serialize, U32Codec,
-        Project.Mergesort.Spec.encodeValues, SortedPermutation] using hpublic
+    simpa [entryPost, serialize, U32Codec,
+      Project.Mergesort.Spec.encodeValues, SortedPermutation] using hpublic
 
 end Project.Mergesort.Adequacy

--- a/programs/lean/Project/Mergesort/Spec.lean
+++ b/programs/lean/Project/Mergesort/Spec.lean
@@ -115,24 +115,40 @@ values, including multiplicities. -/
 def SortedPermutation (input output : List UInt32) : Prop :=
   output.Pairwise (· ≤ ·) ∧ List.Perm input output
 
+/-- Everything publicly observable at the end of a finite execution. -/
+structure RunOutcome where
+  outcome : SmallStep.ObservableOutcome
+  final : Universal.State
+
+/-- The call returned normally and wrote `output` in the public stream format. -/
+def ReturnsOutput (run : RunOutcome) (output : List UInt32) : Prop :=
+  run.outcome = .done [] ∧
+    run.final.stdio.output = encodeValues output
+
+/-- The call terminated with the allocator's distinguished OOM outcome. -/
+def RanOutOfMemory (run : RunOutcome) : Prop :=
+  run.outcome = .trapped (.host OOM.trapMessage) ∧
+    run.final.oom.raised = true
+
+/-- Every finite terminal execution either satisfies `post` or terminates with
+the allocator's distinguished OOM outcome.  This does not assert termination. -/
+def PartiallyRuns (input : List UInt32) (post : RunOutcome → Prop) : Prop :=
+  PartiallyRunsWithOutcome (Universal.envFor «module») «module» "mergesort"
+    (Universal.State.ofInput (encodeValues input))
+    (fun outcome final =>
+      let run : RunOutcome := ⟨outcome, final⟩
+      RanOutOfMemory run ∨ post run)
+
+/-- A successful execution returns the encoding of a sorted permutation. -/
+def Post (input : List UInt32) (run : RunOutcome) : Prop :=
+  ∃ output : List UInt32,
+    ReturnsOutput run output ∧ SortedPermutation input output
+
 /-- Public partial-correctness contract for the exported call.  Every finite
-observable terminal execution either returns no Wasm values after writing a
-sorted permutation, or reaches precisely the allocator's `talos.oom` trap with
-the typed OOM marker set.  This statement intentionally does not assert that a
-terminal outcome is reached. -/
+terminal execution either reports OOM or satisfies `Post`. -/
 @[spec_of "rust-exported-partial" "mergesort::mergesort"]
 def PublicEntrySpecification : Prop :=
   ∀ input : List UInt32,
-    PartiallyRunsWithOutcome (Universal.envFor «module») «module» "mergesort"
-      (Universal.State.ofInput (encodeValues input))
-      (fun outcome final =>
-        match outcome with
-        | .done values =>
-            values = [] ∧
-              ∃ output : List UInt32,
-                final.stdio.output = encodeValues output ∧
-                SortedPermutation input output
-        | .trapped reason =>
-            reason = .host OOM.trapMessage ∧ final.oom.raised = true)
+    PartiallyRuns input (Post input)
 
 end Project.Mergesort.Spec


### PR DESCRIPTION
## Summary

- introduce RunOutcome to keep the terminal outcome and final host state together
- make the merge-sort-specific PartiallyRuns wrapper admit the distinguished allocator OOM result internally
- express PublicEntrySpecification as PartiallyRuns input (Post input)
- adapt the adequacy boundary to prove the successful-post and OOM alternatives directly

## Verification

- cd programs/lean && lake build
- full Project build passed: 3601 jobs
- Lean LSP reports no errors in the modified specification or adequacy files
- the adequacy boundary theorem uses only propext, Classical.choice, and Quot.sound